### PR TITLE
ci: restrict Docker latest tag to release events

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary
- Docker `latest` tag was applied on every push to `main` (including PR merges)
- Changed to only apply `latest` when a GitHub release is published
- Ensures `latest` always points to a stable, versioned release

## Test plan
- [ ] Verify `docker/metadata-action` generates `latest` tag only on `release` event
- [ ] Verify PR merges to main no longer produce a `latest` tag
- [ ] Verify semver tags (`1.x.x`, `1.x`, `1`) still work on release