### PR TITLE
fix: address review feedback on update check

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@ All notable changes to this project are documented here. Format based on [Keep a
 ### Added
 - **Update check** with anonymous usage statistics ([#87](https://github.com/KristianP26/ble-scale-sync/issues/87)). After each successful measurement (max once per 24h), the app checks for newer versions. Only the app version, OS, and architecture are sent via the User-Agent header. Disable with `update_check: false` in config.yaml
 - Setup wizard shows an update notice before the first step if a newer version is available
-- Public stats dashboard at [stats.blescalesync.dev](https://api.blescalesync.dev/stats) with aggregated anonymous data
+- Public stats dashboard at [api.blescalesync.dev/stats](https://api.blescalesync.dev/stats) with aggregated anonymous data
 
 ## v1.6.4 <Badge type="tip" text="latest" /> {#v1-6-4}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,6 +198,9 @@ async function processSingleReading(raw: RawReading, exporters?: Exporter[]): Pr
   );
   logBodyComp(payload);
 
+  // Update check after successful reading (fire-and-forget, max once per 24h)
+  checkAndLogUpdate(appConfig.update_check);
+
   if (!exporters) {
     log.info('\nDry run — skipping export.');
     return true;
@@ -225,8 +228,6 @@ async function processSingleReading(raw: RawReading, exporters?: Exporter[]): Pr
   if (bleHandler === 'mqtt-proxy' && mqttProxy) {
     publishDisplayResult(mqttProxy, user.slug, user.name, payload.weight, details).catch(() => {});
   }
-
-  if (success) checkAndLogUpdate(appConfig.update_check);
 
   return success;
 }
@@ -308,6 +309,9 @@ async function processRawReading(raw: RawReading): Promise<boolean> {
   );
   logBodyComp(payload, prefix);
 
+  // Update check after successful reading (fire-and-forget, max once per 24h)
+  checkAndLogUpdate(appConfig.update_check);
+
   if (dryRun) {
     log.info(`${prefix} Dry run — skipping export.`);
     return true;
@@ -332,8 +336,6 @@ async function processRawReading(raw: RawReading): Promise<boolean> {
   if (configSource === 'yaml' && configPath) {
     updateLastKnownWeight(configPath, user.slug, weight, user.last_known_weight);
   }
-
-  if (success) checkAndLogUpdate(appConfig.update_check);
 
   return success;
 }

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -37,7 +37,8 @@ export function buildUserAgent(): string {
 }
 
 /**
- * Check for updates. Non-blocking, fire-and-forget with 3s timeout.
+ * Check for updates (awaitable, up to TIMEOUT_MS).
+ * Use `checkAndLogUpdate()` for fire-and-forget usage.
  * Respects update_check config, CI env var, and 24h cooldown.
  * Returns update info if a newer version is available, null otherwise.
  */
@@ -53,16 +54,14 @@ export async function checkForUpdate(updateCheckEnabled = true): Promise<UpdateI
   if (now - lastCheckTime < COOLDOWN_MS) return null;
   lastCheckTime = now;
 
-  try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
+  try {
     const res = await fetch(UPDATE_CHECK_URL, {
       headers: { 'User-Agent': buildUserAgent() },
       signal: controller.signal,
     });
-
-    clearTimeout(timer);
 
     if (!res.ok) return null;
 
@@ -77,6 +76,8 @@ export async function checkForUpdate(updateCheckEnabled = true): Promise<UpdateI
   } catch {
     // Silent on network errors, timeouts, parse errors
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/src/wizard/steps/welcome.ts
+++ b/src/wizard/steps/welcome.ts
@@ -1,4 +1,5 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
+import { parse as parseYaml } from 'yaml';
 import type { WizardStep, WizardContext } from '../types.js';
 import { banner, dim, warn } from '../ui.js';
 import { checkForUpdate } from '../../update-check.js';
@@ -11,8 +12,20 @@ export const welcomeStep: WizardStep = {
   async run(ctx: WizardContext): Promise<void> {
     banner();
 
+    // Respect update_check: false from existing config
+    let updateCheckEnabled = true;
+    if (existsSync(ctx.configPath)) {
+      try {
+        const raw = readFileSync(ctx.configPath, 'utf8');
+        const parsed = parseYaml(raw) as { update_check?: boolean };
+        if (parsed.update_check === false) updateCheckEnabled = false;
+      } catch {
+        // Ignore parse errors
+      }
+    }
+
     // Show update notice if a newer version is available
-    const update = await checkForUpdate();
+    const update = await checkForUpdate(updateCheckEnabled);
     if (update) {
       console.log(
         warn(`Update available: v${update.latest} (current: v${update.current})`) +

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -48,11 +48,20 @@ interface ClientInfo {
   arch: string;
 }
 
+const KNOWN_OS = new Set(['linux', 'darwin', 'win32', 'freebsd', 'openbsd', 'sunos', 'aix']);
+const KNOWN_ARCH = new Set(['arm', 'arm64', 'x64', 'ia32', 'ppc64', 's390x', 'riscv64', 'mips', 'mipsel', 'loong64']);
+const MAX_VERSION_LENGTH = 20;
+
 function parseUserAgent(ua: string | null): ClientInfo | null {
   if (!ua) return null;
   const match = ua.match(/^ble-scale-sync\/([\d.]+)\s+\(([^;]+);\s*([^)]+)\)$/);
   if (!match) return null;
-  return { version: match[1], os: match[2], arch: match[3] };
+
+  const version = match[1].slice(0, MAX_VERSION_LENGTH);
+  const os = KNOWN_OS.has(match[2]) ? match[2] : 'other';
+  const arch = KNOWN_ARCH.has(match[3]) ? match[3] : 'other';
+
+  return { version, os, arch };
 }
 
 // ─── KV helpers ─────────────────────────────────────────────────────────────
@@ -69,6 +78,9 @@ interface DailyStats {
   arch: Record<string, number>;
 }
 
+// Note: read-modify-write is not atomic. Under concurrent requests, some increments
+// may be lost due to KV's eventual consistency. This is acceptable for anonymous
+// aggregate stats where approximate counts are sufficient.
 async function recordHit(kv: KVNamespace, client: ClientInfo): Promise<void> {
   const key = `stats:${todayKey()}`;
   const raw = await kv.get(key);


### PR DESCRIPTION
## Summary

Addresses all Copilot review comments from #88.

- Move update check to after successful reading instead of after export success, so it runs in dry-run and when exporters fail
- Wizard respects `update_check: false` from existing config.yaml
- `clearTimeout` moved to `finally` block for proper cleanup on fetch errors
- Clarify JSDoc: `checkForUpdate()` is awaitable, `checkAndLogUpdate()` is fire-and-forget
- Worker: sanitize User-Agent with OS/arch allowlists and version length cap to prevent unbounded KV cardinality
- Worker: document KV read-modify-write race condition as acceptable for approximate anonymous stats
- Fix changelog link text

## Test plan

- [x] 1116 tests passing
- [x] Lint, typecheck, Prettier clean
- [x] Worker deployed and tested