### PR TITLE
release: v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.6.1] - 2026-03-01
+
+### Fixed
+- **BlueZ stale discovery recovery** after Docker container restart. Adds kernel-level adapter reset via `btmgmt` as Tier 4 fallback when D-Bus recovery fails, plus proactive adapter reset in Docker entrypoint ([#39](https://github.com/KristianP26/ble-scale-sync/issues/39), [#43](https://github.com/KristianP26/ble-scale-sync/pull/43))
+
+### Changed
+- **CI**: Docker cleanup workflow removes PR images and untagged versions from GHCR ([#58](https://github.com/KristianP26/ble-scale-sync/pull/58))
+- **Docs**: Contributors section added to README
+- **Node.js**: minimum version bumped to 20.19.0 (required by eslint 10.0.2)
+- **Deps**: @stoprocent/noble 2.3.16, eslint 10.0.2, typescript-eslint 8.56.1, @types/node 25.3.3, @inquirer/prompts 8.3.0
+
+### Thanks
+- [@marcelorodrigo](https://github.com/marcelorodrigo) for reporting the stale BlueZ discovery issue ([#39](https://github.com/KristianP26/ble-scale-sync/issues/39))
+
 ## [1.6.0] - 2026-02-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![GitHub Release](https://img.shields.io/github/v/release/KristianP26/ble-scale-sync)
 ![License: GPL-3.0](https://img.shields.io/github/license/KristianP26/ble-scale-sync)
 ![TypeScript](https://img.shields.io/badge/typescript-%3E%3D5-blue?logo=typescript&logoColor=white)
-![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen?logo=node.js&logoColor=white)
+![Node.js](https://img.shields.io/badge/node-%3E%3D20.19-brightgreen?logo=node.js&logoColor=white)
 ![Docker](https://img.shields.io/badge/docker-ghcr.io-blue?logo=docker&logoColor=white)
 
 A cross-platform CLI tool that reads body composition data from **23 BLE smart scales** and exports to **Garmin Connect**, **Strava**, **MQTT** (Home Assistant), **InfluxDB**, **Webhooks**, **Ntfy**, and **local files** (CSV/JSONL). No phone app needed. Your data stays on your device.
@@ -50,7 +50,7 @@ npm run setup                       # interactive wizard
 CONTINUOUS_MODE=true npm start      # always-on
 ```
 
-Requires Node.js v20+ and a BLE adapter. See the **[full install guide](https://blescalesync.dev/guide/getting-started)** for prerequisites and systemd service setup.
+Requires Node.js v20.19+ and a BLE adapter. See the **[full install guide](https://blescalesync.dev/guide/getting-started)** for prerequisites and systemd service setup.
 
 ## Features
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,20 @@ description: Version history for BLE Scale Sync.
 
 All notable changes to this project are documented here. Format based on [Keep a Changelog](https://keepachangelog.com/).
 
-## v1.6.0 <Badge type="tip" text="latest" /> {#v1-6-0}
+## v1.6.1 <Badge type="tip" text="latest" /> {#v1-6-1}
+
+_2026-03-01_
+
+### Fixed
+- **BlueZ stale discovery recovery** after Docker container restart. Adds kernel-level adapter reset via `btmgmt` as Tier 4 fallback when D-Bus recovery fails, plus proactive adapter reset in Docker entrypoint ([#39](https://github.com/KristianP26/ble-scale-sync/issues/39), [#43](https://github.com/KristianP26/ble-scale-sync/pull/43))
+
+### Changed
+- **CI**: Docker cleanup workflow removes PR images and untagged versions from GHCR ([#58](https://github.com/KristianP26/ble-scale-sync/pull/58))
+- **Docs**: Contributors section added to README
+- **Node.js**: minimum version bumped to 20.19.0 (required by eslint 10.0.2)
+- **Deps**: @stoprocent/noble 2.3.16, eslint 10.0.2, typescript-eslint 8.56.1, @types/node 25.3.3, @inquirer/prompts 8.3.0
+
+## v1.6.0 {#v1-6-0}
 
 _2026-02-28_
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,7 +92,7 @@ npm run setup    # interactive wizard: scale discovery, user profile, exporters
 CONTINUOUS_MODE=true npm start   # always-on, listens for scale indefinitely
 ```
 
-Requires Node.js v20+ and a BLE adapter. For always-on deployments, create a systemd service:
+Requires Node.js v20.19+ and a BLE adapter. For always-on deployments, create a systemd service:
 
 ::: details Example: /etc/systemd/system/ble-scale.service
 ```ini

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ble-scale-sync",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Universal BLE Smart Scale bridge. Captures body composition from Renpho, Xiaomi & 20+ others, syncs to Garmin Connect, Strava, MQTT (Home Assistant), InfluxDB, Webhooks, Ntfy & local files. Headless CLI for Raspberry Pi, Linux, macOS & Windows.",
   "type": "module",
   "main": "src/index.ts",
@@ -34,7 +34,7 @@
   "author": "Kristián Partl",
   "license": "GPL-3.0",
   "engines": {
-    "node": ">=20"
+    "node": ">=20.19.0"
   },
   "dependencies": {
     "@abandonware/noble": "^1.9.2-26",


### PR DESCRIPTION
## Summary
- **BlueZ stale discovery recovery** after Docker container restart via kernel-level `btmgmt` adapter reset (#39, #43)
- **CI**: Docker cleanup workflow for PR images and untagged GHCR versions (#58)
- **Node.js**: minimum version bumped to 20.19.0 (required by eslint 10.0.2)
- **Deps**: @stoprocent/noble 2.3.16, eslint 10.0.2, typescript-eslint 8.56.1, @types/node 25.3.3, @inquirer/prompts 8.3.0
- Contributors section added to README
- Website changelog updated

## Test plan
- [x] 1097 tests passing
- [x] ESLint clean
- [x] TypeScript typecheck clean