### PR TITLE
Add Garmin multi-user Docker authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Requires Node.js v20+ and a BLE adapter. See the **[full install guide](https://
 ## Features
 
 - **[23 scale brands](https://blescalesync.dev/guide/supported-scales)** — Xiaomi, Renpho, Eufy, Yunmai, Beurer, Sanitas, Medisana, and more
-- **[5 export targets](https://blescalesync.dev/exporters)** — Garmin Connect, MQTT (Home Assistant), InfluxDB, Webhook, Ntfy
+- **[5 export targets](https://blescalesync.dev/exporters)** — Garmin Connect (multi-user Docker auth), MQTT (Home Assistant), InfluxDB, Webhook, Ntfy
 - **[10 body metrics](https://blescalesync.dev/body-composition)** — BIA-based body composition from weight + impedance
 - **[Multi-user](https://blescalesync.dev/multi-user)** — automatic weight-based identification with per-user exporters
 - **[Interactive setup wizard](https://blescalesync.dev/guide/configuration)** — scale discovery, exporter config, connectivity tests

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -22,7 +22,11 @@ services:
       # D-Bus socket (required for BlueZ communication)
       - /var/run/dbus:/var/run/dbus:ro
       # Garmin auth tokens (persisted across container restarts)
+      # For single-user setups:
       - garmin-tokens:/home/node/.garmin_tokens
+      # For multi-user setups, uncomment and use separate volumes:
+      # - garmin-tokens-alice:/home/node/.garmin_tokens_alice
+      # - garmin-tokens-bob:/home/node/.garmin_tokens_bob
 
     environment:
       - CONTINUOUS_MODE=true
@@ -41,3 +45,6 @@ services:
 
 volumes:
   garmin-tokens:
+  # Uncomment for multi-user setups:
+  # garmin-tokens-alice:
+  # garmin-tokens-bob:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,17 +16,32 @@ case "$CMD" in
   validate)
     exec npx tsx src/config/validate-cli.ts
     ;;
+  setup-garmin)
+    shift
+    if [ $# -eq 0 ]; then
+      exec python3 garmin-scripts/setup_garmin.py
+    elif [ "$1" = "--all-users" ]; then
+      exec python3 garmin-scripts/setup_garmin.py --from-config
+    elif [ "$1" = "--user" ] && [ -n "$2" ]; then
+      exec python3 garmin-scripts/setup_garmin.py --from-config --user "$2"
+    else
+      exec python3 garmin-scripts/setup_garmin.py "$@"
+    fi
+    ;;
   help|--help|-h)
     echo "BLE Scale Sync — Docker Commands"
     echo ""
     echo "Usage: docker run [options] ghcr.io/kristianp26/ble-scale-sync [command]"
     echo ""
     echo "Commands:"
-    echo "  start      Run the main sync flow (default)"
-    echo "  setup      Interactive setup wizard"
-    echo "  scan       Discover nearby BLE devices"
-    echo "  validate   Validate config.yaml"
-    echo "  help       Show this help message"
+    echo "  start                         Run the main sync flow (default)"
+    echo "  setup                         Interactive setup wizard"
+    echo "  scan                          Discover nearby BLE devices"
+    echo "  validate                      Validate config.yaml"
+    echo "  setup-garmin                  Garmin auth (env vars: GARMIN_EMAIL, GARMIN_PASSWORD)"
+    echo "  setup-garmin --user <name>    Garmin auth for a specific user from config.yaml"
+    echo "  setup-garmin --all-users      Garmin auth for all users from config.yaml"
+    echo "  help                          Show this help message"
     echo ""
     echo "Any other command is executed directly (e.g. 'sh' for a debug shell)."
     ;;

--- a/docs/exporters.md
+++ b/docs/exporters.md
@@ -35,19 +35,50 @@ global_exporters:
 ```
 
 ::: tip Authentication
-The setup wizard handles Garmin authentication automatically. You only need to authenticate once — tokens are cached in `~/.garmin_tokens/` and reused. To re-authenticate manually:
-```bash
-# Docker
-docker run --rm -it -v ./config.yaml:/app/config.yaml \
-  ghcr.io/kristianp26/ble-scale-sync:latest setup-garmin
+The setup wizard handles Garmin authentication automatically. You only need to authenticate once — tokens are cached and reused. To re-authenticate manually:
 
-# Native
+**Native:**
+
+```bash
 npm run setup-garmin
 ```
+
+**Docker (single user with env vars):**
+
+```bash
+docker run --rm -it \
+  -v ./config.yaml:/app/config.yaml \
+  -v garmin-tokens:/home/node/.garmin_tokens \
+  -e GARMIN_EMAIL \
+  -e GARMIN_PASSWORD \
+  ghcr.io/kristianp26/ble-scale-sync:latest setup-garmin
+```
+
+**Docker (specific user from config.yaml):**
+
+```bash
+docker run --rm -it \
+  -v ./config.yaml:/app/config.yaml \
+  -v garmin-tokens-alice:/home/node/.garmin_tokens_alice \
+  -e GARMIN_EMAIL -e GARMIN_PASSWORD \
+  ghcr.io/kristianp26/ble-scale-sync:latest setup-garmin --user Alice
+```
+
+**Docker (all users from config.yaml):**
+
+```bash
+docker run --rm -it \
+  -v ./config.yaml:/app/config.yaml \
+  -v garmin-tokens-alice:/home/node/.garmin_tokens_alice \
+  -v garmin-tokens-bob:/home/node/.garmin_tokens_bob \
+  -e GARMIN_EMAIL -e GARMIN_PASSWORD \
+  ghcr.io/kristianp26/ble-scale-sync:latest setup-garmin --all-users
+```
+
 :::
 
 ::: warning IP blocking
-Garmin may block requests from cloud/VPN IPs. If authentication fails, try from a different network, then copy `~/.garmin_tokens/` to your target machine.
+Garmin may block requests from cloud/VPN IPs. If authentication fails, try from a different network, then copy the token directory to your target machine.
 :::
 
 ## MQTT {#mqtt}

--- a/garmin-scripts/setup_garmin.py
+++ b/garmin-scripts/setup_garmin.py
@@ -1,4 +1,6 @@
+import argparse
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -15,7 +17,9 @@ FAKE_USER_AGENT = (
 )
 
 
-def get_token_dir():
+def get_token_dir(token_dir=None):
+    if token_dir:
+        return str(Path(token_dir).expanduser())
     custom = os.environ.get("TOKEN_DIR", "").strip()
     if custom:
         return str(Path(custom).expanduser())
@@ -26,17 +30,27 @@ def get_token_dir():
     return str(new)
 
 
-def main():
-    email = os.environ.get("GARMIN_EMAIL", "").strip()
-    password = os.environ.get("GARMIN_PASSWORD", "").strip()
+def resolve_env_ref(value):
+    """Resolve ${ENV_VAR} references in config values (matching TS behavior)."""
+    if not isinstance(value, str):
+        return value
 
-    if not email or not password:
-        print(
-            "GARMIN_EMAIL and GARMIN_PASSWORD must be set in your .env file."
-        )
-        sys.exit(1)
+    def replacer(match):
+        var_name = match.group(1)
+        env_val = os.environ.get(var_name)
+        if env_val is None:
+            print(
+                f"[Setup] Warning: environment variable '{var_name}' is not set",
+                file=sys.stderr,
+            )
+            return match.group(0)
+        return env_val
 
-    token_dir = get_token_dir()
+    return re.sub(r"\$\{([^}]+)\}", replacer, value)
+
+
+def authenticate(email, password, token_dir):
+    """Authenticate with Garmin and save tokens."""
     print(f"[Setup] Authenticating as {email}...")
 
     try:
@@ -50,7 +64,7 @@ def main():
         garmin.garth.dump(token_dir)
 
         print(f"[Setup] Tokens saved to: {token_dir}")
-        print("[Setup] You can now run 'npm start' to sync your scale.")
+        return True
 
     except Exception as e:
         print(f"\n[Setup] Authentication failed: {e}")
@@ -59,7 +73,165 @@ def main():
             "from a different machine or network, then copy the token "
             f"directory ({token_dir}) to this machine."
         )
+        return False
+
+
+def load_config(config_path):
+    """Load and parse config.yaml."""
+    try:
+        import yaml
+    except ImportError:
+        print(
+            "Error: PyYAML is required for --from-config mode. "
+            "Install with: pip install pyyaml",
+            file=sys.stderr,
+        )
         sys.exit(1)
+
+    try:
+        with open(config_path, "r") as f:
+            return yaml.safe_load(f)
+    except FileNotFoundError:
+        print(f"Error: Config file not found: {config_path}", file=sys.stderr)
+        sys.exit(1)
+    except yaml.YAMLError as e:
+        print(f"Error parsing config: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def get_garmin_users(config):
+    """Extract Garmin users from config. Returns list of (name, email, password, token_dir)."""
+    users = config.get("users", [])
+    global_exporters = config.get("global_exporters", [])
+    results = []
+
+    # Per-user garmin entries
+    for user in users:
+        for entry in user.get("exporters", []):
+            if entry.get("type") == "garmin":
+                results.append(
+                    {
+                        "name": user.get("name", "Unknown"),
+                        "email": resolve_env_ref(entry.get("email", "")),
+                        "password": resolve_env_ref(entry.get("password", "")),
+                        "token_dir": entry.get("token_dir", ""),
+                    }
+                )
+
+    # Global garmin entries apply to all users (only if no per-user entries found)
+    if not results:
+        for entry in global_exporters:
+            if entry.get("type") == "garmin":
+                for user in users:
+                    results.append(
+                        {
+                            "name": user.get("name", "Unknown"),
+                            "email": resolve_env_ref(entry.get("email", "")),
+                            "password": resolve_env_ref(entry.get("password", "")),
+                            "token_dir": entry.get("token_dir", ""),
+                        }
+                    )
+
+    return results
+
+
+def run_from_config(config_path, target_user=None, cli_token_dir=None):
+    """Authenticate Garmin users from config.yaml."""
+    config = load_config(config_path)
+    garmin_users = get_garmin_users(config)
+
+    if not garmin_users:
+        print("[Setup] No Garmin exporters found in config.")
+        sys.exit(1)
+
+    if target_user:
+        garmin_users = [u for u in garmin_users if u["name"] == target_user]
+        if not garmin_users:
+            print(
+                f"[Setup] User '{target_user}' not found in config "
+                "or has no Garmin exporter."
+            )
+            sys.exit(1)
+
+    has_error = False
+    for user in garmin_users:
+        print(f"\n[Setup] ===========================================")
+        print(f"[Setup] Setting up Garmin for user: {user['name']}")
+        print(f"[Setup] ===========================================")
+
+        email = (user.get("email") or "").strip()
+        password = (user.get("password") or "").strip()
+
+        if not email or not password:
+            print(
+                f"[Setup] Error: Missing email or password for user {user['name']}."
+            )
+            print("[Setup] Add credentials to config.yaml or set env vars.")
+            has_error = True
+            continue
+
+        token_dir = get_token_dir(cli_token_dir or user.get("token_dir") or None)
+
+        if not authenticate(email, password, token_dir):
+            has_error = True
+
+    if has_error:
+        sys.exit(1)
+
+    print("\n[Setup] All done! You can now run 'npm start' to sync your scale.")
+
+
+def run_legacy(cli_token_dir=None):
+    """Original env-var-based authentication (backward compatible)."""
+    email = os.environ.get("GARMIN_EMAIL", "").strip()
+    password = os.environ.get("GARMIN_PASSWORD", "").strip()
+
+    if not email or not password:
+        print(
+            "GARMIN_EMAIL and GARMIN_PASSWORD must be set in your .env file."
+        )
+        sys.exit(1)
+
+    token_dir = get_token_dir(cli_token_dir)
+
+    if not authenticate(email, password, token_dir):
+        sys.exit(1)
+
+    print("[Setup] You can now run 'npm start' to sync your scale.")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Setup Garmin Connect authentication"
+    )
+    parser.add_argument(
+        "--from-config",
+        action="store_true",
+        help="Read users and credentials from config.yaml",
+    )
+    parser.add_argument(
+        "--config-path",
+        default="config.yaml",
+        help="Path to config.yaml (default: config.yaml)",
+    )
+    parser.add_argument(
+        "--user",
+        help="Setup only this user (requires --from-config)",
+    )
+    parser.add_argument(
+        "--token-dir",
+        help="Override token directory (or set TOKEN_DIR env var)",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    if args.from_config:
+        run_from_config(args.config_path, args.user, args.token_dir)
+    else:
+        run_legacy(args.token_dir)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 garminconnect>=0.2.19
 python-dotenv>=1.0.0
+pyyaml>=6.0


### PR DESCRIPTION
## Summary

Fixes #28 — Garmin token setup now works properly in Docker for multi-user configurations.

- **`setup_garmin.py --from-config`** reads users and credentials directly from `config.yaml`, resolving `${ENV_VAR}` references — no separate shell scripts or Python helpers needed
- **`docker-entrypoint.sh`** gains `setup-garmin` command with `--user <name>` and `--all-users` flags
- **`garmin_upload.py`** accepts `--token-dir` so each user's tokens go to separate directories (persisted via Docker volumes)
- **TS exporter** passes `--token-dir` to Python subprocess with proper tilde expansion
- **Wizard** passes credentials via env vars (not CLI args) to avoid `ps` visibility
- **Fully backward compatible** — without `--from-config`, everything works exactly as before

### Security improvements over #29
- Credentials passed via environment variables, not CLI arguments (not visible via `ps`)
- No password piping through stdout between shell and Python

### Simplification over #29
- **0 new files** vs 3 in #29 (`get_garmin_users.py`, `setup-garmin.sh`, modified `setup_garmin.py`)
- Everything handled in `setup_garmin.py` with `--from-config` mode
- No shell↔Python piping, no subshell variable bugs

### Docker usage

```bash
# Single user (legacy env var mode)
docker run --rm -it ... setup-garmin

# Specific user from config.yaml
docker run --rm -it ... setup-garmin --user Alice

# All users from config.yaml
docker run --rm -it ... setup-garmin --all-users
```

## Changed files

| File | Change |
|---|---|
| `garmin-scripts/setup_garmin.py` | `--from-config`, `--user`, `--token-dir` args; config.yaml parsing with `${ENV_VAR}` resolution |
| `garmin-scripts/garmin_upload.py` | `--token-dir` arg (CLI > env > default) |
| `src/exporters/garmin.ts` | `expandTilde()` helper, pass `--token-dir` to Python |
| `src/wizard/steps/garmin-auth.ts` | Credentials via env vars, `--token-dir` via CLI |
| `docker-entrypoint.sh` | `setup-garmin` command with `--user` and `--all-users` |
| `requirements.txt` | `pyyaml>=6.0` |
| `docker-compose.example.yml` | Multi-user volume examples |
| `docs/exporters.md` | Docker multi-user setup examples |
| `tests/exporters/garmin.test.ts` | 4 new tests (token_dir, tilde expansion, error, backward compat) |
| `README.md` | Mention multi-user Docker auth |

## Test plan

- [x] `npm test` — 972 tests / 55 files passing
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: Docker `setup-garmin --all-users` with multi-user config

## Credits

Thanks to [@marcelorodrigo](https://github.com/marcelorodrigo) for opening #29 and identifying the core issues with Garmin Docker auth. His PR provided the foundation and direction for this implementation. Supersedes #29.