### PR TITLE
Fix layout shift when GitHub stars count loads

### DIFF
--- a/docs/.vitepress/theme/GitHubStars.vue
+++ b/docs/.vitepress/theme/GitHubStars.vue
@@ -22,7 +22,7 @@ onMounted(async () => {
     rel="noopener noreferrer"
     title="Star on GitHub"
   >
-    <span v-if="stars !== null">{{ stars }}</span>
+    <span class="stars-count">{{ stars !== null ? stars : '' }}</span>
     <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: -2px">
       <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/>
     </svg>
@@ -43,5 +43,9 @@ onMounted(async () => {
 }
 .github-stars:hover {
   color: var(--vp-c-brand-1);
+}
+.stars-count {
+  min-width: 1.5ch;
+  display: inline-block;
 }
 </style>


### PR DESCRIPTION
## Summary

- Reserve space for GitHub stars count to prevent layout shift on load

## Test plan

- [x] Verified on dev.blescalesync.dev — no visual jump when stars count appears