### PR TITLE
ci: remove push-to-main Docker trigger

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,6 @@
 name: Docker
 
 on:
-  push:
-    branches: [main]
   release:
     types: [published]
   pull_request:


### PR DESCRIPTION
## Summary
- Fixes failed Docker build from #70 (no tags generated on push to main)
- Removes `push: branches: [main]` trigger since it no longer produces any tags
- Docker builds now only run on PRs (validation) and releases (tagged push)

## Test plan
- [ ] Verify merging this PR does not trigger a Docker build
- [ ] Verify PR builds still produce `pr-*` tagged images
- [ ] Verify release builds still produce semver + `latest` tags