### PR TITLE
ci: replace PR Docker push with manual dispatch

### DIFF
--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -1,8 +1,6 @@
 name: Docker Cleanup
 
 on:
-  pull_request:
-    types: [closed]
   schedule:
     # Daily at 3:00 UTC: prune untagged images
     - cron: '0 3 * * *'
@@ -12,24 +10,7 @@ permissions:
   packages: write
 
 jobs:
-  # Delete PR image after PR is closed/merged
-  delete-pr-image:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Delete PR image
-        uses: actions/delete-package-versions@v5
-        with:
-          package-name: ble-scale-sync
-          package-type: container
-          min-versions-to-keep: 0
-          delete-only-pre-release-versions: false
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ignore-versions: '^(?!pr-${{ github.event.number }}$).*$'
-
-  # Prune untagged images (leftover manifests from multi-arch builds)
   prune-untagged:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Prune untagged images

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag (e.g. test, pr-72)'
+        required: true
 
 permissions:
   contents: read
@@ -41,18 +45,18 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
## Summary
- PR Docker builds no longer push images (build-only validation)
- Added manual `workflow_dispatch` with required tag input for on-demand test images
- Removed `delete-pr-image` job from cleanup workflow (no longer needed)
- Eliminates race condition where cleanup runs before PR image finishes building

## Test plan
- [ ] PR build runs without pushing
- [ ] Manual dispatch with custom tag pushes successfully
- [ ] Release still produces semver + latest tags