### PR TITLE
Add Garmin 2FA/MFA support to setup script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-garminconnect>=0.2.19
+garminconnect>=0.2.25
 python-dotenv>=1.0.0
 pyyaml>=6.0


### PR DESCRIPTION
## Summary

Allows Garmin login to work with 2FA, garmin required me to enable 2FA to use the login at all so it wouldn't work for me without this.

## Changes

Use garminconnect's return_on_mfa=True to detect when MFA is required, then prompt the user for their authenticator code via stdin. 
Bump garminconnect minimum to >=0.2.25 for return_on_mfa support.


## Test Plan

<!-- How did you verify this works? -->

- [/] Tests pass (`npm test`)
- [/] Lint clean (`npm run lint`)
- [/] TypeScript compiles (`npx tsc --noEmit`)
- [/] Tested manually (describe below)
