### PR TITLE
ci: multi-arch aware Docker image cleanup (#77)

### DIFF
--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -1,0 +1,25 @@
+name: Docker Cleanup
+
+on:
+  schedule:
+    - cron: '0 3 * * 0' # Weekly on Sunday at 3:00 UTC
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clean up old container images
+        uses: snok/container-retention-policy@v3
+        with:
+          account: KristianP26
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-names: ble-scale-sync
+          cut-off: 30d
+          keep-n-most-recent: 10
+          skip-tags: "latest|\\d+(\\.\\d+)*"
+          token-type: github-token


### PR DESCRIPTION
## Summary
- Replaces the removed cleanup workflow with `snok/container-retention-policy@v3` which understands multi-arch manifest lists
- Runs weekly (Sunday 3:00 UTC), deletes images older than 30 days
- Preserves release tags (semver) and `latest`, cleans up old test/fix tags

Closes #77