### PR TITLE
Release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [1.8.0] - 2026-04-17
 
 ### Added
-- **HA Add-on**: one-click install via a [My Home Assistant](https://www.home-assistant.io/integrations/my/) badge. Clicking the badge opens your HA instance, confirms the repository, and lands on the Add-on Store with BLE Scale Sync ready to install. Manual steps remain documented as a fallback for users without My Home Assistant configured
-- **HA Add-on**: `weight_unit` and `height_unit` are now exposed as add-on options (kg/lbs, cm/in). Previously hardcoded to metric regardless of user preference
-- **HA Add-on**: `last_known_weight` now persists across add-on restarts. The runtime config lives at `/data/config.yaml` and `merge_last_weights.py` copies preserved per-user weights from the previous run into the freshly generated config on every startup
-- **Docs**: new [Home Assistant Add-on guide](https://blescalesync.dev/guide/home-assistant-addon) covering install, configuration reference, MQTT auto-detection, Garmin setup including the MFA workaround, custom config mode, persistence, and troubleshooting. Linked from Getting Started and the MQTT exporter reference
+- **HA Add-on**: one-click install via a [My Home Assistant](https://www.home-assistant.io/integrations/my/) badge in the README, landing page, getting-started guide, and HA Add-on guide. Manual steps remain as a fallback for users without My Home Assistant configured
+- **HA Add-on**: `weight_unit` and `height_unit` exposed as add-on options (kg/lbs, cm/in). The CLI and exporters display in the chosen unit while internal math stays in kg/cm
+- **HA Add-on**: `last_known_weight` persists across restarts. The runtime config lives at `/data/config.yaml` and a small Python helper (`merge_last_weights.py`) copies preserved per-user weights from the previous run into the freshly generated config on every startup, so multi-user identification by weight stays accurate after reboots and add-on updates
+- **Docs**: new [Home Assistant Add-on guide](https://blescalesync.dev/guide/home-assistant-addon) covering install, full configuration reference, MQTT auto-detection, Garmin setup (including the MFA and IP-block workarounds), custom config mode, persistence semantics, and troubleshooting. Promoted to a first-class quick-start in the README and landing page
+
+## [Unreleased]
 
 ## [1.7.5] - 2026-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+- **HA Add-on**: `weight_unit` and `height_unit` are now exposed as add-on options (kg/lbs, cm/in). Previously hardcoded to metric regardless of user preference
+- **HA Add-on**: `last_known_weight` now persists across add-on restarts. The runtime config lives at `/data/config.yaml` and `merge_last_weights.py` copies preserved per-user weights from the previous run into the freshly generated config on every startup
+- **Docs**: new [Home Assistant Add-on guide](https://blescalesync.dev/guide/home-assistant-addon) covering install, configuration reference, MQTT auto-detection, Garmin setup including the MFA workaround, custom config mode, persistence, and troubleshooting. Linked from Getting Started and the MQTT exporter reference
+
 ## [1.7.5] - 2026-04-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **HA Add-on**: one-click install via a [My Home Assistant](https://www.home-assistant.io/integrations/my/) badge. Clicking the badge opens your HA instance, confirms the repository, and lands on the Add-on Store with BLE Scale Sync ready to install. Manual steps remain documented as a fallback for users without My Home Assistant configured
 - **HA Add-on**: `weight_unit` and `height_unit` are now exposed as add-on options (kg/lbs, cm/in). Previously hardcoded to metric regardless of user preference
 - **HA Add-on**: `last_known_weight` now persists across add-on restarts. The runtime config lives at `/data/config.yaml` and `merge_last_weights.py` copies preserved per-user weights from the previous run into the freshly generated config on every startup
 - **Docs**: new [Home Assistant Add-on guide](https://blescalesync.dev/guide/home-assistant-addon) covering install, configuration reference, MQTT auto-detection, Garmin setup including the MFA workaround, custom config mode, persistence, and troubleshooting. Linked from Getting Started and the MQTT exporter reference

--- a/README.md
+++ b/README.md
@@ -21,15 +21,6 @@ If you can't have a Pi next to your scale, a cheap **ESP32 proxy** can sit nearb
 
 ## Quick Start
 
-### Home Assistant Add-on
-
-If you run Home Assistant OS or Supervised, install the add-on in two clicks:
-
-1. **Settings** > **Add-ons** > **Add-on Store** > three-dot menu > **Repositories**
-2. Add `https://github.com/KristianP26/ble-scale-sync` and install **BLE Scale Sync**
-
-The add-on handles config through the UI, auto-detects the Mosquitto broker for Home Assistant auto-discovery, and bootstraps Garmin tokens on first start. See the [Home Assistant Add-on guide](https://blescalesync.dev/guide/home-assistant-addon) for the full option reference, MFA workaround, and custom config mode.
-
 ### Docker (Linux)
 
 ```bash
@@ -50,7 +41,22 @@ docker run -d --restart unless-stopped --network host \
   ghcr.io/kristianp26/ble-scale-sync:latest
 ```
 
-### Native (Linux, macOS, Windows)
+Ideal for Raspberry Pi, NAS, and headless servers. Works alongside any Home Assistant install (Container, Core, OS) via MQTT auto-discovery.
+
+### Home Assistant Add-on
+
+If you run Home Assistant **OS** or **Supervised**, install the add-on in two clicks:
+
+1. **Settings** > **Add-ons** > **Add-on Store** > three-dot menu > **Repositories**
+2. Add `https://github.com/KristianP26/ble-scale-sync` and install **BLE Scale Sync**
+
+The add-on handles config through the UI, auto-detects the Mosquitto broker for Home Assistant auto-discovery, and bootstraps Garmin tokens on first start. See the [Home Assistant Add-on guide](https://blescalesync.dev/guide/home-assistant-addon) for the full option reference, MFA workaround, and custom config mode.
+
+> **Note:** Add-ons are not available on **HA Container** or **HA Core** installs (no Supervisor). Use the Docker method above instead — sensors still appear in HA via MQTT auto-discovery.
+
+### Standalone (Node.js — Linux, macOS, Windows)
+
+Runs natively on all major desktop and server operating systems. No containers required.
 
 ```bash
 git clone https://github.com/KristianP26/ble-scale-sync.git

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![Node.js](https://img.shields.io/badge/node-%3E%3D20.19-brightgreen?logo=node.js&logoColor=white)
 ![Docker](https://img.shields.io/badge/docker-ghcr.io-blue?logo=docker&logoColor=white)
 
-A cross-platform CLI tool that reads body composition data from **23 BLE smart scales** and exports to **Garmin Connect**, **Strava**, **MQTT** (Home Assistant), **InfluxDB**, **Webhooks**, **Ntfy**, and **local files** (CSV/JSONL). No phone app needed. Your data stays on your device.
+A cross-platform CLI tool that reads body composition data from **20+ BLE smart scales** and exports to **Garmin Connect**, **Strava**, **MQTT** (Home Assistant), **InfluxDB**, **Webhooks**, **Ntfy**, and **local files** (CSV/JSONL). No phone app needed. Your data stays on your device.
 
 **[Documentation](https://blescalesync.dev)** · **[Getting Started](https://blescalesync.dev/guide/getting-started)** · **[Supported Scales](https://blescalesync.dev/guide/supported-scales)** · **[Exporters](https://blescalesync.dev/exporters)**
 
@@ -63,7 +63,7 @@ Requires Node.js v20.19+ and a BLE adapter. See the **[full install guide](https
 
 ## Features
 
-- **[23 scale brands](https://blescalesync.dev/guide/supported-scales)** — Xiaomi, Renpho (Elis 1), Eufy, Yunmai, Beurer, Sanitas, Medisana, and more
+- **[20+ scale brands](https://blescalesync.dev/guide/supported-scales)** — Xiaomi, Renpho (Elis 1, FITINDEX, Sencor, QN-Scale), Eufy, Yunmai, Beurer, Sanitas, Medisana, and more
 - **[7 export targets](https://blescalesync.dev/exporters)** — Garmin Connect, Strava, MQTT (Home Assistant), InfluxDB, Webhook, Ntfy, File (CSV/JSONL)
 - **[10 body metrics](https://blescalesync.dev/body-composition)** — BIA-based body composition from weight + impedance
 - **[Multi-user](https://blescalesync.dev/multi-user)** — automatic weight-based identification with per-user exporters

--- a/README.md
+++ b/README.md
@@ -45,10 +45,19 @@ Ideal for Raspberry Pi, NAS, and headless servers. Works alongside any Home Assi
 
 ### Home Assistant Add-on
 
-If you run Home Assistant **OS** or **Supervised**, install the add-on in two clicks:
+If you run Home Assistant **OS** or **Supervised**, one click is all it takes:
+
+[![Add BLE Scale Sync repository to your Home Assistant](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2FKristianP26%2Fble-scale-sync)
+
+The badge opens your Home Assistant instance, confirms the repository, and shows BLE Scale Sync in the Add-on Store ready to install.
+
+<details>
+<summary>Prefer manual steps?</summary>
 
 1. **Settings** > **Add-ons** > **Add-on Store** > three-dot menu > **Repositories**
 2. Add `https://github.com/KristianP26/ble-scale-sync` and install **BLE Scale Sync**
+
+</details>
 
 The add-on handles config through the UI, auto-detects the Mosquitto broker for Home Assistant auto-discovery, and bootstraps Garmin tokens on first start. See the [Home Assistant Add-on guide](https://blescalesync.dev/guide/home-assistant-addon) for the full option reference, MFA workaround, and custom config mode.
 
@@ -75,7 +84,7 @@ Requires Node.js v20.19+ and a BLE adapter. See the **[full install guide](https
 - **[Multi-user](https://blescalesync.dev/multi-user)** — automatic weight-based identification with per-user exporters
 - **[Interactive setup wizard](https://blescalesync.dev/guide/configuration)** — scale discovery, exporter config, connectivity tests
 - **[BLE diagnostic tool](https://blescalesync.dev/troubleshooting)** — `npm run diagnose` for detailed BLE troubleshooting
-- **[Home Assistant Add-on](https://blescalesync.dev/guide/home-assistant-addon)** — two-click install with MQTT auto-discovery, UI-driven config, Garmin token bootstrap, and MFA workaround
+- **[Home Assistant Add-on](https://blescalesync.dev/guide/home-assistant-addon)** — one-click install via My Home Assistant badge, MQTT auto-discovery, UI-driven config, Garmin token bootstrap, and MFA workaround
 - **[ESP32 BLE proxy](https://blescalesync.dev/guide/esp32-proxy)** — use a remote ESP32 as a BLE radio over MQTT, with simplified Docker deployment and optional display
 - **BLE adapter selection** — `ble.adapter: hci1` for multi-adapter setups (Linux)
 - **Broadcast mode** — supports non-connectable scales that only advertise weight via BLE advertisements

--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ If you can't have a Pi next to your scale, a cheap **ESP32 proxy** can sit nearb
 
 ## Quick Start
 
+### Home Assistant Add-on
+
+If you run Home Assistant OS or Supervised, install the add-on in two clicks:
+
+1. **Settings** > **Add-ons** > **Add-on Store** > three-dot menu > **Repositories**
+2. Add `https://github.com/KristianP26/ble-scale-sync` and install **BLE Scale Sync**
+
+The add-on handles config through the UI, auto-detects the Mosquitto broker for Home Assistant auto-discovery, and bootstraps Garmin tokens on first start. See the [Home Assistant Add-on guide](https://blescalesync.dev/guide/home-assistant-addon) for the full option reference, MFA workaround, and custom config mode.
+
 ### Docker (Linux)
 
 ```bash
@@ -60,6 +69,7 @@ Requires Node.js v20.19+ and a BLE adapter. See the **[full install guide](https
 - **[Multi-user](https://blescalesync.dev/multi-user)** — automatic weight-based identification with per-user exporters
 - **[Interactive setup wizard](https://blescalesync.dev/guide/configuration)** — scale discovery, exporter config, connectivity tests
 - **[BLE diagnostic tool](https://blescalesync.dev/troubleshooting)** — `npm run diagnose` for detailed BLE troubleshooting
+- **[Home Assistant Add-on](https://blescalesync.dev/guide/home-assistant-addon)** — two-click install with MQTT auto-discovery, UI-driven config, Garmin token bootstrap, and MFA workaround
 - **[ESP32 BLE proxy](https://blescalesync.dev/guide/esp32-proxy)** — use a remote ESP32 as a BLE radio over MQTT, with simplified Docker deployment and optional display
 - **BLE adapter selection** — `ble.adapter: hci1` for multi-adapter setups (Linux)
 - **Broadcast mode** — supports non-connectable scales that only advertise weight via BLE advertisements

--- a/ble-scale-sync-addon/Dockerfile
+++ b/ble-scale-sync-addon/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY run.sh /app/run.sh
-RUN chmod +x /app/run.sh
+COPY merge_last_weights.py /app/merge_last_weights.py
+RUN chmod +x /app/run.sh /app/merge_last_weights.py
 
 ENTRYPOINT ["tini", "--", "/app/run.sh"]

--- a/ble-scale-sync-addon/config.yaml
+++ b/ble-scale-sync-addon/config.yaml
@@ -1,5 +1,5 @@
 name: BLE Scale Sync
-version: "1.7.5"
+version: "1.8.0"
 slug: ble-scale-sync
 description: Read BLE smart scales and export to Garmin Connect, MQTT (HA auto-discovery), InfluxDB, and more
 url: https://github.com/KristianP26/ble-scale-sync
@@ -24,6 +24,8 @@ map:
 options:
   scale_mac: ""
   ble_adapter: ""
+  weight_unit: "kg"
+  height_unit: "cm"
   user_name: "Default"
   user_height: 170
   user_birth_date: "1990-01-01"
@@ -50,6 +52,8 @@ options:
 schema:
   scale_mac: str?
   ble_adapter: str?
+  weight_unit: "list(kg|lbs)"
+  height_unit: "list(cm|in)"
   user_name: str
   user_height: "int(50,250)"
   user_birth_date: str

--- a/ble-scale-sync-addon/merge_last_weights.py
+++ b/ble-scale-sync-addon/merge_last_weights.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Preserve per-user last_known_weight across add-on restarts.
+
+Reads the previously persisted config.yaml and the freshly generated one,
+copies last_known_weight per slug from old to new, and writes the merged
+result back to the persistent path.
+"""
+import sys
+import yaml
+
+
+def load(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    return data if isinstance(data, dict) else {}
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("Usage: merge_last_weights.py <fresh> <persistent>", file=sys.stderr)
+        return 2
+
+    fresh_path, persistent_path = sys.argv[1], sys.argv[2]
+
+    new = load(fresh_path)
+
+    try:
+        old = load(persistent_path)
+    except FileNotFoundError:
+        old = {}
+
+    old_weights = {}
+    for u in old.get("users") or []:
+        slug = u.get("slug")
+        weight = u.get("last_known_weight")
+        if slug and weight is not None:
+            old_weights[slug] = weight
+
+    merged = 0
+    for u in new.get("users") or []:
+        slug = u.get("slug")
+        if slug in old_weights:
+            u["last_known_weight"] = old_weights[slug]
+            merged += 1
+
+    with open(persistent_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(new, f, sort_keys=False, allow_unicode=True)
+
+    if merged:
+        print(f"Preserved last_known_weight for {merged} user(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ble-scale-sync-addon/run.sh
+++ b/ble-scale-sync-addon/run.sh
@@ -2,7 +2,11 @@
 set -e
 
 OPTIONS="/data/options.json"
-CONFIG="/app/config.yaml"
+# Config lives in /data (persistent) so last_known_weight survives add-on
+# restarts. The app is launched with --config to read from this path.
+CONFIG="/data/config.yaml"
+FRESH="/tmp/config-fresh.yaml"
+mkdir -p /data
 
 log() { echo "[ble-scale-sync] $*"; }
 
@@ -31,7 +35,7 @@ if [ "$CUSTOM_CONFIG" = "true" ]; then
     exit 1
   fi
   log "Using custom config from $CUSTOM_PATH"
-  if ! cp "$CUSTOM_PATH" "$CONFIG"; then
+  if ! cp "$CUSTOM_PATH" "$FRESH"; then
     log "ERROR: Failed to copy custom config from $CUSTOM_PATH"
     exit 1
   fi
@@ -40,6 +44,11 @@ else
   # ── Read all options ────────────────────────────────────────────────────
 
   SCALE_MAC=$(opt scale_mac)
+
+  WEIGHT_UNIT=$(opt weight_unit)
+  HEIGHT_UNIT=$(opt height_unit)
+  [ -z "$WEIGHT_UNIT" ] && WEIGHT_UNIT="kg"
+  [ -z "$HEIGHT_UNIT" ] && HEIGHT_UNIT="cm"
 
   USER_NAME=$(opt user_name)
   USER_HEIGHT=$(opt_int user_height 170)
@@ -105,7 +114,7 @@ else
 
   log "Generating config.yaml..."
 
-  cat > "$CONFIG" <<YAML
+  cat > "$FRESH" <<YAML
 version: 1
 
 YAML
@@ -120,16 +129,16 @@ YAML
 
   # BLE section (only if scale_mac or adapter is set)
   if [ -n "$SCALE_MAC" ] || [ -n "$BLE_ADAPTER" ]; then
-    echo "ble:" >> "$CONFIG"
-    [ -n "$SCALE_MAC" ] && echo "  scale_mac: \"$(yaml_escape "$SCALE_MAC")\"" >> "$CONFIG"
-    [ -n "$BLE_ADAPTER" ] && echo "  adapter: \"$(yaml_escape "$BLE_ADAPTER")\"" >> "$CONFIG"
-    echo "" >> "$CONFIG"
+    echo "ble:" >> "$FRESH"
+    [ -n "$SCALE_MAC" ] && echo "  scale_mac: \"$(yaml_escape "$SCALE_MAC")\"" >> "$FRESH"
+    [ -n "$BLE_ADAPTER" ] && echo "  adapter: \"$(yaml_escape "$BLE_ADAPTER")\"" >> "$FRESH"
+    echo "" >> "$FRESH"
   fi
 
-  cat >> "$CONFIG" <<YAML
+  cat >> "$FRESH" <<YAML
 scale:
-  weight_unit: kg
-  height_unit: cm
+  weight_unit: $WEIGHT_UNIT
+  height_unit: $HEIGHT_UNIT
 
 unknown_user: nearest
 
@@ -163,12 +172,12 @@ YAML
   fi
 
   if [ "$HAVE_EXPORTERS" = "true" ]; then
-    echo "global_exporters:" >> "$CONFIG"
+    echo "global_exporters:" >> "$FRESH"
 
     # MQTT exporter
     if [ "$MQTT_ENABLED" = "true" ] && [ -n "$MQTT_BROKER_URL" ]; then
       MQTT_TOPIC="${MQTT_TOPIC:-scale/body-composition}"
-      cat >> "$CONFIG" <<YAML
+      cat >> "$FRESH" <<YAML
   - type: mqtt
     broker_url: "$(yaml_escape "$MQTT_BROKER_URL")"
     topic: "$(yaml_escape "$MQTT_TOPIC")"
@@ -177,14 +186,14 @@ YAML
     ha_discovery: $MQTT_HA_DISCOVERY
     ha_device_name: "$(yaml_escape "$MQTT_HA_DEVICE_NAME")"
 YAML
-      [ -n "$MQTT_USERNAME" ] && echo "    username: \"$(yaml_escape "$MQTT_USERNAME")\"" >> "$CONFIG"
-      [ -n "$MQTT_PASSWORD" ] && echo "    password: \"$(yaml_escape "$MQTT_PASSWORD")\"" >> "$CONFIG"
+      [ -n "$MQTT_USERNAME" ] && echo "    username: \"$(yaml_escape "$MQTT_USERNAME")\"" >> "$FRESH"
+      [ -n "$MQTT_PASSWORD" ] && echo "    password: \"$(yaml_escape "$MQTT_PASSWORD")\"" >> "$FRESH"
     fi
 
     # Garmin exporter
     if [ "$GARMIN_ENABLED" = "true" ] && [ -n "$GARMIN_EMAIL" ] && [ -n "$GARMIN_PASSWORD" ]; then
       mkdir -p /data/garmin-tokens
-      cat >> "$CONFIG" <<YAML
+      cat >> "$FRESH" <<YAML
   - type: garmin
     email: "$(yaml_escape "$GARMIN_EMAIL")"
     password: "$(yaml_escape "$GARMIN_PASSWORD")"
@@ -192,12 +201,12 @@ YAML
 YAML
     fi
 
-    echo "" >> "$CONFIG"
+    echo "" >> "$FRESH"
   fi
 
   # ── Runtime ───────────────────────────────────────────────────────────
 
-  cat >> "$CONFIG" <<YAML
+  cat >> "$FRESH" <<YAML
 runtime:
   continuous_mode: true
   scan_cooldown: $SCAN_COOLDOWN
@@ -209,6 +218,18 @@ YAML
 
   log "Config generated successfully"
 fi
+
+# ── Merge last_known_weight from previous run ────────────────────────────────
+# merge_last_weights.py reads the freshly generated config and, if the
+# persistent config.yaml already exists (from a previous run), copies each
+# user's last_known_weight into the fresh config before overwriting.
+# Result is written to $CONFIG so the app reads a merged view.
+
+if ! python3 /app/merge_last_weights.py "$FRESH" "$CONFIG"; then
+  log "WARNING: merge_last_weights.py failed, using fresh config without preserved weights"
+  cp "$FRESH" "$CONFIG"
+fi
+rm -f "$FRESH"
 
 # ── Garmin token bootstrap ──────────────────────────────────────────────────
 # garmin_upload.py only loads tokens; it does not authenticate from email and
@@ -280,4 +301,4 @@ fi
 # ── Start ───────────────────────────────────────────────────────────────────
 
 log "Starting BLE Scale Sync..."
-exec node dist/index.js
+exec node dist/index.js --config "$CONFIG"

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -67,7 +67,10 @@ export default defineConfig({
       },
       {
         text: 'Deployment',
-        items: [{ text: 'ESP32 BLE Proxy', link: '/guide/esp32-proxy' }],
+        items: [
+          { text: 'Home Assistant Add-on', link: '/guide/home-assistant-addon' },
+          { text: 'ESP32 BLE Proxy', link: '/guide/esp32-proxy' },
+        ],
       },
       {
         text: 'Reference',

--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -25,7 +25,7 @@ head:
 | **Push notifications** | Ntfy | No | No | App only |
 | **Local file export** | CSV and JSONL | SQLite | No | No |
 | **Multi-user** | Automatic weight matching | Manual selection | Per-user sync | Per-account |
-| **Supported scales** | 23 brands | 20+ brands | Via openScale | 1 (own brand) |
+| **Supported scales** | 23 protocol adapters | 20+ brands | Via openScale | 1 (own brand) |
 | **Body composition** | 10 metrics (BIA) | Varies | 4 metrics | Varies |
 | **Docker** | Multi-arch images | No | No | No |
 | **Open source** | GPL-3.0 | GPL-3.0 | GPL-3.0 | No |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented here. Format based on [Keep a
 ## Unreleased {#unreleased}
 
 ### Added
+- **HA Add-on**: one-click install via a [My Home Assistant](https://www.home-assistant.io/integrations/my/) badge. The badge opens your HA instance, confirms the repository, and lands on the Add-on Store with BLE Scale Sync ready to install. Manual steps stay as a fallback
 - **HA Add-on**: `weight_unit` and `height_unit` exposed as add-on options (kg/lbs, cm/in), no longer hardcoded
 - **HA Add-on**: `last_known_weight` persists across restarts. Runtime config lives at `/data/config.yaml`; a small Python helper merges preserved per-user weights into the freshly generated config on every startup
 - **Docs**: new [Home Assistant Add-on guide](/guide/home-assistant-addon) with install, configuration reference, MQTT auto-detection, Garmin setup, MFA workaround, custom config mode, and troubleshooting

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,13 @@ description: Version history for BLE Scale Sync.
 
 All notable changes to this project are documented here. Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## Unreleased {#unreleased}
+
+### Added
+- **HA Add-on**: `weight_unit` and `height_unit` exposed as add-on options (kg/lbs, cm/in), no longer hardcoded
+- **HA Add-on**: `last_known_weight` persists across restarts. Runtime config lives at `/data/config.yaml`; a small Python helper merges preserved per-user weights into the freshly generated config on every startup
+- **Docs**: new [Home Assistant Add-on guide](/guide/home-assistant-addon) with install, configuration reference, MQTT auto-detection, Garmin setup, MFA workaround, custom config mode, and troubleshooting
+
 ## v1.7.5 <Badge type="tip" text="latest" /> {#v1-7-5}
 
 _2026-04-15_

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,13 +9,17 @@ All notable changes to this project are documented here. Format based on [Keep a
 
 ## Unreleased {#unreleased}
 
+## v1.8.0 <Badge type="tip" text="latest" /> {#v1-8-0}
+
+_2026-04-17_
+
 ### Added
 - **HA Add-on**: one-click install via a [My Home Assistant](https://www.home-assistant.io/integrations/my/) badge. The badge opens your HA instance, confirms the repository, and lands on the Add-on Store with BLE Scale Sync ready to install. Manual steps stay as a fallback
 - **HA Add-on**: `weight_unit` and `height_unit` exposed as add-on options (kg/lbs, cm/in), no longer hardcoded
 - **HA Add-on**: `last_known_weight` persists across restarts. Runtime config lives at `/data/config.yaml`; a small Python helper merges preserved per-user weights into the freshly generated config on every startup
 - **Docs**: new [Home Assistant Add-on guide](/guide/home-assistant-addon) with install, configuration reference, MQTT auto-detection, Garmin setup, MFA workaround, custom config mode, and troubleshooting
 
-## v1.7.5 <Badge type="tip" text="latest" /> {#v1-7-5}
+## v1.7.5 {#v1-7-5}
 
 _2026-04-15_
 

--- a/docs/exporters.md
+++ b/docs/exporters.md
@@ -43,7 +43,7 @@ global_exporters:
 ::: tip Authentication
 The setup wizard handles Garmin authentication automatically. You only need to authenticate once — tokens are cached and reused. To re-authenticate manually:
 
-**Native:**
+**Standalone (Node.js):**
 
 ```bash
 npm run setup-garmin
@@ -241,7 +241,7 @@ The **Authorization Callback Domain** must be set to `localhost`. During the OAu
 ::: tip Authentication
 After adding the Strava exporter to your config, run the setup script to authorize:
 
-**Native:**
+**Standalone (Node.js):**
 
 ```bash
 npm run setup-strava

--- a/docs/exporters.md
+++ b/docs/exporters.md
@@ -91,6 +91,10 @@ Garmin may block requests from cloud/VPN IPs. If authentication fails, try from 
 
 Publishes body composition as JSON to an MQTT broker. **Home Assistant auto-discovery** is enabled by default — all 10 metrics appear as sensors grouped under a single device, with availability tracking (LWT) and display precision per metric.
 
+::: tip Home Assistant users
+If you run Home Assistant OS or Supervised, the [Home Assistant Add-on](./guide/home-assistant-addon) auto-detects the Mosquitto broker through the Supervisor API, so you do not need to wire MQTT manually.
+:::
+
 | Field | Required | Default | Description |
 |---|---|---|---|
 | `broker_url` | Yes | — | `mqtt://host:1883` or `mqtts://` for TLS |

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -40,7 +40,7 @@ You don't need to edit `config.yaml` manually. The wizard handles everything, in
 docker run --rm -v ./config.yaml:/app/config.yaml:ro \
   ghcr.io/kristianp26/ble-scale-sync:latest validate
 
-# Native
+# Standalone (Node.js)
 npm run validate
 ```
 
@@ -131,7 +131,7 @@ global_exporters:
     password: '${GARMIN_PASSWORD}'
 ```
 
-Shared by all users unless a user defines their own `exporters` list. See [Exporters](/exporters) for all 5 targets and their configuration fields.
+Shared by all users unless a user defines their own `exporters` list. See [Exporters](/exporters) for all 7 targets and their configuration fields.
 
 ### Runtime
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -9,6 +9,10 @@ head:
 
 # Configuration
 
+::: tip Using the Home Assistant Add-on?
+The add-on is configured through the HA UI, not `config.yaml`. See the [Home Assistant Add-on guide](./home-assistant-addon) for the full option reference.
+:::
+
 ## Setup Wizard (recommended) {#setup-wizard-recommended}
 
 The fastest way to configure BLE Scale Sync is with the **interactive setup wizard**. It walks you through scale discovery, user profiles, exporter selection, and connectivity tests:
@@ -19,7 +23,7 @@ docker run --rm -it --network host --cap-add NET_ADMIN --cap-add NET_RAW \
   --group-add 112 -v /var/run/dbus:/var/run/dbus:ro \
   -v ./config.yaml:/app/config.yaml ghcr.io/kristianp26/ble-scale-sync:latest setup
 
-# Native (Linux, macOS, Windows)
+# Standalone (Node.js — Linux, macOS, Windows)
 npm run setup
 ```
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -91,7 +91,7 @@ sudo chown -R $(id -u):$(id -g) ./garmin-tokens
 ## Home Assistant Add-on {#home-assistant-addon}
 
 ::: warning Home Assistant OS / Supervised only
-Add-ons require the Home Assistant Supervisor, which is only present on **HA OS** and **HA Supervised** installations. If you run **HA Container** (Docker) or **HA Core** (Python venv), the **Add-on Store does not exist** in your UI — use the [Docker](#docker) method above and the [MQTT exporter](/exporters/mqtt) instead. Sensors still appear in HA via MQTT auto-discovery exactly the same way.
+Add-ons require the Home Assistant Supervisor, which is only present on **HA OS** and **HA Supervised** installations. If you run **HA Container** (Docker) or **HA Core** (Python venv), the **Add-on Store does not exist** in your UI — use the [Docker](#docker) method above and the [MQTT exporter](/exporters#mqtt) instead. Sensors still appear in HA via MQTT auto-discovery exactly the same way.
 
 To check your install type: **Settings → About**.
 :::

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -96,16 +96,22 @@ Add-ons require the Home Assistant Supervisor, which is only present on **HA OS*
 To check your install type: **Settings → About**.
 :::
 
-The easiest path on Home Assistant OS or Supervised. Install in two clicks, configure through the UI, and every metric shows up automatically as an MQTT auto-discovery sensor.
+The easiest path on Home Assistant OS or Supervised. One click adds the repository, then configure through the UI and every metric shows up automatically as an MQTT auto-discovery sensor.
 
-1. **Settings** > **Add-ons** > **Add-on Store** > three-dot menu > **Repositories**
+[![Add BLE Scale Sync repository to your Home Assistant](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2FKristianP26%2Fble-scale-sync)
+
+The badge uses [My Home Assistant](https://www.home-assistant.io/integrations/my/) to open your instance, confirm the repository, and land on the Add-on Store with **BLE Scale Sync** visible. Click **Install**, fill in your user profile on the **Configuration** tab, then start the add-on from the **Info** tab.
+
+::: details Prefer manual steps?
+1. **Settings** > **Add-ons** > **Add-on Store** > three-dot menu > **Repositories**.
 2. Add the repository URL:
 
    ```
    https://github.com/KristianP26/ble-scale-sync
    ```
 
-3. Refresh the store, install **BLE Scale Sync**, fill in your user profile on the **Configuration** tab, then start it from the **Info** tab.
+3. Refresh the store, install **BLE Scale Sync**, fill in your user profile on the **Configuration** tab, then start the add-on from the **Info** tab.
+:::
 
 See the [Home Assistant Add-on guide](./home-assistant-addon) for the full option reference, Garmin setup (including MFA), custom config mode, and troubleshooting.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -253,6 +253,6 @@ The original Raspberry Pi Zero W has an ARMv6 CPU. Key dependencies (`esbuild`, 
 ## What's Next?
 
 - [Configuration](./configuration) — config.yaml reference
-- [Supported Scales](./supported-scales) — all 23 brands
+- [Supported Scales](./supported-scales) — full adapter list
 - [Exporters](/exporters) — configure export targets
 - [ESP32 BLE Proxy](./esp32-proxy) — remote BLE via WiFi/MQTT

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -11,9 +11,20 @@ head:
 
 BLE Scale Sync runs on any device with BLE support — Linux (including Raspberry Pi), macOS, and Windows. If your server has no Bluetooth adapter, you can use a cheap [ESP32 as a remote BLE radio](#esp32-proxy) over WiFi.
 
-::: tip Running on Home Assistant?
-There is a dedicated [Home Assistant Add-on](./home-assistant-addon) with UI-driven configuration, Mosquitto auto-detection, and Garmin token bootstrap. It is the easiest path on Home Assistant OS.
-:::
+## Home Assistant Add-on {#home-assistant-addon}
+
+The easiest path on Home Assistant OS or Supervised. Install in two clicks, configure through the UI, and every metric shows up automatically as an MQTT auto-discovery sensor.
+
+1. **Settings** > **Add-ons** > **Add-on Store** > three-dot menu > **Repositories**
+2. Add the repository URL:
+
+   ```
+   https://github.com/KristianP26/ble-scale-sync
+   ```
+
+3. Refresh the store, install **BLE Scale Sync**, fill in your user profile on the **Configuration** tab, then start it from the **Info** tab.
+
+See the [Home Assistant Add-on guide](./home-assistant-addon) for the full option reference, Garmin setup (including MFA), custom config mode, and troubleshooting.
 
 ## Docker (Linux only) {#docker}
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -214,7 +214,7 @@ This also simplifies Docker deployments: no `NET_ADMIN`, no `--group-add`, no D-
 ble:
   handler: mqtt-proxy
   mqtt_proxy:
-    broker: mqtt://your-broker:1883
+    broker_url: mqtt://your-broker:1883
 ```
 
 4. Run with the simplified Docker compose:

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -11,6 +11,10 @@ head:
 
 BLE Scale Sync runs on any device with BLE support — Linux (including Raspberry Pi), macOS, and Windows. If your server has no Bluetooth adapter, you can use a cheap [ESP32 as a remote BLE radio](#esp32-proxy) over WiFi.
 
+::: tip Running on Home Assistant?
+There is a dedicated [Home Assistant Add-on](./home-assistant-addon) with UI-driven configuration, Mosquitto auto-detection, and Garmin token bootstrap. It is the easiest path on Home Assistant OS.
+:::
+
 ## Docker (Linux only) {#docker}
 
 ::: warning Linux only

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -17,7 +17,7 @@ Pick the install method that fits your setup:
 |---|---|
 | [Docker](#docker) | Linux / Raspberry Pi / NAS — works alongside any Home Assistant install (Container, Core, OS) via MQTT |
 | [Home Assistant Add-on](#home-assistant-addon) | Home Assistant **OS** or **Supervised** only |
-| [Standalone (Node.js)](#standalone) | macOS / Windows, or Linux without Docker |
+| [Standalone (Node.js)](#standalone) | All operating systems — Linux, macOS, Windows. No containers required. |
 | [ESP32 BLE Proxy](#esp32-proxy) | Server has no Bluetooth — pair with any method above |
 
 ## Docker (Linux only) {#docker}
@@ -110,6 +110,8 @@ The easiest path on Home Assistant OS or Supervised. Install in two clicks, conf
 See the [Home Assistant Add-on guide](./home-assistant-addon) for the full option reference, Garmin setup (including MFA), custom config mode, and troubleshooting.
 
 ## Standalone (Node.js) {#standalone}
+
+Runs natively on **Linux, macOS, and Windows** — no containers, no Supervisor required. The right pick for non-Linux hosts, hosts where Docker is not an option, or when you want to run BLE Scale Sync directly with `npm start`.
 
 ### Prerequisites
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: Install and run BLE Scale Sync with Docker or Node.js.
+description: Install and run BLE Scale Sync with Docker, the Home Assistant add-on, or natively on Node.js.
 head:
   - - meta
     - name: keywords
@@ -11,25 +11,19 @@ head:
 
 BLE Scale Sync runs on any device with BLE support — Linux (including Raspberry Pi), macOS, and Windows. If your server has no Bluetooth adapter, you can use a cheap [ESP32 as a remote BLE radio](#esp32-proxy) over WiFi.
 
-## Home Assistant Add-on {#home-assistant-addon}
+Pick the install method that fits your setup:
 
-The easiest path on Home Assistant OS or Supervised. Install in two clicks, configure through the UI, and every metric shows up automatically as an MQTT auto-discovery sensor.
-
-1. **Settings** > **Add-ons** > **Add-on Store** > three-dot menu > **Repositories**
-2. Add the repository URL:
-
-   ```
-   https://github.com/KristianP26/ble-scale-sync
-   ```
-
-3. Refresh the store, install **BLE Scale Sync**, fill in your user profile on the **Configuration** tab, then start it from the **Info** tab.
-
-See the [Home Assistant Add-on guide](./home-assistant-addon) for the full option reference, Garmin setup (including MFA), custom config mode, and troubleshooting.
+| Method | Best for |
+|---|---|
+| [Docker](#docker) | Linux / Raspberry Pi / NAS — works alongside any Home Assistant install (Container, Core, OS) via MQTT |
+| [Home Assistant Add-on](#home-assistant-addon) | Home Assistant **OS** or **Supervised** only |
+| [Standalone (Node.js)](#standalone) | macOS / Windows, or Linux without Docker |
+| [ESP32 BLE Proxy](#esp32-proxy) | Server has no Bluetooth — pair with any method above |
 
 ## Docker (Linux only) {#docker}
 
 ::: warning Linux only
-Docker requires a Linux host (including Raspberry Pi). It uses BlueZ via D-Bus for BLE access, which is not available on macOS or Windows Docker. For those platforms, use the [native install](#native).
+Docker requires a Linux host (including Raspberry Pi). It uses BlueZ via D-Bus for BLE access, which is not available on macOS or Windows Docker. For those platforms, use the [standalone install](#standalone).
 :::
 
 ### 1. Configure
@@ -94,7 +88,28 @@ sudo chown -R $(id -u):$(id -g) ./garmin-tokens
 | `--group-add <GID>` | Bluetooth group GID — run `getent group bluetooth \| cut -d: -f3` (commonly `112`) |
 :::
 
-## Native (Linux, macOS, Windows) {#native}
+## Home Assistant Add-on {#home-assistant-addon}
+
+::: warning Home Assistant OS / Supervised only
+Add-ons require the Home Assistant Supervisor, which is only present on **HA OS** and **HA Supervised** installations. If you run **HA Container** (Docker) or **HA Core** (Python venv), the **Add-on Store does not exist** in your UI — use the [Docker](#docker) method above and the [MQTT exporter](/exporters/mqtt) instead. Sensors still appear in HA via MQTT auto-discovery exactly the same way.
+
+To check your install type: **Settings → About**.
+:::
+
+The easiest path on Home Assistant OS or Supervised. Install in two clicks, configure through the UI, and every metric shows up automatically as an MQTT auto-discovery sensor.
+
+1. **Settings** > **Add-ons** > **Add-on Store** > three-dot menu > **Repositories**
+2. Add the repository URL:
+
+   ```
+   https://github.com/KristianP26/ble-scale-sync
+   ```
+
+3. Refresh the store, install **BLE Scale Sync**, fill in your user profile on the **Configuration** tab, then start it from the **Info** tab.
+
+See the [Home Assistant Add-on guide](./home-assistant-addon) for the full option reference, Garmin setup (including MFA), custom config mode, and troubleshooting.
+
+## Standalone (Node.js) {#standalone}
 
 ### Prerequisites
 

--- a/docs/guide/home-assistant-addon.md
+++ b/docs/guide/home-assistant-addon.md
@@ -1,0 +1,196 @@
+---
+title: Home Assistant Add-on
+description: Install BLE Scale Sync as a Home Assistant add-on, read measurements from Bluetooth smart scales, and expose them as HA sensors via MQTT auto-discovery.
+head:
+  - - meta
+    - name: keywords
+      content: home assistant ble scale, hassio bluetooth scale, home assistant addon, mqtt auto discovery, ble scale sync hassio, smart scale home assistant, hacs bluetooth scale
+---
+
+# Home Assistant Add-on
+
+BLE Scale Sync ships as a native Home Assistant add-on for Home Assistant OS and Supervised installations. The add-on generates a working config from the UI, auto-detects the Mosquitto broker, exposes every metric as an MQTT auto-discovery sensor, and can optionally upload to Garmin Connect.
+
+## Install
+
+1. In Home Assistant, go to **Settings** > **Add-ons** > **Add-on Store**.
+2. Click the three-dot menu > **Repositories** and add:
+
+   ```
+   https://github.com/KristianP26/ble-scale-sync
+   ```
+
+3. Refresh the store. "BLE Scale Sync" appears under the new repository.
+4. Click **Install**. The Supervisor pulls the arm64 / armv7 / amd64 image (whichever matches your host).
+5. After install, open the **Configuration** tab and fill in your scale MAC and user profile. Then start the add-on from the **Info** tab.
+
+::: tip
+The add-on requires `host_network`, `host_dbus`, and the `NET_ADMIN` / `NET_RAW` capabilities to access the host Bluetooth adapter through BlueZ. The Supervisor grants these automatically.
+:::
+
+## Quick start
+
+Minimal config for a single-user Renpho / Xiaomi / Eufy scale with MQTT and Home Assistant auto-discovery:
+
+1. Install the **Mosquitto broker** add-on (if you do not already run an MQTT broker) and start it.
+2. In the BLE Scale Sync config:
+   - Leave **Scale MAC address** empty for auto-discovery, or paste the MAC you found with the `scan` command.
+   - Fill **User profile** (name, height, birth date, gender).
+   - Leave **MQTT enabled** and **MQTT auto-detect** on. The add-on reads the Mosquitto broker details from the Supervisor API, so no broker URL or credentials are needed.
+3. Start the add-on and step on the scale. Within a few minutes new sensors appear under **Settings** > **Devices & Services** > **MQTT**.
+
+The exposed sensors cover weight, body fat, water, muscle mass, bone mass, BMI, BMR, visceral fat, metabolic age, and impedance.
+
+## Configuration reference
+
+All options live under the **Configuration** tab. The add-on regenerates `/data/config.yaml` on every restart, so changes here take effect on the next start.
+
+### Scale and BLE
+
+| Option | Default | Notes |
+|---|---|---|
+| `scale_mac` | empty | Leave empty for auto-discovery. Set to a specific MAC like `AA:BB:CC:DD:EE:FF` to skip scanning. Required for scales with non-unique advertised names. |
+| `ble_adapter` | empty (uses default) | Set to `hci0`, `hci1`, ... on hosts with multiple Bluetooth adapters. |
+| `reset_bluetooth` | `true` | Runs `btmgmt power off/on` at startup. Leave on unless you run other HA Bluetooth integrations that lose connectivity when the adapter is power-cycled. |
+
+### Unit preferences
+
+| Option | Default | Allowed |
+|---|---|---|
+| `weight_unit` | `kg` | `kg`, `lbs` |
+| `height_unit` | `cm` | `cm`, `in` |
+
+The CLI and exporters display weights and heights in your chosen unit; all internal math stays in kg / cm.
+
+### User profile
+
+| Option | Default | Notes |
+|---|---|---|
+| `user_name` | `Default` | Display name used in logs and HA entity names. |
+| `user_height` | `170` | In the unit chosen above. |
+| `user_birth_date` | `1990-01-01` | `YYYY-MM-DD`. Used for age-based BMR and physique rating. |
+| `user_gender` | `male` | `male` or `female`. |
+| `user_is_athlete` | `false` | Shifts body fat formulas for athletic body types. |
+| `user_weight_min` / `user_weight_max` | `40` / `150` | Used by the multi-user matcher to filter implausible readings. |
+
+### MQTT
+
+| Option | Default | Notes |
+|---|---|---|
+| `mqtt_enabled` | `true` | Enable the MQTT exporter. |
+| `mqtt_auto` | `true` | Auto-detect the Mosquitto add-on broker via the Supervisor API. Overrides manual URL / credentials when the Mosquitto add-on is installed. |
+| `mqtt_broker_url` | empty | Manual broker URL, e.g. `mqtt://192.168.1.50:1883` or `mqtts://...`. Only used when `mqtt_auto` is off or auto-detection fails. |
+| `mqtt_username` / `mqtt_password` | empty | Credentials for the manual broker. |
+| `mqtt_topic` | `scale/body-composition` | Base topic. Payload is published to this topic; HA discovery entities use `homeassistant/sensor/<topic>/...`. |
+| `mqtt_ha_discovery` | `true` | Publish auto-discovery entities under `homeassistant/`. Disable if you want raw MQTT only. |
+| `mqtt_ha_device_name` | `BLE Scale` | Device name grouping the entities in HA. |
+
+### Garmin Connect
+
+| Option | Default | Notes |
+|---|---|---|
+| `garmin_enabled` | `false` | Enable the Garmin Connect exporter. |
+| `garmin_email` / `garmin_password` | empty | Garmin credentials. On first start the add-on runs `setup_garmin.py` to authenticate and saves OAuth tokens to `/data/garmin-tokens/`. |
+
+If your account uses MFA, see [MFA workaround](#mfa-workaround) below.
+
+### Runtime
+
+| Option | Default | Notes |
+|---|---|---|
+| `scan_cooldown` | `30` | Seconds to wait between scan cycles in continuous mode. Range: 5-3600. |
+| `debug` | `false` | Enable verbose BLE logs. Useful when opening an issue. |
+| `custom_config` | `false` | Ignore UI options entirely and use `/share/ble-scale-sync/config.yaml` instead. See [Custom config mode](#custom-config-mode). |
+
+## MQTT auto-detection
+
+When `mqtt_auto: true` and the Mosquitto add-on is running on the same host, BLE Scale Sync pulls the broker URL, username, and password from the Supervisor API (`GET /services/mqtt`) and wires the MQTT exporter automatically. You will see a line like this in the logs:
+
+```
+[ble-scale-sync] MQTT auto-detected: mqtt://core-mosquitto:1883
+```
+
+If the Mosquitto add-on is not installed or the API call fails, the add-on falls back to whatever you set in `mqtt_broker_url` / `mqtt_username` / `mqtt_password`.
+
+## Garmin Connect
+
+To upload measurements to Garmin Connect:
+
+1. Enable **Garmin Connect** and enter your email and password in the Configuration tab.
+2. Start the add-on.
+3. On first start the add-on runs `python3 garmin-scripts/setup_garmin.py --from-config /data/config.yaml`. If authentication succeeds, OAuth tokens are saved under `/data/garmin-tokens/` and subsequent runs reuse them without re-entering the password.
+
+### MFA workaround
+
+Home Assistant add-ons run without an interactive terminal, so the add-on cannot prompt for a 2FA code. If your account has MFA enabled:
+
+1. On a laptop or desktop, clone the repo and run `python3 garmin-scripts/setup_garmin.py`. Enter email, password, and MFA code when prompted. This writes `oauth1_token.json` and `oauth2_token.json` to `~/.garmin_tokens/`.
+2. Copy those two files to `/share/ble-scale-sync/garmin-tokens/` on the Home Assistant host. The Samba and File editor add-ons both expose `/share/` for easy uploads.
+3. Restart BLE Scale Sync. On startup the add-on detects the pre-generated tokens and imports them into `/data/garmin-tokens/`.
+
+The same workflow applies if Garmin is blocking your HA host's IP as a data-centre / VPN address: authenticate from a trusted network and import the tokens.
+
+## Custom config mode
+
+For multi-user setups or exporters the UI does not cover (InfluxDB, Webhook, Ntfy, Strava, File), flip `custom_config: true` and drop a full `config.yaml` at:
+
+```
+/share/ble-scale-sync/config.yaml
+```
+
+The add-on copies that file verbatim into the runtime location on each start. See [config.yaml.example](https://github.com/KristianP26/ble-scale-sync/blob/main/config.yaml.example) for the full schema.
+
+Custom config mode still benefits from `last_known_weight` persistence (see below) but the add-on does not auto-run Garmin authentication; you handle that yourself by pre-seeding `/share/ble-scale-sync/garmin-tokens/`.
+
+## Persistence
+
+Everything that should survive add-on restarts lives under `/data/` inside the container, which the Supervisor maps to persistent storage:
+
+| Path | Purpose |
+|---|---|
+| `/data/config.yaml` | The merged runtime config. Regenerated from UI options on every start, with `last_known_weight` preserved per user. |
+| `/data/garmin-tokens/` | Garmin OAuth tokens produced by first authentication. |
+
+User-supplied files live under `/share/ble-scale-sync/`:
+
+| Path | Purpose |
+|---|---|
+| `/share/ble-scale-sync/config.yaml` | Custom config (used when `custom_config: true`). |
+| `/share/ble-scale-sync/garmin-tokens/` | Optional pre-generated Garmin tokens imported on startup (MFA workaround). |
+
+## Troubleshooting
+
+### No scale found
+
+1. Step on the scale to wake it up. Most scales go to sleep after a few seconds.
+2. Run the **scan** command from a terminal on the HA host:
+
+   ```bash
+   docker run --rm -it --network host --cap-add NET_ADMIN --cap-add NET_RAW \
+     --group-add 112 -v /var/run/dbus:/var/run/dbus:ro \
+     ghcr.io/kristianp26/ble-scale-sync:latest scan
+   ```
+3. If the scale is visible, paste its MAC into the **Scale MAC address** field.
+4. If multiple Bluetooth adapters are attached, set **BLE adapter** to the one facing the scale (`hci1`, etc.).
+
+### MQTT entities do not appear
+
+1. Open the Mosquitto add-on logs and confirm it is running and accepting connections.
+2. Enable `debug: true` in the BLE Scale Sync add-on and restart. Look for `[ble-scale-sync] MQTT auto-detected: ...` at startup.
+3. Check that the scale actually produced a measurement; HA auto-discovery entities are published on the first successful reading.
+
+### Garmin "No such file or directory: oauth1_token.json"
+
+Fixed in v1.7.5. Make sure the add-on is on that version or newer. If it still fails, your account likely uses MFA — see [MFA workaround](#mfa-workaround).
+
+### BlueZ discovery gets stuck after hours
+
+Known upstream BlueZ bug on Broadcom adapters (`bluez/bluez#807`). See the general [troubleshooting page](/troubleshooting#ble-discovery-stops-working-after-hours-bluez-zombie-state) for the full recovery behaviour the app implements. The add-on already has `/dev/rfkill` and `CAP_NET_ADMIN` available for the recovery tiers.
+
+## Limitations and roadmap
+
+- The UI is scoped to a single user. For multi-user / per-user-exporter setups, use [custom config mode](#custom-config-mode).
+- The add-on has not yet been submitted to the [HACS](https://hacs.xyz/) default repository. For now, add the GitHub URL as a custom repository.
+- A dedicated Home Assistant notification exporter (persistent notifications or Companion app push) is planned.
+
+Source, issue tracker, and changelog live at [github.com/KristianP26/ble-scale-sync](https://github.com/KristianP26/ble-scale-sync).

--- a/docs/guide/home-assistant-addon.md
+++ b/docs/guide/home-assistant-addon.md
@@ -13,16 +13,21 @@ BLE Scale Sync ships as a native Home Assistant add-on for Home Assistant OS and
 
 ## Install
 
-1. In Home Assistant, go to **Settings** > **Add-ons** > **Add-on Store**.
-2. Click the three-dot menu > **Repositories** and add:
+[![Add BLE Scale Sync repository to your Home Assistant](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2FKristianP26%2Fble-scale-sync)
+
+The badge above uses [My Home Assistant](https://www.home-assistant.io/integrations/my/) to open your instance, confirm the repository, and drop you on the Add-on Store with **BLE Scale Sync** visible. Click **Install**, then head to the **Configuration** tab and fill in your scale MAC and user profile. Start the add-on from the **Info** tab. The Supervisor pulls the arm64 / armv7 / amd64 image to match your host.
+
+::: details Prefer manual steps?
+1. **Settings** > **Add-ons** > **Add-on Store**.
+2. Three-dot menu > **Repositories** and add:
 
    ```
    https://github.com/KristianP26/ble-scale-sync
    ```
 
-3. Refresh the store. "BLE Scale Sync" appears under the new repository.
-4. Click **Install**. The Supervisor pulls the arm64 / armv7 / amd64 image (whichever matches your host).
-5. After install, open the **Configuration** tab and fill in your scale MAC and user profile. Then start the add-on from the **Info** tab.
+3. Refresh the store. **BLE Scale Sync** appears under the new repository.
+4. Click **Install**, then open the **Configuration** tab and fill in your scale MAC and user profile. Start the add-on from the **Info** tab.
+:::
 
 ::: tip
 The add-on requires `host_network`, `host_dbus`, and the `NET_ADMIN` / `NET_RAW` capabilities to access the host Bluetooth adapter through BlueZ. The Supervisor grants these automatically.

--- a/docs/guide/supported-scales.md
+++ b/docs/guide/supported-scales.md
@@ -51,7 +51,7 @@ The [setup wizard](/guide/configuration#setup-wizard-recommended) includes inter
 docker run --rm --network host --cap-add NET_ADMIN --cap-add NET_RAW \
   ghcr.io/kristianp26/ble-scale-sync:latest scan
 
-# Native
+# Standalone (Node.js)
 npm run scan
 ```
 

--- a/docs/guide/supported-scales.md
+++ b/docs/guide/supported-scales.md
@@ -9,7 +9,7 @@ head:
 
 # Supported Scales
 
-BLE Scale Sync supports **23 scale brands** out of the box. All scales provide weight + impedance for full [body composition](/body-composition) calculation.
+BLE Scale Sync ships **23 protocol adapters** out of the box, covering Xiaomi, Renpho (incl. FITINDEX, Sencor, QN-Scale), Eufy, Yunmai, Beurer, Sanitas, Medisana, and more — plus a generic Bluetooth SIG adapter that works with any spec-compliant BCS/WSS scale. Each adapter typically supports several models or rebrands sold under different names, so the real device coverage is much wider than the adapter count. All adapters provide weight + impedance for full [body composition](/body-composition) calculation.
 
 ## Scale List
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,10 +89,11 @@ Ideal for Raspberry Pi, NAS, and headless servers. Works alongside any Home Assi
 
 ### Option 2: Home Assistant Add-on
 
-Running Home Assistant **OS** or **Supervised**? Install the add-on in two clicks and skip the CLI entirely.
+Running Home Assistant **OS** or **Supervised**? One click and skip the CLI entirely.
 
-1. **Settings** > **Add-ons** > **Add-on Store** > three-dot menu > **Repositories**
-2. Add `https://github.com/KristianP26/ble-scale-sync` and install **BLE Scale Sync**
+[![Add BLE Scale Sync repository to your Home Assistant](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2FKristianP26%2Fble-scale-sync)
+
+The badge opens your Home Assistant instance, confirms the repository, and lands you on the Add-on Store with **BLE Scale Sync** ready to install.
 
 The add-on handles config through the UI, auto-detects the Mosquitto broker for Home Assistant auto-discovery, and bootstraps Garmin tokens on first start. See the [Home Assistant Add-on guide](/guide/home-assistant-addon) for the full option reference, MFA workaround, and custom config mode.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ head:
 hero:
   name: BLE Scale Sync
   text: Automatic body composition sync
-  tagline: Cross-platform CLI for Linux, macOS & Windows. Read weight & impedance from 23 BLE smart scales and export to Garmin Connect, Strava, Home Assistant, InfluxDB, Webhooks, Ntfy & local files. No phone app needed.
+  tagline: Cross-platform CLI for Linux, macOS & Windows. Read weight & impedance from 20+ BLE smart scales and export to Garmin Connect, Strava, Home Assistant, InfluxDB, Webhooks, Ntfy & local files. No phone app needed.
   image:
     src: /logo.svg
     alt: BLE Scale Sync
@@ -22,8 +22,8 @@ hero:
 
 features:
   - icon: "\u2696\uFE0F"
-    title: 23 Scale Brands
-    details: Xiaomi, Renpho, Eufy, Yunmai, Beurer, Sanitas, Medisana, and more. Auto-detection out of the box.
+    title: 20+ Smart Scales
+    details: Xiaomi, Renpho (FITINDEX, Sencor, QN-Scale), Eufy, Yunmai, Beurer, Sanitas, Medisana, and more. Auto-detection out of the box.
     link: /guide/supported-scales
     linkText: See all scales
   - icon: "\uD83D\uDCE4"

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,16 +65,7 @@ features:
 
 ## Quick Start
 
-### Option 1: Home Assistant Add-on
-
-Running Home Assistant OS or Supervised? Install the add-on in two clicks and skip the CLI entirely.
-
-1. **Settings** > **Add-ons** > **Add-on Store** > three-dot menu > **Repositories**
-2. Add `https://github.com/KristianP26/ble-scale-sync` and install **BLE Scale Sync**
-
-The add-on handles config through the UI, auto-detects the Mosquitto broker for Home Assistant auto-discovery, and bootstraps Garmin tokens on first start. See the [Home Assistant Add-on guide](/guide/home-assistant-addon) for the full option reference, MFA workaround, and custom config mode.
-
-### Option 2: Docker (Linux)
+### Option 1: Docker (Linux)
 
 ```bash
 # Configure
@@ -94,9 +85,24 @@ docker run -d --restart unless-stopped --network host \
   ghcr.io/kristianp26/ble-scale-sync:latest
 ```
 
-Ideal for Raspberry Pi and headless servers. Your data never leaves your network.
+Ideal for Raspberry Pi, NAS, and headless servers. Works alongside any Home Assistant install (Container, Core, OS) via MQTT auto-discovery. Your data never leaves your network.
 
-### Option 3: Native (Linux, macOS, Windows)
+### Option 2: Home Assistant Add-on
+
+Running Home Assistant **OS** or **Supervised**? Install the add-on in two clicks and skip the CLI entirely.
+
+1. **Settings** > **Add-ons** > **Add-on Store** > three-dot menu > **Repositories**
+2. Add `https://github.com/KristianP26/ble-scale-sync` and install **BLE Scale Sync**
+
+The add-on handles config through the UI, auto-detects the Mosquitto broker for Home Assistant auto-discovery, and bootstraps Garmin tokens on first start. See the [Home Assistant Add-on guide](/guide/home-assistant-addon) for the full option reference, MFA workaround, and custom config mode.
+
+::: warning
+Add-ons are not available on **HA Container** or **HA Core** installs (no Supervisor). Use Option 1 instead.
+:::
+
+### Option 3: Standalone (Node.js — Linux, macOS, Windows)
+
+Runs natively on all major desktop and server operating systems. No containers, no Supervisor required.
 
 ```bash
 git clone https://github.com/KristianP26/ble-scale-sync.git
@@ -137,7 +143,7 @@ The ideal setup: a [~15€ single-board computer](https://www.raspberrypi.com/pr
 :::
 
 ::: tip Two ways to connect your scale
-**Local BLE** (Options 1 & 2): the server has a Bluetooth adapter and talks to the scale directly. Needs BlueZ/D-Bus on Linux, or native BLE on macOS/Windows.
+**Local BLE** (any of the options above): the server has a Bluetooth adapter and talks to the scale directly. Needs BlueZ/D-Bus on Linux, or native BLE on macOS/Windows.
 
 **Remote BLE via ESP32**: a cheap ~8€ ESP32 board sits near the scale and relays BLE data over WiFi/MQTT. The server needs no Bluetooth at all, which makes Docker deployment much simpler (no `NET_ADMIN`, no D-Bus mounts). See the [ESP32 BLE Proxy guide](/guide/esp32-proxy).
 :::

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,16 +46,16 @@ features:
     details: Runs natively on Linux, macOS & Windows. Docker images available for Linux.
     link: /guide/getting-started
     linkText: Install guide
+  - icon: "\uD83C\uDFE0"
+    title: Home Assistant Add-on
+    details: Two-click install in HA OS / Supervised. UI-driven config, Mosquitto auto-detection for HA auto-discovery, and Garmin token bootstrap on first start.
+    link: /guide/home-assistant-addon
+    linkText: Add-on guide
   - icon: "\uD83D\uDCE1"
     title: ESP32 BLE Proxy
     details: Use a cheap ESP32 as a remote Bluetooth radio over MQTT. No BLE adapter needed on the server. Optional display board for live status.
     link: /guide/esp32-proxy
     linkText: Proxy setup guide
-  - icon: "\uD83E\uDDD9"
-    title: Setup Wizard
-    details: Interactive CLI wizard that discovers scales, configures exporters, tests connectivity, and generates your config.yaml.
-    link: /guide/configuration
-    linkText: Configuration guide
   - icon: "\uD83D\uDD12"
     title: Private & Self-Hosted
     details: Your data stays on your device. No vendor cloud, no account, no tracking. Fully open source.
@@ -65,7 +65,16 @@ features:
 
 ## Quick Start
 
-### Option 1: Docker (Linux)
+### Option 1: Home Assistant Add-on
+
+Running Home Assistant OS or Supervised? Install the add-on in two clicks and skip the CLI entirely.
+
+1. **Settings** > **Add-ons** > **Add-on Store** > three-dot menu > **Repositories**
+2. Add `https://github.com/KristianP26/ble-scale-sync` and install **BLE Scale Sync**
+
+The add-on handles config through the UI, auto-detects the Mosquitto broker for Home Assistant auto-discovery, and bootstraps Garmin tokens on first start. See the [Home Assistant Add-on guide](/guide/home-assistant-addon) for the full option reference, MFA workaround, and custom config mode.
+
+### Option 2: Docker (Linux)
 
 ```bash
 # Configure
@@ -87,7 +96,7 @@ docker run -d --restart unless-stopped --network host \
 
 Ideal for Raspberry Pi and headless servers. Your data never leaves your network.
 
-### Option 2: Native (Linux, macOS, Windows)
+### Option 3: Native (Linux, macOS, Windows)
 
 ```bash
 git clone https://github.com/KristianP26/ble-scale-sync.git

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ble-scale-sync",
-  "version": "1.7.5",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ble-scale-sync",
-      "version": "1.7.5",
+      "version": "1.8.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@abandonware/noble": "^1.9.2-26",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ble-scale-sync",
-  "version": "1.7.5",
+  "version": "1.8.0",
   "description": "Universal BLE Smart Scale bridge. Captures body composition from Renpho, Xiaomi & 20+ others, syncs to Garmin Connect, Strava, MQTT (Home Assistant), InfluxDB, Webhooks, Ntfy & local files. Headless CLI for Raspberry Pi, Linux, macOS & Windows.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary
- **HA Add-on**: one-click install via My Home Assistant badge
- **HA Add-on**: `weight_unit` / `height_unit` options (kg/lbs, cm/in)
- **HA Add-on**: `last_known_weight` persists across restarts via `/data/config.yaml`
- **Docs**: new Home Assistant Add-on guide, promoted to first-class quick-start

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npx vitest run` (1151 tests / 60 files)
- [ ] CI: `typecheck-and-test (20)`, `(22)`, `(24)`, `python-check`
- [ ] Manual: install add-on via My HA badge into a clean HA OS instance
- [ ] Manual: confirm `weight_unit: lbs` round-trips through the UI
- [ ] Manual: restart add-on and verify `last_known_weight` is preserved