### PR TITLE
feat: Add a case for setup-garmin in docker-entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,6 +16,9 @@ case "$CMD" in
   validate)
     exec npx tsx src/config/validate-cli.ts
     ;;
+  setup-garmin)
+    exec python3 garmin-scripts/setup_garmin.py
+    ;;
   help|--help|-h)
     echo "BLE Scale Sync — Docker Commands"
     echo ""


### PR DESCRIPTION
## Summary
The docker-entrypoint.sh script only handles specific commands (start, setup, scan, validate, help). There's no case for setup-garmin as described in the [documentation](https://blescalesync.dev/exporters#garmin).
When you pass an unrecognized command, it falls through to line 34 (exec "$@") which tries to execute setup-garmin directly as a command in PATH, but it's not an executable; it's an npm script defined in package.json.

## Changes
Add a case for setup-garmin in docker-entrypoint.sh

## Test Plan

- [x] Tests pass (`npm test`)
- [x] Lint clean (`npm run lint`)
- [x] TypeScript compiles (`npx tsc --noEmit`)

