### PR TITLE
docs: add StartLimitIntervalSec=0 to systemd service example

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -126,6 +126,11 @@ For always-on deployments (e.g. Raspberry Pi), create a systemd service:
 [Unit]
 Description=BLE Scale Sync
 After=network.target bluetooth.target
+# Disable the default restart rate limit (5 starts per 10s).
+# Without this, systemd stops restarting the service after repeated
+# BLE or network failures -- on a headless device this means silent
+# downtime until you notice and manually intervene.
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple


### PR DESCRIPTION
## Summary
- Add `StartLimitIntervalSec=0` to the systemd service example in Getting Started docs
- Include comments explaining why it's needed: without it, systemd's default rate limit (5 starts per 10s) silently stops restarting the service after repeated BLE/network failures on headless devices

## Test plan
- [x] `npm test` - 972 passed
- [x] `npm run lint` - clean
- [x] `npx tsc --noEmit` - clean
- [x] Matches production service running on Raspberry Pi Zero 2W