### PR TITLE
v1.2.2 — Documentation Overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,25 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [1.2.3] - 2026-02-14
-
-### Changed
-- Rewrite README (~220 lines, Docker-first quick start, simplified scales table)
-- Split documentation into `docs/` — exporters, multi-user, body-composition, troubleshooting
-- Move dev content (project structure, test coverage, adding adapters/exporters) into CONTRIBUTING.md
-
-### Added
-- GitHub Release and TypeScript badges
-
-## [1.2.2] - 2026-02-13
+## [1.2.2] - 2026-02-14
 
 ### Added
 - Annotated `config.yaml.example` with all sections and exporters
-- `CONTRIBUTING.md` — development guide, adding adapters/exporters, PR guidelines
-- This `CHANGELOG.md`
-- README badges (CI, License, Node.js, Docker)
+- `CONTRIBUTING.md` — development guide, project structure, test coverage, adding adapters/exporters, PR guidelines
+- `CHANGELOG.md`
+- GitHub Release and TypeScript badges
+- Documentation split into `docs/` — exporters, multi-user, body-composition, troubleshooting
 
 ### Changed
+- Rewrite README (~220 lines, Docker-first quick start, simplified scales table)
+- Move dev content (project structure, test coverage, adding adapters/exporters) into CONTRIBUTING.md
 - `.env.example` now notes that `config.yaml` is the preferred configuration method
 
 ## [1.2.1] - 2026-02-13
@@ -73,7 +66,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Exporter healthchecks at startup
 - 894 unit tests across 49 test files
 
-[1.2.3]: https://github.com/KristianP26/ble-scale-sync/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/KristianP26/ble-scale-sync/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/KristianP26/ble-scale-sync/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/KristianP26/ble-scale-sync/compare/v1.1.0...v1.2.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ble-scale-sync",
-  "version": "1.2.3",
+  "version": "1.2.2",
   "description": "Universal BLE Smart Scale bridge. Captures body composition from Renpho, Xiaomi & 20+ others, syncs to Garmin Connect, MQTT (Home Assistant), InfluxDB, Webhooks & Ntfy. Headless CLI for Raspberry Pi, Linux, macOS & Windows.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary
- Rewrite README from 873 to ~220 lines with Docker-first quick start, simplified scales table
- Split documentation into `docs/` — exporters, multi-user, body-composition, troubleshooting
- Consolidate dev content into CONTRIBUTING.md (project structure, test coverage, branches)
- Add config.yaml.example, CHANGELOG.md, GitHub Release + TypeScript badges

## Test plan
- [ ] All `docs/*.md` links from README resolve correctly
- [ ] No content lost from original README
- [ ] `npm test` passes (no code changes)