### PR TITLE
Add repository hardening and docs navbar version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce the issue?
+      placeholder: |
+        1. Configure with ...
+        2. Run `npm start`
+        3. Step on scale
+        4. See error ...
+    validations:
+      required: true
+
+  - type: input
+    id: scale
+    attributes:
+      label: Scale Brand / Model
+      placeholder: e.g. Renpho ES-CS20M, Xiaomi Mi Scale 2
+    validations:
+      required: false
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Linux (Raspberry Pi)
+        - Linux (other)
+        - Windows
+        - macOS
+        - Docker
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js Version
+      placeholder: e.g. 20.11.0 (run `node -v`)
+    validations:
+      required: true
+
+  - type: input
+    id: app-version
+    attributes:
+      label: App Version
+      placeholder: e.g. v1.2.2 (from package.json or Docker tag)
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Debug Logs
+      description: Run with `DEBUG=true npm start` and paste relevant output
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://blescalesync.dev
+    about: Check the docs before opening an issue
+  - name: Troubleshooting
+    url: https://blescalesync.dev/troubleshooting
+    about: Common issues and solutions

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What would you like to see added or changed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: Why do you need this? What problem does it solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Have you tried any workarounds or alternative approaches?
+    validations:
+      required: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "deps:"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "ci:"
+    labels:
+      - ci

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- What does this PR do? Why is it needed? -->
+
+## Changes
+
+<!-- List the key changes -->
+
+-
+
+## Test Plan
+
+<!-- How did you verify this works? -->
+
+- [ ] Tests pass (`npm test`)
+- [ ] Lint clean (`npm run lint`)
+- [ ] TypeScript compiles (`npx tsc --noEmit`)
+- [ ] Tested manually (describe below)
+
+## Notes
+
+<!-- Anything reviewers should know? Breaking changes, migration steps, etc. -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly via email:
+
+**security@blescalesync.dev**
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+## What to Include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+## Response
+
+- I will acknowledge your report within **48 hours**
+- I will provide a fix or mitigation plan within **7 days**
+- Credit will be given in the release notes (unless you prefer to remain anonymous)
+
+## Scope
+
+This policy covers:
+
+- The BLE Scale Sync application (`src/`)
+- Docker image and entrypoint
+- GitHub Actions workflows
+- Documentation site (blescalesync.dev)
+
+Out of scope:
+
+- Third-party dependencies (report upstream)
+- The Garmin Connect API or other external services

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,4 +1,8 @@
 import { defineConfig } from 'vitepress';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const pkg = require('../../package.json');
 
 export default defineConfig({
   title: 'BLE Scale Sync',
@@ -37,6 +41,10 @@ export default defineConfig({
       { text: 'Guide', link: '/guide/getting-started' },
       { text: 'Exporters', link: '/exporters' },
       { text: 'Changelog', link: '/changelog' },
+      {
+        text: `v${pkg.version}`,
+        link: `https://github.com/KristianP26/ble-scale-sync/releases/tag/v${pkg.version}`,
+      },
     ],
 
     sidebar: [


### PR DESCRIPTION
## Summary

- Add security policy (SECURITY.md) with responsible disclosure via security@blescalesync.dev
- Add PR template and issue templates (bug report + feature request YAML forms)
- Add Dependabot config (monthly npm + GitHub Actions updates)
- Add version badge in docs navbar (auto-reads from package.json)
- Repository settings: merge commit only, auto-delete branches, branch protection on main (PR + review + CI)
- 7 project-specific labels added

No code changes — app remains at v1.2.2.

## Test plan

- [x] Docs build passes (`npx vitepress build docs`)
- [x] Version shows in navbar linking to GitHub release
- [x] Branch protection verified via API
- [x] Labels visible on repo