### PR TITLE
docs: add ESP32 proxy to getting started guide

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -5,7 +5,7 @@ description: Install and run BLE Scale Sync with Docker or Node.js.
 
 # Getting Started
 
-BLE Scale Sync runs on any device with BLE support — Linux (including Raspberry Pi), macOS, and Windows.
+BLE Scale Sync runs on any device with BLE support — Linux (including Raspberry Pi), macOS, and Windows. If your server has no Bluetooth adapter, you can use a cheap [ESP32 as a remote BLE radio](#esp32-proxy) over WiFi.
 
 ## Docker (Linux only) {#docker}
 
@@ -81,7 +81,7 @@ sudo chown -R $(id -u):$(id -g) ./garmin-tokens
 
 | Platform | Requirements |
 |---|---|
-| **All** | [Node.js](https://nodejs.org/) v20+, BLE adapter |
+| **All** | [Node.js](https://nodejs.org/) v20.19+, BLE adapter |
 | **Linux** | `sudo apt-get install bluetooth bluez libbluetooth-dev libudev-dev build-essential` |
 | **macOS** | `xcode-select --install` (Xcode CLI tools) |
 | **Windows** | [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) (C++ workload) |
@@ -137,7 +137,7 @@ Description=BLE Scale Sync
 After=network.target bluetooth.target
 # Disable the default restart rate limit (5 starts per 10s).
 # Without this, systemd stops restarting the service after repeated
-# BLE or network failures -- on a headless device this means silent
+# BLE or network failures; on a headless device this means silent
 # downtime until you notice and manually intervene.
 StartLimitIntervalSec=0
 
@@ -161,16 +161,53 @@ WantedBy=multi-user.target
 sudo systemctl enable --now ble-scale.service
 ```
 
+## ESP32 BLE Proxy {#esp32-proxy}
+
+No Bluetooth on your server? Use a cheap ESP32 board (~8€) as a remote BLE radio. The ESP32 sits near the scale, scans for BLE advertisements, and relays data over WiFi/MQTT. The server needs no Bluetooth adapter at all.
+
+This also simplifies Docker deployments: no `NET_ADMIN`, no `--group-add`, no D-Bus mounts.
+
+### Quick setup
+
+1. Flash MicroPython and the proxy script onto an ESP32 (see [ESP32 BLE Proxy guide](./esp32-proxy) for details)
+2. Point the ESP32 at your MQTT broker
+3. Configure BLE Scale Sync to use the MQTT proxy:
+
+```yaml
+# config.yaml
+ble:
+  handler: mqtt-proxy
+  mqtt_proxy:
+    broker: mqtt://your-broker:1883
+```
+
+4. Run with the simplified Docker compose:
+
+```bash
+# No BlueZ, no D-Bus, no NET_ADMIN needed
+docker compose -f docker-compose.mqtt-proxy.yml up -d
+```
+
+Or set the handler via environment variable:
+
+```bash
+BLE_HANDLER=mqtt-proxy npm start
+```
+
+::: tip
+The ESP32 proxy supports both broadcast scales (weight from BLE advertisements) and GATT scales (notification-based readings via remote connect/read/write commands over MQTT). See the full [ESP32 BLE Proxy guide](./esp32-proxy) for hardware options, flashing instructions, and MQTT topic reference.
+:::
+
 ## Recommended Hardware
 
 | Component | Recommendation |
 |---|---|
-| **Single-board computer** | [Raspberry Pi Zero 2W](https://www.raspberrypi.com/products/raspberry-pi-zero-2-w/) — $15, built-in BLE, ~0.4W idle |
+| **Single-board computer** | [Raspberry Pi Zero 2W](https://www.raspberrypi.com/products/raspberry-pi-zero-2-w/) — ~15€, built-in BLE, ~0.4W idle |
 | **Scale** | Any [supported BLE scale](./supported-scales) |
 | **OS** | Raspberry Pi OS Lite (headless) |
 
 ::: tip
-The Raspberry Pi Zero 2W is the ideal deployment target. It's cheap, tiny, always on, and has built-in Bluetooth. Step on the scale and your data appears in Garmin Connect within seconds — no phone needed.
+The Raspberry Pi Zero 2W is the ideal deployment target. It's cheap, tiny, always on, and has built-in Bluetooth. Step on the scale and your data appears in Garmin Connect within seconds, no phone needed.
 :::
 
 ::: danger Pi Zero W (first gen) is not supported
@@ -182,3 +219,4 @@ The original Raspberry Pi Zero W has an ARMv6 CPU. Key dependencies (`esbuild`, 
 - [Configuration](./configuration) — config.yaml reference
 - [Supported Scales](./supported-scales) — all 23 brands
 - [Exporters](/exporters) — configure export targets
+- [ESP32 BLE Proxy](./esp32-proxy) — remote BLE via WiFi/MQTT


### PR DESCRIPTION
## Summary
- Adds ESP32 BLE Proxy section to the getting started guide with quick setup, config example, and simplified Docker compose
- Updates Node.js minimum version to v20.19+ in prerequisites
- Fixes currency (€) and formatting