### PR TITLE
release: v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.6.2] - 2026-03-02
+
+### Changed
+- **CI**: Docker `latest` tag now only applies to GitHub releases, not every push to main ([#70](https://github.com/KristianP26/ble-scale-sync/pull/70))
+- **CI**: Removed push-to-main Docker build trigger ([#71](https://github.com/KristianP26/ble-scale-sync/pull/71))
+- **Docs**: SEO meta keywords added to all documentation pages ([#69](https://github.com/KristianP26/ble-scale-sync/pull/69))
+- **Docs**: Alternatives page updated with Strava, file export, and ESP32 proxy sections ([#68](https://github.com/KristianP26/ble-scale-sync/pull/68))
+- **Docs**: ESP32 BLE proxy section added to getting started guide ([#67](https://github.com/KristianP26/ble-scale-sync/pull/67))
+
 ## [1.6.1] - 2026-03-01
 
 ### Fixed
@@ -148,6 +157,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Exporter healthchecks at startup
 - 894 unit tests across 49 test files
 
+[1.6.2]: https://github.com/KristianP26/ble-scale-sync/compare/v1.6.1...v1.6.2
+[1.6.1]: https://github.com/KristianP26/ble-scale-sync/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/KristianP26/ble-scale-sync/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/KristianP26/ble-scale-sync/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/KristianP26/ble-scale-sync/compare/v1.3.1...v1.4.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,18 @@ description: Version history for BLE Scale Sync.
 
 All notable changes to this project are documented here. Format based on [Keep a Changelog](https://keepachangelog.com/).
 
-## v1.6.1 <Badge type="tip" text="latest" /> {#v1-6-1}
+## v1.6.2 <Badge type="tip" text="latest" /> {#v1-6-2}
+
+_2026-03-02_
+
+### Changed
+- **CI**: Docker `latest` tag now only applies to GitHub releases, not every push to main ([#70](https://github.com/KristianP26/ble-scale-sync/pull/70))
+- **CI**: Removed push-to-main Docker build trigger ([#71](https://github.com/KristianP26/ble-scale-sync/pull/71))
+- **Docs**: SEO meta keywords added to all documentation pages ([#69](https://github.com/KristianP26/ble-scale-sync/pull/69))
+- **Docs**: Alternatives page updated with Strava, file export, and ESP32 proxy sections ([#68](https://github.com/KristianP26/ble-scale-sync/pull/68))
+- **Docs**: ESP32 BLE proxy section added to getting started guide ([#67](https://github.com/KristianP26/ble-scale-sync/pull/67))
+
+## v1.6.1 {#v1-6-1}
 
 _2026-03-01_
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ble-scale-sync",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Universal BLE Smart Scale bridge. Captures body composition from Renpho, Xiaomi & 20+ others, syncs to Garmin Connect, Strava, MQTT (Home Assistant), InfluxDB, Webhooks, Ntfy & local files. Headless CLI for Raspberry Pi, Linux, macOS & Windows.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary
- Bump version to 1.6.2
- Update CHANGELOG.md and docs/changelog.md
- Docker `latest` tag restricted to release events only
- Documentation improvements (SEO keywords, alternatives page, ESP32 getting started)

## Test plan
- [x] 1097 tests passing
- [x] ESLint clean
- [x] TSC clean