### PR TITLE
v1.2.0 — Setup Wizard + Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,54 @@
+# Dependencies & build artifacts
+node_modules
+dist
+
+# Version control
+.git
+.gitignore
+
+# Tests
+tests
+
+# CI / GitHub
+.github
+
+# Documentation (not needed at runtime)
+*.md
+LICENSE
+
+# Docker files (avoid recursive COPY)
+Dockerfile
+.dockerignore
+docker-compose*.yml
+
+# Config & secrets (mounted at runtime)
+.env
+.env.example
+config.yaml
+config.yaml.*
+
+# IDE & editor
+.idea
+.vscode
+*.swp
+*.swo
+
+# Garmin tokens (mounted at runtime)
+.garmin_tokens
+.garmin_renpho_tokens
+
+# Python virtual environments
+.venv
+env
+venv
+__pycache__
+
+# Lint / format configs (not needed at runtime)
+eslint.config.js
+.prettierrc
+tsconfig.eslint.json
+
+# OS files
+.DS_Store
+Thumbs.db
+nul

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,57 @@
+name: Docker
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            BUILD_DATE=${{ github.event.release.created_at || github.event.head_commit.timestamp }}
+            VCS_REF=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ config.py
 # Garmin tokens (should not be committed)
 .garmin_tokens/
 .garmin_renpho_tokens/
+
+# Docker Compose (local overrides — docker-compose.example.yml is tracked)
+docker-compose.yml
+docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+FROM node:20-slim AS base
+
+# OCI labels
+ARG VERSION=dev
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL org.opencontainers.image.title="BLE Scale Sync" \
+      org.opencontainers.image.description="Universal BLE Smart Scale bridge — Garmin Connect, MQTT, InfluxDB, Webhook, Ntfy" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.source="https://github.com/KristianP26/ble-scale-sync" \
+      org.opencontainers.image.licenses="GPL-3.0"
+
+# System dependencies: BLE (BlueZ + D-Bus), Python (Garmin upload), tini (PID 1)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bluetooth \
+      bluez \
+      libbluetooth-dev \
+      libusb-1.0-0-dev \
+      libdbus-1-dev \
+      dbus \
+      python3 \
+      python3-pip \
+      python3-venv \
+      tini \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Python dependencies (Garmin upload)
+COPY requirements.txt ./
+RUN pip3 install --break-system-packages --no-cache-dir -r requirements.txt
+
+# Node.js dependencies (production only — tsx is in dependencies)
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+
+# Application source
+COPY src/ ./src/
+COPY garmin-scripts/ ./garmin-scripts/
+COPY tsconfig.json docker-entrypoint.sh ./
+RUN chmod +x docker-entrypoint.sh
+
+# Non-root user (UID 1000 from node:20-slim)
+USER node
+
+# Heartbeat check: /tmp/.ble-scale-sync-heartbeat must be updated within 5 minutes
+HEALTHCHECK --interval=60s --timeout=5s --start-period=120s --retries=3 \
+  CMD test -f /tmp/.ble-scale-sync-heartbeat && \
+      [ "$(find /tmp/.ble-scale-sync-heartbeat -mmin -5 2>/dev/null)" ] || exit 1
+
+ENTRYPOINT ["tini", "--", "./docker-entrypoint.sh"]
+CMD ["start"]

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,43 @@
+services:
+  ble-scale-sync:
+    image: ghcr.io/kristianp26/ble-scale-sync:latest
+    container_name: ble-scale-sync
+
+    # Host network is required for BLE (BlueZ uses D-Bus on the host)
+    network_mode: host
+
+    # BLE requires NET_ADMIN + NET_RAW capabilities
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+
+    # Add the bluetooth group so the container can access BLE devices.
+    # Find the correct GID on your host: getent group bluetooth | cut -d: -f3
+    group_add:
+      - '112'
+
+    volumes:
+      # Your config file (create from config.yaml example in README)
+      - ./config.yaml:/app/config.yaml:ro
+      # D-Bus socket (required for BlueZ communication)
+      - /var/run/dbus:/var/run/dbus:ro
+      # Garmin auth tokens (persisted across container restarts)
+      - garmin-tokens:/home/node/.garmin_tokens
+
+    environment:
+      - CONTINUOUS_MODE=true
+      # Secrets referenced via ${ENV_VAR} in config.yaml:
+      # - GARMIN_EMAIL=your_email@example.com
+      # - GARMIN_PASSWORD=your_password
+      # - INFLUXDB_TOKEN=your_token
+
+    restart: unless-stopped
+
+    logging:
+      driver: json-file
+      options:
+        max-size: '10m'
+        max-file: '3'
+
+volumes:
+  garmin-tokens:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -e
+
+CMD="${1:-start}"
+
+case "$CMD" in
+  start)
+    exec npx tsx src/index.ts
+    ;;
+  setup)
+    exec npx tsx src/wizard/index.ts
+    ;;
+  scan)
+    exec npx tsx src/scan.ts
+    ;;
+  validate)
+    exec npx tsx src/config/validate-cli.ts
+    ;;
+  help|--help|-h)
+    echo "BLE Scale Sync — Docker Commands"
+    echo ""
+    echo "Usage: docker run [options] ghcr.io/kristianp26/ble-scale-sync [command]"
+    echo ""
+    echo "Commands:"
+    echo "  start      Run the main sync flow (default)"
+    echo "  setup      Interactive setup wizard"
+    echo "  scan       Discover nearby BLE devices"
+    echo "  validate   Validate config.yaml"
+    echo "  help       Show this help message"
+    echo ""
+    echo "Any other command is executed directly (e.g. 'sh' for a debug shell)."
+    ;;
+  *)
+    exec "$@"
+    ;;
+esac

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "dotenv": "^16.4.7",
         "mqtt": "^5.10.0",
         "node-ble": "^1.13.0",
