### PR TITLE
Fix missing D-Bus flags in Docker setup command

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -12,6 +12,7 @@ The fastest way to configure BLE Scale Sync is with the **interactive setup wiza
 ```bash
 # Docker (Linux)
 docker run --rm -it --network host --cap-add NET_ADMIN --cap-add NET_RAW \
+  --group-add 112 -v /var/run/dbus:/var/run/dbus:ro \
   -v ./config.yaml:/app/config.yaml ghcr.io/kristianp26/ble-scale-sync:latest setup
 
 # Native (Linux, macOS, Windows)


### PR DESCRIPTION
## Summary
- The Docker setup command on the [Configuration page](https://blescalesync.dev/guide/configuration#setup-wizard-recommended) was missing `-v /var/run/dbus:/var/run/dbus:ro` and `--group-add 112`, causing `ENOENT /var/run/dbus/system_bus_socket` when users followed it.
- All other pages (README, Getting Started, landing page) already had the correct command.

Closes #25