### PR TITLE
docs: add SEO meta keywords to all pages

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -13,6 +13,14 @@ export default defineConfig({
   head: [
     ['link', { rel: 'icon', href: '/favicon.svg', type: 'image/svg+xml' }],
     ['meta', { name: 'theme-color', content: '#3b82f6' }],
+    [
+      'meta',
+      {
+        name: 'keywords',
+        content:
+          'ble scale, smart scale, body composition, garmin connect, strava, bluetooth scale, weight sync, raspberry pi, home assistant, mqtt, self-hosted, docker, body fat, impedance',
+      },
+    ],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:title', content: 'BLE Scale Sync' }],
     [
@@ -20,7 +28,7 @@ export default defineConfig({
       {
         property: 'og:description',
         content:
-          'Automatic body composition sync from BLE smart scales to Garmin Connect, Home Assistant, InfluxDB and more.',
+          'Automatic body composition sync from BLE smart scales to Garmin Connect, Strava, Home Assistant, InfluxDB and more.',
       },
     ],
     ['meta', { property: 'og:url', content: 'https://blescalesync.dev' }],

--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -1,6 +1,10 @@
 ---
 title: Alternatives
 description: How BLE Scale Sync compares to openScale, openScale-sync, manufacturer apps, and more.
+head:
+  - - meta
+    - name: keywords
+      content: openscale alternative, smart scale garmin sync, scale app comparison, openscale sync garmin, renpho garmin connect, xiaomi garmin connect, self hosted scale app
 ---
 
 # Alternatives

--- a/docs/body-composition.md
+++ b/docs/body-composition.md
@@ -1,6 +1,10 @@
 ---
 title: Body Composition
 description: Body composition metrics, BIA formulas, Deurenberg fallback, and athlete mode adjustments.
+head:
+  - - meta
+    - name: keywords
+      content: body fat percentage, muscle mass calculation, bioelectrical impedance analysis, bia formula, bmi calculator, visceral fat, bone mass, body water percentage, smart scale accuracy, body composition metrics
 ---
 
 # Body Composition

--- a/docs/exporters.md
+++ b/docs/exporters.md
@@ -1,6 +1,10 @@
 ---
 title: Exporters
 description: Configure Garmin Connect, Strava, MQTT, Webhook, InfluxDB, Ntfy, and File export targets.
+head:
+  - - meta
+    - name: keywords
+      content: garmin connect scale sync, strava weight sync, mqtt home assistant scale, influxdb body weight, smart scale webhook, ntfy notifications, scale data export csv, garmin body composition upload
 ---
 
 # Exporters

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,6 +1,10 @@
 ---
 title: Configuration
 description: Complete config.yaml reference for BLE Scale Sync.
+head:
+  - - meta
+    - name: keywords
+      content: ble scale sync config, config.yaml smart scale, setup wizard, scale configuration, garmin exporter config, mqtt exporter config
 ---
 
 # Configuration

--- a/docs/guide/esp32-proxy.md
+++ b/docs/guide/esp32-proxy.md
@@ -1,6 +1,10 @@
 ---
 title: ESP32 BLE Proxy
 description: Use an ESP32 as a remote BLE-to-MQTT bridge for headless or Docker deployments.
+head:
+  - - meta
+    - name: keywords
+      content: esp32 bluetooth proxy, esp32 ble mqtt bridge, remote bluetooth raspberry pi, esp32 micropython ble, esp32 smart scale, mqtt ble gateway, esp32 weight scale, wireless ble relay
 ---
 
 # ESP32 BLE Proxy

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,6 +1,10 @@
 ---
 title: Getting Started
 description: Install and run BLE Scale Sync with Docker or Node.js.
+head:
+  - - meta
+    - name: keywords
+      content: ble scale setup, smart scale raspberry pi, docker bluetooth scale, install ble scale sync, garmin scale sync, esp32 ble proxy setup
 ---
 
 # Getting Started

--- a/docs/guide/supported-scales.md
+++ b/docs/guide/supported-scales.md
@@ -1,6 +1,10 @@
 ---
 title: Supported Scales
 description: All 23 BLE smart scale brands supported by BLE Scale Sync.
+head:
+  - - meta
+    - name: keywords
+      content: xiaomi mi scale, renpho scale bluetooth, eufy smart scale, yunmai scale, beurer bf scale, sanitas scale, medisana bs scale, silvercrest scale, 1byone scale, etekcity scale, inevifit scale, arboleaf scale, lepulse scale, fitdays scale, senssun scale, supported ble scales
 ---
 
 # Supported Scales

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,9 @@
 ---
 layout: home
+head:
+  - - meta
+    - name: keywords
+      content: ble scale sync, smart scale garmin connect, bluetooth scale raspberry pi, body composition sync, renpho garmin, xiaomi scale garmin, strava weight sync, mqtt smart scale, home assistant scale, self hosted weight tracker, esp32 ble proxy, docker smart scale
 
 hero:
   name: BLE Scale Sync

--- a/docs/multi-user.md
+++ b/docs/multi-user.md
@@ -1,6 +1,10 @@
 ---
 title: Multi-User Support
 description: Automatic weight-based user identification, drift detection, and per-user exporter configuration.
+head:
+  - - meta
+    - name: keywords
+      content: multi user smart scale, family scale sync, automatic user detection, weight matching, shared scale garmin, per user garmin strava
 ---
 
 # Multi-User Support

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,10 @@
 ---
 title: Troubleshooting
 description: Common issues, debug tips, and solutions for BLE Scale Sync.
+head:
+  - - meta
+    - name: keywords
+      content: bluetooth scale not found, ble troubleshooting linux, bluez docker, raspberry pi bluetooth issues, scale not connecting, dbus bluetooth error, noble ble error
 ---
 
 # Troubleshooting


### PR DESCRIPTION
## Summary
- Adds per-page `<meta name="keywords">` tags to all 10 content pages (landing, getting started, supported scales, configuration, ESP32 proxy, exporters, body composition, multi-user, troubleshooting, alternatives)
- Adds global keywords meta tag in VitePress config
- Updates OG description to include Strava

Keywords target scale brand names, export targets, common search terms, and technical queries.