+        "tsx": "^4.19.0",
         "yaml": "^2.8.2",
         "zod": "^4.3.6"
       },
@@ -25,7 +26,6 @@
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
         "prettier": "^3.8.1",
-        "tsx": "^4.19.0",
         "typescript": "^5.7.0",
         "typescript-eslint": "^8.55.0",
         "vitest": "^4.0.18"
@@ -101,7 +101,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -118,7 +117,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -135,7 +133,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -152,7 +149,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -169,7 +165,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -186,7 +181,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -203,7 +197,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -220,7 +213,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -237,7 +229,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -254,7 +245,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -271,7 +261,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -288,7 +277,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -305,7 +293,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -322,7 +309,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -339,7 +325,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -356,7 +341,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -373,7 +357,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -390,7 +373,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -407,7 +389,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -424,7 +405,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -441,7 +421,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -458,7 +437,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -475,7 +453,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -492,7 +469,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -509,7 +485,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -526,7 +501,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3367,7 +3341,6 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -3979,7 +3952,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4129,7 +4101,6 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -5898,7 +5869,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -6659,7 +6629,6 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "dotenv": "^16.4.7",
     "mqtt": "^5.10.0",
     "node-ble": "^1.13.0",
+    "tsx": "^4.19.0",
     "yaml": "^2.8.2",
     "zod": "^4.3.6"
   },
@@ -47,7 +48,6 @@
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "prettier": "^3.8.1",
-    "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.55.0",
     "vitest": "^4.0.18"


### PR DESCRIPTION
## Summary

- **Interactive setup wizard** (`npm run setup`) — walks through BLE discovery, user profiles, exporter selection, runtime settings, and connectivity tests. Supports edit mode for existing configs and `--non-interactive` for CI.
- **Multi-user enhancements** — `waitForRawReading()` extraction for weight-based matching, `last_known_weight` auto-tracking with atomic YAML writes, drift detection
- **Docker support** — multi-arch image (`linux/amd64`, `linux/arm64`, `linux/arm/v7`) on GHCR, built on release tags. `node:20-slim` + BlueZ + Python + tini. Entrypoint with `start`/`setup`/`scan`/`validate`/`help` commands. Example Compose file with host network + BLE passthrough.
- **CI** — Docker workflow (`docker.yml`) triggered on `release: [published]` + `workflow_dispatch`
- **README** — config.yaml-first documentation, Docker Quick Start section, updated project structure

## Commits

1. `98093b1` Add config writing and weight-based user matching
2. `8bd9afa` Rewrite README configuration to config.yaml-first
3. `5126f92` Bump version to 1.0.1
4. `4311086` Extract waitForRawReading() for multi-user weight matching
5. `b36913c` Wire multi-user flow into main entry point
6. `2fe5a4a` Add interactive setup wizard and bump to v1.2.0
7. `8466454` Add Docker support with multi-arch GHCR builds

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 961 tests / 54 files passing
- [ ] Docker build test after merge + release tag