### PR TITLE
feat: update check with anonymous usage statistics (#87)

### DIFF
--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -1,0 +1,23 @@
+name: Deploy Worker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'worker/**'
+      - '.github/workflows/worker.yml'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: worker
+          command: deploy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+- **Update check** with anonymous usage statistics ([#87](https://github.com/KristianP26/ble-scale-sync/issues/87)). After each successful measurement (max once per 24h), the app checks `api.blescalesync.dev` for newer versions. Only the app version, OS, and architecture are sent via the User-Agent header. Disable with `update_check: false` in config.yaml. Automatically disabled in CI environments
+- **Cloudflare Worker** (`worker/`) serving the `/version` endpoint and a public stats dashboard at `/stats` with aggregated anonymous data (version distribution, OS/architecture breakdown)
+- Setup wizard shows an update notice before the first step if a newer version is available
+- **CI**: GitHub Actions workflow for automatic Cloudflare Worker deployment on push to main (`worker.yml`)
+
 ## [1.6.4] - 2026-03-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Requires Node.js v20.19+ and a BLE adapter. See the **[full install guide](https
 - **[BLE diagnostic tool](https://blescalesync.dev/troubleshooting)** — `npm run diagnose` for detailed BLE troubleshooting
 - **[ESP32 BLE proxy](https://blescalesync.dev/guide/esp32-proxy)** — use a remote ESP32 as a BLE radio over MQTT, with simplified Docker deployment and optional display
 - **Broadcast mode** — supports non-connectable scales that only advertise weight via BLE advertisements
+- **Update check** — optional, anonymous version check after each measurement (opt-out via `update_check: false`)
 - **Cross-platform** — Linux (Docker + native), macOS, Windows
 - **Private** — your data stays on your device, no vendor cloud
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -137,3 +137,10 @@ runtime:
   scan_cooldown: 30         # seconds between scans in continuous mode (5–3600)
   dry_run: false            # true = read scale + compute body comp, skip all exports
   debug: false              # true = verbose BLE logging
+
+# --- Update Check ---
+# On each successful measurement (max once per 24h), the app sends a lightweight
+# GET request to check for newer versions. Only the app version, OS, and architecture
+# are sent via the User-Agent header. No personal data is collected.
+# Disable with: update_check: false
+update_check: true

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,13 @@ description: Version history for BLE Scale Sync.
 
 All notable changes to this project are documented here. Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## Unreleased {#unreleased}
+
+### Added
+- **Update check** with anonymous usage statistics ([#87](https://github.com/KristianP26/ble-scale-sync/issues/87)). After each successful measurement (max once per 24h), the app checks for newer versions. Only the app version, OS, and architecture are sent via the User-Agent header. Disable with `update_check: false` in config.yaml
+- Setup wizard shows an update notice before the first step if a newer version is available
+- Public stats dashboard at [stats.blescalesync.dev](https://api.blescalesync.dev/stats) with aggregated anonymous data
+
 ## v1.6.4 <Badge type="tip" text="latest" /> {#v1-6-4}
 
 _2026-03-27_

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -295,6 +295,7 @@ export function loadEnvConfig(): AppConfig {
       dry_run: envConfig.dryRun,
       debug: process.env.DEBUG === 'true',
     },
+    update_check: true,
   };
 }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -95,6 +95,7 @@ export const AppConfigSchema = z.object({
   global_exporters: z.array(ExporterEntrySchema).optional(),
   runtime: RuntimeSchema.optional(),
   docker: DockerSchema.optional(),
+  update_check: z.boolean().default(true),
 });
 
 // --- Standalone types ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { updateLastKnownWeight, withWriteLock } from './config/write.js';
 import type { Exporter, ExportContext } from './interfaces/exporter.js';
 import type { BodyComposition } from './interfaces/scale-adapter.js';
 import type { WeightUnit } from './config/schema.js';
+import { checkAndLogUpdate } from './update-check.js';
 
 // ─── CLI flags ──────────────────────────────────────────────────────────────
 
@@ -225,6 +226,8 @@ async function processSingleReading(raw: RawReading, exporters?: Exporter[]): Pr
     publishDisplayResult(mqttProxy, user.slug, user.name, payload.weight, details).catch(() => {});
   }
 
+  if (success) checkAndLogUpdate(appConfig.update_check);
+
   return success;
 }
 
@@ -329,6 +332,8 @@ async function processRawReading(raw: RawReading): Promise<boolean> {
   if (configSource === 'yaml' && configPath) {
     updateLastKnownWeight(configPath, user.slug, weight, user.last_known_weight);
   }
+
+  if (success) checkAndLogUpdate(appConfig.update_check);
 
   return success;
 }

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -1,0 +1,110 @@
+import { createRequire } from 'node:module';
+import { createLogger } from './logger.js';
+
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json') as { version: string };
+
+const log = createLogger('Sync');
+
+const UPDATE_CHECK_URL = 'https://api.blescalesync.dev/version';
+const TIMEOUT_MS = 3_000;
+const COOLDOWN_MS = 24 * 60 * 60 * 1_000; // 24 hours
+
+let lastCheckTime = 0;
+
+export interface UpdateInfo {
+  latest: string;
+  current: string;
+}
+
+/**
+ * Compare two semver strings. Returns true if `latest` is newer than `current`.
+ */
+export function isNewerVersion(current: string, latest: string): boolean {
+  const parse = (v: string): number[] => v.replace(/^v/, '').split('.').map(Number);
+  const [cMajor, cMinor, cPatch] = parse(current);
+  const [lMajor, lMinor, lPatch] = parse(latest);
+  if (lMajor !== cMajor) return lMajor > cMajor;
+  if (lMinor !== cMinor) return lMinor > cMinor;
+  return lPatch > cPatch;
+}
+
+/**
+ * Build the User-Agent string: ble-scale-sync/1.6.4 (linux; arm64)
+ */
+export function buildUserAgent(): string {
+  return `ble-scale-sync/${pkg.version} (${process.platform}; ${process.arch})`;
+}
+
+/**
+ * Check for updates. Non-blocking, fire-and-forget with 3s timeout.
+ * Respects update_check config, CI env var, and 24h cooldown.
+ * Returns update info if a newer version is available, null otherwise.
+ */
+export async function checkForUpdate(updateCheckEnabled = true): Promise<UpdateInfo | null> {
+  // Disabled via config
+  if (!updateCheckEnabled) return null;
+
+  // Disabled in CI
+  if (process.env.CI === 'true') return null;
+
+  // 24h cooldown
+  const now = Date.now();
+  if (now - lastCheckTime < COOLDOWN_MS) return null;
+  lastCheckTime = now;
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+    const res = await fetch(UPDATE_CHECK_URL, {
+      headers: { 'User-Agent': buildUserAgent() },
+      signal: controller.signal,
+    });
+
+    clearTimeout(timer);
+
+    if (!res.ok) return null;
+
+    const data = (await res.json()) as { latest?: string };
+    if (!data.latest) return null;
+
+    if (isNewerVersion(pkg.version, data.latest)) {
+      return { latest: data.latest, current: pkg.version };
+    }
+
+    return null;
+  } catch {
+    // Silent on network errors, timeouts, parse errors
+    return null;
+  }
+}
+
+/**
+ * Check for updates and log a notice if a newer version is available.
+ * Fire-and-forget: never throws, never blocks startup.
+ */
+export function checkAndLogUpdate(updateCheckEnabled = true): void {
+  checkForUpdate(updateCheckEnabled)
+    .then((info) => {
+      if (info) {
+        log.info(
+          `Update available: v${info.latest} (current: v${info.current}). ` +
+            'See https://blescalesync.dev/changelog',
+        );
+      }
+    })
+    .catch(() => {
+      // Never propagate errors
+    });
+}
+
+/** Reset internal cooldown timer (for testing). */
+export function resetUpdateCheckTimer(): void {
+  lastCheckTime = 0;
+}
+
+/** Get current version from package.json. */
+export function getCurrentVersion(): string {
+  return pkg.version;
+}

--- a/src/wizard/steps/welcome.ts
+++ b/src/wizard/steps/welcome.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import type { WizardStep, WizardContext } from '../types.js';
-import { banner, dim } from '../ui.js';
+import { banner, dim, warn } from '../ui.js';
+import { checkForUpdate } from '../../update-check.js';
 
 export const welcomeStep: WizardStep = {
   id: 'welcome',
@@ -9,6 +10,15 @@ export const welcomeStep: WizardStep = {
 
   async run(ctx: WizardContext): Promise<void> {
     banner();
+
+    // Show update notice if a newer version is available
+    const update = await checkForUpdate();
+    if (update) {
+      console.log(
+        warn(`Update available: v${update.latest} (current: v${update.current})`) +
+          '\n    https://blescalesync.dev/changelog\n',
+      );
+    }
 
     console.log(dim('  Before you start, make sure you have:'));
     console.log(dim('    - Your scale nearby (powered on)'));

--- a/tests/update-check.test.ts
+++ b/tests/update-check.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  isNewerVersion,
+  buildUserAgent,
+  checkForUpdate,
+  resetUpdateCheckTimer,
+  getCurrentVersion,
+} from '../src/update-check.js';
+
+// Suppress log output during tests
+vi.spyOn(console, 'log').mockImplementation(() => {});
+
+beforeEach(() => {
+  resetUpdateCheckTimer();
+  vi.restoreAllMocks();
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  delete process.env.CI;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─── isNewerVersion ─────────────────────────────────────────────────────────
+
+describe('isNewerVersion()', () => {
+  it('returns true when latest major is higher', () => {
+    expect(isNewerVersion('1.6.4', '2.0.0')).toBe(true);
+  });
+
+  it('returns true when latest minor is higher', () => {
+    expect(isNewerVersion('1.6.4', '1.7.0')).toBe(true);
+  });
+
+  it('returns true when latest patch is higher', () => {
+    expect(isNewerVersion('1.6.4', '1.6.5')).toBe(true);
+  });
+
+  it('returns false when versions are equal', () => {
+    expect(isNewerVersion('1.6.4', '1.6.4')).toBe(false);
+  });
+
+  it('returns false when current is newer', () => {
+    expect(isNewerVersion('2.0.0', '1.6.4')).toBe(false);
+  });
+
+  it('handles v prefix', () => {
+    expect(isNewerVersion('v1.6.4', 'v1.7.0')).toBe(true);
+    expect(isNewerVersion('v1.7.0', 'v1.6.4')).toBe(false);
+  });
+
+  it('handles mixed v prefix', () => {
+    expect(isNewerVersion('1.6.4', 'v1.7.0')).toBe(true);
+    expect(isNewerVersion('v1.6.4', '1.7.0')).toBe(true);
+  });
+});
+
+// ─── buildUserAgent ─────────────────────────────────────────────────────────
+
+describe('buildUserAgent()', () => {
+  it('includes version, platform, and arch', () => {
+    const ua = buildUserAgent();
+    expect(ua).toMatch(/^ble-scale-sync\/[\d.]+ \([^;]+; [^)]+\)$/);
+    expect(ua).toContain(getCurrentVersion());
+    expect(ua).toContain(process.platform);
+    expect(ua).toContain(process.arch);
+  });
+});
+
+// ─── checkForUpdate ─────────────────────────────────────────────────────────
+
+describe('checkForUpdate()', () => {
+  it('returns null when update_check is disabled', async () => {
+    const result = await checkForUpdate(false);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when CI=true', async () => {
+    process.env.CI = 'true';
+    const result = await checkForUpdate(true);
+    expect(result).toBeNull();
+  });
+
+  it('returns update info when a newer version is available', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ latest: '99.0.0' }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await checkForUpdate(true);
+    expect(result).not.toBeNull();
+    expect(result!.latest).toBe('99.0.0');
+    expect(result!.current).toBe(getCurrentVersion());
+    expect(mockFetch).toHaveBeenCalledOnce();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('returns null when current version is up to date', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ latest: getCurrentVersion() }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await checkForUpdate(true);
+    expect(result).toBeNull();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('returns null on HTTP error', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await checkForUpdate(true);
+    expect(result).toBeNull();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('returns null on network error', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await checkForUpdate(true);
+    expect(result).toBeNull();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('returns null on invalid JSON response', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ unexpected: 'data' }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await checkForUpdate(true);
+    expect(result).toBeNull();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('respects 24h cooldown (skips second call)', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ latest: '99.0.0' }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    // First call should go through
+    const first = await checkForUpdate(true);
+    expect(first).not.toBeNull();
+    expect(mockFetch).toHaveBeenCalledOnce();
+
+    // Second call within 24h should be skipped
+    const second = await checkForUpdate(true);
+    expect(second).toBeNull();
+    expect(mockFetch).toHaveBeenCalledOnce(); // Still only 1 call
+
+    vi.unstubAllGlobals();
+  });
+
+  it('sends correct User-Agent header', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ latest: getCurrentVersion() }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await checkForUpdate(true);
+
+    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.blescalesync.dev/version');
+    expect((options.headers as Record<string, string>)['User-Agent']).toMatch(
+      /^ble-scale-sync\/[\d.]+ \([^;]+; [^)]+\)$/,
+    );
+
+    vi.unstubAllGlobals();
+  });
+
+  it('uses AbortSignal for timeout', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ latest: getCurrentVersion() }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await checkForUpdate(true);
+
+    const options = mockFetch.mock.calls[0][1] as RequestInit;
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+
+    vi.unstubAllGlobals();
+  });
+});
+
+// ─── getCurrentVersion ──────────────────────────────────────────────────────
+
+describe('getCurrentVersion()', () => {
+  it('returns a semver string', () => {
+    expect(getCurrentVersion()).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});

--- a/tests/wizard/non-interactive.test.ts
+++ b/tests/wizard/non-interactive.test.ts
@@ -152,6 +152,7 @@ describe('runNonInteractive()', () => {
           last_known_weight: null,
         },
       ],
+      update_check: true,
     };
     writeTestConfig(config);
 

--- a/worker/.gitignore
+++ b/worker/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.wrangler/

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ble-scale-sync-api",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "types": "wrangler types"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250321.0",
+    "wrangler": "^4.14.4"
+  }
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,0 +1,398 @@
+/**
+ * BLE Scale Sync API Worker
+ *
+ * Endpoints:
+ *   GET /version          Returns { latest: "x.y.z" }
+ *   GET /stats            HTML dashboard with aggregated anonymous stats
+ *   GET /stats/json       JSON stats for programmatic access
+ *
+ * Anonymous usage stats are derived from User-Agent headers:
+ *   ble-scale-sync/1.6.4 (linux; arm64)
+ */
+
+export interface Env {
+  STATS: KVNamespace;
+}
+
+const GITHUB_RELEASES_URL =
+  'https://api.github.com/repos/KristianP26/ble-scale-sync/releases/latest';
+const VERSION_CACHE_KEY = 'latest-version';
+const VERSION_CACHE_TTL = 3600; // 1 hour
+
+/** Fetch latest version from GitHub Releases API, cached in KV for 1h. */
+async function getLatestVersion(kv: KVNamespace): Promise<string> {
+  const cached = await kv.get(VERSION_CACHE_KEY);
+  if (cached) return cached;
+
+  try {
+    const res = await fetch(GITHUB_RELEASES_URL, {
+      headers: { 'User-Agent': 'ble-scale-sync-api-worker' },
+    });
+    if (!res.ok) return cached ?? '0.0.0';
+
+    const data = (await res.json()) as { tag_name?: string };
+    const version = data.tag_name?.replace(/^v/, '') ?? '0.0.0';
+
+    await kv.put(VERSION_CACHE_KEY, version, { expirationTtl: VERSION_CACHE_TTL });
+    return version;
+  } catch {
+    return cached ?? '0.0.0';
+  }
+}
+
+// ─── User-Agent parsing ─────────────────────────────────────────────────────
+
+interface ClientInfo {
+  version: string;
+  os: string;
+  arch: string;
+}
+
+function parseUserAgent(ua: string | null): ClientInfo | null {
+  if (!ua) return null;
+  const match = ua.match(/^ble-scale-sync\/([\d.]+)\s+\(([^;]+);\s*([^)]+)\)$/);
+  if (!match) return null;
+  return { version: match[1], os: match[2], arch: match[3] };
+}
+
+// ─── KV helpers ─────────────────────────────────────────────────────────────
+
+/** Date key in YYYY-MM-DD format (UTC). */
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+interface DailyStats {
+  total: number;
+  versions: Record<string, number>;
+  os: Record<string, number>;
+  arch: Record<string, number>;
+}
+
+async function recordHit(kv: KVNamespace, client: ClientInfo): Promise<void> {
+  const key = `stats:${todayKey()}`;
+  const raw = await kv.get(key);
+  const stats: DailyStats = raw
+    ? (JSON.parse(raw) as DailyStats)
+    : { total: 0, versions: {}, os: {}, arch: {} };
+
+  stats.total++;
+  stats.versions[client.version] = (stats.versions[client.version] ?? 0) + 1;
+  stats.os[client.os] = (stats.os[client.os] ?? 0) + 1;
+  stats.arch[client.arch] = (stats.arch[client.arch] ?? 0) + 1;
+
+  // Keep daily stats for 90 days
+  await kv.put(key, JSON.stringify(stats), { expirationTtl: 90 * 86400 });
+}
+
+// ─── Stats aggregation ──────────────────────────────────────────────────────
+
+interface AggregatedStats {
+  period: string;
+  days: number;
+  uniqueDays: number;
+  totalChecks: number;
+  versions: Record<string, number>;
+  os: Record<string, number>;
+  arch: Record<string, number>;
+}
+
+async function aggregateStats(kv: KVNamespace, days: number): Promise<AggregatedStats> {
+  const now = new Date();
+  const versions: Record<string, number> = {};
+  const os: Record<string, number> = {};
+  const arch: Record<string, number> = {};
+  let totalChecks = 0;
+  let uniqueDays = 0;
+
+  for (let i = 0; i < days; i++) {
+    const d = new Date(now);
+    d.setUTCDate(d.getUTCDate() - i);
+    const key = `stats:${d.toISOString().slice(0, 10)}`;
+    const raw = await kv.get(key);
+    if (!raw) continue;
+
+    uniqueDays++;
+    const stats = JSON.parse(raw) as DailyStats;
+    totalChecks += stats.total;
+
+    for (const [k, v] of Object.entries(stats.versions)) {
+      versions[k] = (versions[k] ?? 0) + v;
+    }
+    for (const [k, v] of Object.entries(stats.os)) {
+      os[k] = (os[k] ?? 0) + v;
+    }
+    for (const [k, v] of Object.entries(stats.arch)) {
+      arch[k] = (arch[k] ?? 0) + v;
+    }
+  }
+
+  const label = days === 1 ? '24h' : days === 7 ? '7d' : '30d';
+
+  return { period: label, days, uniqueDays, totalChecks, versions, os, arch };
+}
+
+// ─── Stats dashboard HTML ───────────────────────────────────────────────────
+
+function renderDashboard(stats24h: AggregatedStats, stats7d: AggregatedStats, stats30d: AggregatedStats): string {
+  const sortedEntries = (obj: Record<string, number>): [string, number][] =>
+    Object.entries(obj).sort((a, b) => b[1] - a[1]);
+
+  const renderTable = (data: Record<string, number>, total: number): string => {
+    if (total === 0) return '<tr><td colspan="3" class="empty">No data yet</td></tr>';
+    return sortedEntries(data)
+      .map(([k, v]) => {
+        const pct = total > 0 ? ((v / total) * 100).toFixed(1) : '0.0';
+        return `<tr><td>${esc(k)}</td><td>${v}</td><td>${pct}%</td></tr>`;
+      })
+      .join('');
+  };
+
+  const renderPeriodCard = (s: AggregatedStats): string => `
+    <div class="card">
+      <h2>${s.period}</h2>
+      <div class="big-number">${s.totalChecks}</div>
+      <div class="label">update checks</div>
+      <div class="sub">${s.uniqueDays} active day${s.uniqueDays !== 1 ? 's' : ''}</div>
+    </div>`;
+
+  const renderBreakdown = (title: string, data24: Record<string, number>, data7: Record<string, number>, data30: Record<string, number>, total24: number, total7: number, total30: number): string => `
+    <div class="breakdown">
+      <h2>${title}</h2>
+      <div class="tabs">
+        <div class="tab-group" data-group="${title.toLowerCase()}">
+          <button class="tab active" data-period="24h">24h</button>
+          <button class="tab" data-period="7d">7d</button>
+          <button class="tab" data-period="30d">30d</button>
+        </div>
+      </div>
+      <table class="tab-content active" data-group="${title.toLowerCase()}" data-period="24h">
+        <thead><tr><th>${title}</th><th>Count</th><th>Share</th></tr></thead>
+        <tbody>${renderTable(data24, total24)}</tbody>
+      </table>
+      <table class="tab-content" data-group="${title.toLowerCase()}" data-period="7d">
+        <thead><tr><th>${title}</th><th>Count</th><th>Share</th></tr></thead>
+        <tbody>${renderTable(data7, total7)}</tbody>
+      </table>
+      <table class="tab-content" data-group="${title.toLowerCase()}" data-period="30d">
+        <thead><tr><th>${title}</th><th>Count</th><th>Share</th></tr></thead>
+        <tbody>${renderTable(data30, total30)}</tbody>
+      </table>
+    </div>`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BLE Scale Sync Stats</title>
+  <style>
+    :root {
+      --bg: #0f172a;
+      --surface: #1e293b;
+      --border: #334155;
+      --text: #e2e8f0;
+      --text-dim: #94a3b8;
+      --accent: #38bdf8;
+      --accent-dim: #0284c7;
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      padding: 2rem 1rem;
+    }
+    .container { max-width: 900px; margin: 0 auto; }
+    header {
+      text-align: center;
+      margin-bottom: 2.5rem;
+    }
+    header h1 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      color: var(--accent);
+    }
+    header p { color: var(--text-dim); margin-top: 0.25rem; font-size: 0.875rem; }
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1rem;
+      margin-bottom: 2rem;
+    }
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 0.75rem;
+      padding: 1.25rem;
+      text-align: center;
+    }
+    .card h2 { font-size: 0.875rem; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; }
+    .big-number { font-size: 2.25rem; font-weight: 700; color: var(--accent); margin: 0.25rem 0; }
+    .label { font-size: 0.8rem; color: var(--text-dim); }
+    .sub { font-size: 0.75rem; color: var(--text-dim); margin-top: 0.25rem; }
+    .breakdowns {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1rem;
+    }
+    .breakdown {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 0.75rem;
+      padding: 1.25rem;
+    }
+    .breakdown h2 { font-size: 0.875rem; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.75rem; }
+    .tabs { margin-bottom: 0.75rem; }
+    .tab-group { display: flex; gap: 0.25rem; }
+    .tab {
+      background: transparent;
+      border: 1px solid var(--border);
+      color: var(--text-dim);
+      padding: 0.25rem 0.625rem;
+      border-radius: 0.375rem;
+      cursor: pointer;
+      font-size: 0.75rem;
+    }
+    .tab.active { background: var(--accent-dim); color: white; border-color: var(--accent-dim); }
+    .tab:hover { border-color: var(--accent); }
+    table { width: 100%; border-collapse: collapse; display: none; }
+    table.active { display: table; }
+    th { text-align: left; font-size: 0.75rem; color: var(--text-dim); padding: 0.375rem 0; border-bottom: 1px solid var(--border); }
+    td { padding: 0.375rem 0; font-size: 0.8rem; border-bottom: 1px solid var(--border); }
+    td:nth-child(2), td:nth-child(3), th:nth-child(2), th:nth-child(3) { text-align: right; }
+    .empty { text-align: center !important; color: var(--text-dim); padding: 1rem 0; }
+    footer { text-align: center; margin-top: 2.5rem; color: var(--text-dim); font-size: 0.75rem; }
+    footer a { color: var(--accent); text-decoration: none; }
+    footer a:hover { text-decoration: underline; }
+    @media (max-width: 640px) {
+      .cards, .breakdowns { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>BLE Scale Sync</h1>
+      <p>Anonymous usage statistics from update checks</p>
+    </header>
+    <div class="cards">
+      ${renderPeriodCard(stats24h)}
+      ${renderPeriodCard(stats7d)}
+      ${renderPeriodCard(stats30d)}
+    </div>
+    <div class="breakdowns">
+      ${renderBreakdown('Version', stats24h.versions, stats7d.versions, stats30d.versions, stats24h.totalChecks, stats7d.totalChecks, stats30d.totalChecks)}
+      ${renderBreakdown('OS', stats24h.os, stats7d.os, stats30d.os, stats24h.totalChecks, stats7d.totalChecks, stats30d.totalChecks)}
+      ${renderBreakdown('Architecture', stats24h.arch, stats7d.arch, stats30d.arch, stats24h.totalChecks, stats7d.totalChecks, stats30d.totalChecks)}
+    </div>
+    <footer>
+      <p>Data from update check requests only. No personal data collected.</p>
+      <p><a href="https://blescalesync.dev">blescalesync.dev</a></p>
+    </footer>
+  </div>
+  <script>
+    document.querySelectorAll('.tab').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const group = btn.closest('.tab-group')?.getAttribute('data-group');
+        if (!group) return;
+        document.querySelectorAll(\`.tab-group[data-group="\${group}"] .tab\`).forEach(t => t.classList.remove('active'));
+        btn.classList.add('active');
+        const period = btn.getAttribute('data-period');
+        document.querySelectorAll(\`.tab-content[data-group="\${group}"]\`).forEach(t => {
+          t.classList.toggle('active', t.getAttribute('data-period') === period);
+        });
+      });
+    });
+  </script>
+</body>
+</html>`;
+}
+
+function esc(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+// ─── Request handler ────────────────────────────────────────────────────────
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'User-Agent',
+};
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+
+    // CORS preflight
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: CORS_HEADERS });
+    }
+
+    if (request.method !== 'GET') {
+      return new Response('Method not allowed', { status: 405 });
+    }
+
+    // GET /version
+    if (url.pathname === '/version') {
+      const client = parseUserAgent(request.headers.get('User-Agent'));
+
+      // Record stats asynchronously (don't block the response)
+      if (client) {
+        ctx.waitUntil(recordHit(env.STATS, client));
+      }
+
+      const latest = await getLatestVersion(env.STATS);
+
+      return new Response(JSON.stringify({ latest }), {
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'public, max-age=3600',
+          ...CORS_HEADERS,
+        },
+      });
+    }
+
+    // GET /stats/json
+    if (url.pathname === '/stats/json') {
+      const [stats24h, stats7d, stats30d] = await Promise.all([
+        aggregateStats(env.STATS, 1),
+        aggregateStats(env.STATS, 7),
+        aggregateStats(env.STATS, 30),
+      ]);
+
+      return new Response(JSON.stringify({ stats24h, stats7d, stats30d }, null, 2), {
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'public, max-age=300',
+          ...CORS_HEADERS,
+        },
+      });
+    }
+
+    // GET /stats
+    if (url.pathname === '/stats') {
+      const [stats24h, stats7d, stats30d] = await Promise.all([
+        aggregateStats(env.STATS, 1),
+        aggregateStats(env.STATS, 7),
+        aggregateStats(env.STATS, 30),
+      ]);
+
+      return new Response(renderDashboard(stats24h, stats7d, stats30d), {
+        headers: {
+          'Content-Type': 'text/html; charset=utf-8',
+          'Cache-Control': 'public, max-age=300',
+        },
+      });
+    }
+
+    // GET / (redirect to stats)
+    if (url.pathname === '/') {
+      return Response.redirect(new URL('/stats', url.origin).toString(), 302);
+    }
+
+    return new Response('Not found', { status: 404 });
+  },
+} satisfies ExportedHandler<Env>;

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,11 @@
+name = "ble-scale-sync-api"
+main = "src/index.ts"
+compatibility_date = "2025-03-01"
+
+[[routes]]
+pattern = "api.blescalesync.dev"
+custom_domain = true
+
+[[kv_namespaces]]
+binding = "STATS"
+id = "716153b9797d4c5589aa976ee6f3cae2"


### PR DESCRIPTION
## Summary

Merges dev into main. Includes PR #88.

Closes #87.

- Lightweight update check after each successful measurement (max once per 24h)
- Cloudflare Worker on api.blescalesync.dev with /version endpoint and /stats dashboard
- Worker auto-deploy workflow, dynamic version from GitHub Releases API (cached 1h in KV)
- Setup wizard shows update notice before first step
- Opt-out via update_check: false, auto-disabled in CI

## Test plan

- [x] 1116 tests passing (15 new for update-check)
- [x] Lint, typecheck, formatting clean
- [x] Worker deployed and tested (api.blescalesync.dev/version, /stats)
- [x] CI passed on all Node.js versions (20, 22, 24)