### PR TITLE
Release v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.8.1] - 2026-04-20
+
+### Fixed
+- **Garmin**: upload failed with `'Garmin' object has no attribute 'garth'` after `garminconnect` released 0.3.0 on 2026-04-02, which dropped the `garth` dependency in favor of native authentication. The Python bridge accessed `garmin.garth.sess.headers` and `garmin.garth.dump()`, both removed in 0.3.x. Migrated to the new API: `Garmin.login(tokenstore)` auto-persists on successful credential login, and `client.dump(token_dir)` saves tokens after MFA. Custom User-Agent override is no longer needed because `garminconnect` now uses `curl_cffi` TLS impersonation and randomized browser fingerprints internally ([#114](https://github.com/KristianP26/ble-scale-sync/issues/114))
+- **Docker**: added `libcurl4-openssl-dev` so `curl_cffi` (new transitive dep via `garminconnect` 0.3.x) builds from source on armv7, where PyPI has no prebuilt wheel
+
+### Breaking
+- Tokens from `garminconnect` 0.2.x (old garth OAuth1/OAuth2 files) are incompatible with 0.3.x. Existing installs must re-authenticate: `npm run setup-garmin`, or in the HA Add-on just restart the add-on so it re-runs setup from the credentials you entered. The setup script auto-removes leftover `oauth*_token.json` files before writing the new token format.
+
+### Thanks
+- [@Phipseyy](https://github.com/Phipseyy) and [@mooredav87](https://github.com/mooredav87) for reporting the Garmin upload regression ([#114](https://github.com/KristianP26/ble-scale-sync/issues/114))
+
 ## [1.8.0] - 2026-04-17
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,10 @@ LABEL org.opencontainers.image.title="BLE Scale Sync" \
 
 # System dependencies: BLE (BlueZ + D-Bus), Python (Garmin upload), tini (PID 1),
 # build-essential (node-gyp needs gcc/g++/make for native BLE modules),
-# python3-dev + libffi-dev + libssl-dev (cffi/cryptography build from source
-# on architectures without pre-built wheels, e.g. linux/arm/v7)
+# python3-dev + libffi-dev + libssl-dev + libcurl4-openssl-dev
+# (cffi/cryptography/curl_cffi build from source on architectures without
+# pre-built wheels, e.g. linux/arm/v7. curl_cffi is a transitive dep of
+# garminconnect 0.3.x and has no armv7 wheel on PyPI.)
 RUN apt-get update && apt-get install -y --no-install-recommends \
       bluez \
       libbluetooth-dev \
@@ -41,6 +43,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       python3-venv \
       libffi-dev \
       libssl-dev \
+      libcurl4-openssl-dev \
       tini \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ble-scale-sync-addon/CHANGELOG.md
+++ b/ble-scale-sync-addon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.8.1
+
+- Fix Garmin upload failing with `'Garmin' object has no attribute 'garth'` after `garminconnect` 0.3.0 dropped the garth dependency. Migrated to the new native auth API and single `garmin_tokens.json` token format.
+- Legacy `oauth1_token.json` / `oauth2_token.json` files are automatically removed on first start; the add-on re-authenticates from the credentials you entered in the UI. MFA users regenerate the token file per the MFA workaround in DOCS.md.
+- Docker: added `libcurl4-openssl-dev` so `curl_cffi` (new transitive dep) builds from source on armv7.
+
 ## 1.7.0
 
 - Initial Home Assistant Add-on release

--- a/ble-scale-sync-addon/DOCS.md
+++ b/ble-scale-sync-addon/DOCS.md
@@ -58,13 +58,17 @@ Home Assistant add-ons run without an interactive terminal, so the add-on cannot
    ```bash
    python3 garmin-scripts/setup_garmin.py
    ```
-   Enter your email, password, and MFA code when prompted. This writes `oauth1_token.json` and `oauth2_token.json` to `~/.garmin_tokens/`.
-2. Copy those two files into `/share/ble-scale-sync/garmin-tokens/` on the Home Assistant host (use the Samba or File editor add-on).
-3. Restart the BLE Scale Sync add-on. On startup it detects the pre-generated tokens and imports them into `/data/garmin-tokens/`.
+   Enter your email, password, and MFA code when prompted. This writes `garmin_tokens.json` to `~/.garmin_tokens/`.
+2. Copy that file into `/share/ble-scale-sync/garmin-tokens/` on the Home Assistant host (use the Samba or File editor add-on).
+3. Restart the BLE Scale Sync add-on. On startup it detects the pre-generated token and imports it into `/data/garmin-tokens/`.
 
-If Garmin also blocks cloud or residential proxy IPs, the same workflow applies: authenticate from a trusted network, then import the tokens.
+If Garmin also blocks cloud or residential proxy IPs, the same workflow applies: authenticate from a trusted network, then import the token.
 
 If you disable Garmin in the add-on UI, cached tokens are left in place so you can turn it back on without re-authenticating.
+
+### Upgrading from add-on v1.7.x or v1.8.0
+
+Add-on v1.8.1 bumps `garminconnect` to 0.3.x, which uses a new native auth engine and a new token format. Tokens from earlier versions (`oauth1_token.json`, `oauth2_token.json`) are incompatible and are removed automatically on first start. The add-on re-runs `setup_garmin.py` with the email and password you entered in the UI, so for non-MFA accounts no action is needed beyond restarting the add-on. MFA users follow the workaround above with the new single-file token.
 
 ## Advanced: Custom Config
 

--- a/ble-scale-sync-addon/config.yaml
+++ b/ble-scale-sync-addon/config.yaml
@@ -1,5 +1,5 @@
 name: BLE Scale Sync
-version: "1.8.0"
+version: "1.8.1"
 slug: ble-scale-sync
 description: Read BLE smart scales and export to Garmin Connect, MQTT (HA auto-discovery), InfluxDB, and more
 url: https://github.com/KristianP26/ble-scale-sync

--- a/ble-scale-sync-addon/run.sh
+++ b/ble-scale-sync-addon/run.sh
@@ -234,9 +234,14 @@ rm -f "$FRESH"
 # ── Garmin token bootstrap ──────────────────────────────────────────────────
 # garmin_upload.py only loads tokens; it does not authenticate from email and
 # password. On first start the token directory is empty, so we run
-# setup_garmin.py to produce oauth1_token.json and oauth2_token.json from the
-# credentials the user entered in the add-on UI. Skipped in custom config
-# mode, where advanced users handle their own Garmin auth.
+# setup_garmin.py to produce garmin_tokens.json from the credentials the user
+# entered in the add-on UI. Skipped in custom config mode, where advanced
+# users handle their own Garmin auth.
+#
+# garminconnect 0.3.x (2026-04) replaced the garth-based oauth1/oauth2 token
+# files with a single garmin_tokens.json. Legacy oauth*_token.json files left
+# over from pre-0.3 are stripped by setup_garmin.py before writing the new
+# format.
 
 if [ "$CUSTOM_CONFIG" != "true" ] && [ "$GARMIN_ENABLED" = "true" ] \
    && [ -n "$GARMIN_EMAIL" ] && [ -n "$GARMIN_PASSWORD" ]; then
@@ -244,17 +249,23 @@ if [ "$CUSTOM_CONFIG" != "true" ] && [ "$GARMIN_ENABLED" = "true" ] \
   SHARE_DIR="/share/ble-scale-sync/garmin-tokens"
   mkdir -p "$TOKEN_DIR"
 
+  # If only legacy pre-0.3 tokens are present, treat the dir as empty so we
+  # re-authenticate (or re-import from /share) and write the new format.
+  if [ -f "$TOKEN_DIR/oauth1_token.json" ] \
+     && [ ! -f "$TOKEN_DIR/garmin_tokens.json" ]; then
+    log "Removing legacy garth tokens (incompatible with garminconnect 0.3.x)"
+    rm -f "$TOKEN_DIR"/oauth*_token.json
+  fi
+
   # Option 1: user pre-generated tokens on another machine (MFA workaround)
-  if [ ! -f "$TOKEN_DIR/oauth1_token.json" ] \
-     && [ -f "$SHARE_DIR/oauth1_token.json" ]; then
+  if [ ! -f "$TOKEN_DIR/garmin_tokens.json" ] \
+     && [ -f "$SHARE_DIR/garmin_tokens.json" ]; then
     log "Importing Garmin tokens from $SHARE_DIR"
-    cp "$SHARE_DIR/oauth1_token.json" "$TOKEN_DIR/" 2>/dev/null || true
-    [ -f "$SHARE_DIR/oauth2_token.json" ] && \
-      cp "$SHARE_DIR/oauth2_token.json" "$TOKEN_DIR/" 2>/dev/null || true
+    cp "$SHARE_DIR/garmin_tokens.json" "$TOKEN_DIR/" 2>/dev/null || true
   fi
 
   # Option 2: auto-authenticate if tokens still missing
-  if [ ! -f "$TOKEN_DIR/oauth1_token.json" ]; then
+  if [ ! -f "$TOKEN_DIR/garmin_tokens.json" ]; then
     log "Garmin tokens missing, authenticating with provided credentials..."
     if python3 /app/garmin-scripts/setup_garmin.py --from-config "$CONFIG"; then
       log "Garmin authentication successful, tokens saved to $TOKEN_DIR"
@@ -262,8 +273,8 @@ if [ "$CUSTOM_CONFIG" != "true" ] && [ "$GARMIN_ENABLED" = "true" ] \
       log "WARNING: Garmin authentication failed."
       log "If your account uses MFA or Garmin is blocking this IP, run"
       log "  python3 garmin-scripts/setup_garmin.py --from-config config.yaml"
-      log "on another machine and copy oauth1_token.json and oauth2_token.json"
-      log "into /share/ble-scale-sync/garmin-tokens/ on this HA host."
+      log "on another machine and copy garmin_tokens.json into"
+      log "/share/ble-scale-sync/garmin-tokens/ on this HA host."
       log "Other exporters (MQTT, etc.) will continue to work."
     fi
   else

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,18 @@ All notable changes to this project are documented here. Format based on [Keep a
 
 ## Unreleased {#unreleased}
 
-## v1.8.0 <Badge type="tip" text="latest" /> {#v1-8-0}
+## v1.8.1 <Badge type="tip" text="latest" /> {#v1-8-1}
+
+_2026-04-20_
+
+### Fixed
+- **Garmin**: upload failed with `'Garmin' object has no attribute 'garth'` after `garminconnect` 0.3.0 (released 2026-04-02) dropped the `garth` dependency. Migrated the Python bridge to the new native auth API: `Garmin.login(tokenstore)` auto-persists on successful login, and `client.dump(token_dir)` saves tokens after MFA. The custom User-Agent override is obsolete because `garminconnect` now uses `curl_cffi` TLS impersonation internally ([#114](https://github.com/KristianP26/ble-scale-sync/issues/114))
+- **Docker**: added `libcurl4-openssl-dev` so `curl_cffi` builds from source on armv7 (no prebuilt wheel on PyPI)
+
+### Breaking
+- Old tokens from `garminconnect` 0.2.x are incompatible with 0.3.x. Existing installs must re-authenticate: run `npm run setup-garmin`, or in the HA Add-on restart the add-on so it re-runs setup from your saved credentials. The setup script auto-cleans leftover `oauth*_token.json` files before writing the new format.
+
+## v1.8.0 {#v1-8-0}
 
 _2026-04-17_
 

--- a/docs/exporters.md
+++ b/docs/exporters.md
@@ -87,6 +87,10 @@ docker run --rm -it \
 Garmin may block requests from cloud/VPN IPs. If authentication fails, try from a different network, then copy the token directory to your target machine.
 :::
 
+::: warning Upgrading from v1.8.0 or earlier
+v1.8.1 bumps `garminconnect` to 0.3.x, which replaced the old garth-based OAuth files (`oauth1_token.json`, `oauth2_token.json`) with a single `garmin_tokens.json`. Existing tokens are incompatible. Re-run `npm run setup-garmin`; the script auto-removes the legacy files before writing the new format.
+:::
+
 ## MQTT {#mqtt}
 
 Publishes body composition as JSON to an MQTT broker. **Home Assistant auto-discovery** is enabled by default — all 10 metrics appear as sensors grouped under a single device, with availability tracking (LWT) and display precision per metric.

--- a/docs/guide/home-assistant-addon.md
+++ b/docs/guide/home-assistant-addon.md
@@ -129,9 +129,9 @@ To upload measurements to Garmin Connect:
 
 Home Assistant add-ons run without an interactive terminal, so the add-on cannot prompt for a 2FA code. If your account has MFA enabled:
 
-1. On a laptop or desktop, clone the repo and run `python3 garmin-scripts/setup_garmin.py`. Enter email, password, and MFA code when prompted. This writes `oauth1_token.json` and `oauth2_token.json` to `~/.garmin_tokens/`.
-2. Copy those two files to `/share/ble-scale-sync/garmin-tokens/` on the Home Assistant host. The Samba and File editor add-ons both expose `/share/` for easy uploads.
-3. Restart BLE Scale Sync. On startup the add-on detects the pre-generated tokens and imports them into `/data/garmin-tokens/`.
+1. On a laptop or desktop, clone the repo and run `python3 garmin-scripts/setup_garmin.py`. Enter email, password, and MFA code when prompted. This writes `garmin_tokens.json` to `~/.garmin_tokens/`.
+2. Copy that file to `/share/ble-scale-sync/garmin-tokens/` on the Home Assistant host. The Samba and File editor add-ons both expose `/share/` for easy uploads.
+3. Restart BLE Scale Sync. On startup the add-on detects the pre-generated token and imports it into `/data/garmin-tokens/`.
 
 The same workflow applies if Garmin is blocking your HA host's IP as a data-centre / VPN address: authenticate from a trusted network and import the tokens.
 
@@ -187,6 +187,10 @@ User-supplied files live under `/share/ble-scale-sync/`:
 ### Garmin "No such file or directory: oauth1_token.json"
 
 Fixed in v1.7.5. Make sure the add-on is on that version or newer. If it still fails, your account likely uses MFA — see [MFA workaround](#mfa-workaround).
+
+### Garmin "'Garmin' object has no attribute 'garth'"
+
+Fixed in v1.8.1. The `garminconnect` library released 0.3.0 on 2026-04-02 which removed the `garth` attribute. The add-on now uses the new native auth API and automatically strips incompatible legacy token files on startup, then re-authenticates from the credentials you entered. If you still see this error, upgrade to v1.8.1 or newer and restart the add-on. MFA users also need to regenerate the MFA token (single `garmin_tokens.json` file now, no more `oauth1/oauth2_token.json`).
 
 ### BlueZ discovery gets stuck after hours
 

--- a/garmin-scripts/garmin_upload.py
+++ b/garmin-scripts/garmin_upload.py
@@ -10,12 +10,6 @@ from garminconnect import Garmin
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 load_dotenv(PROJECT_ROOT / ".env")
 
-FAKE_USER_AGENT = (
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-    "AppleWebKit/537.36 (KHTML, like Gecko) "
-    "Chrome/121.0.0.0 Safari/537.36"
-)
-
 
 def log(msg):
     print(msg, file=sys.stderr)
@@ -34,6 +28,20 @@ def get_token_dir(token_dir=None):
     return str(new)
 
 
+def has_legacy_only_tokens(token_dir):
+    """True when directory contains pre-0.3 garth tokens but no new-format token.
+
+    Pre-0.3 garminconnect persisted oauth1_token.json + oauth2_token.json via garth.
+    garminconnect 0.3.x uses a different format (single garmin_tokens.json).
+    """
+    path = Path(token_dir)
+    if not path.is_dir():
+        return False
+    legacy = list(path.glob("oauth*_token.json"))
+    new_token = path / "garmin_tokens.json"
+    return bool(legacy) and not new_token.exists()
+
+
 def get_garmin_client(token_dir=None):
     token_dir = get_token_dir(token_dir)
     log(f"[Garmin] Loading tokens from {token_dir}")
@@ -44,9 +52,14 @@ def get_garmin_client(token_dir=None):
             "Run 'npm run setup-garmin' first."
         )
 
+    if has_legacy_only_tokens(token_dir):
+        raise RuntimeError(
+            "Token format changed in garminconnect 0.3.x. "
+            "Run 'npm run setup-garmin' to re-authenticate."
+        )
+
     garmin = Garmin()
-    garmin.garth.sess.headers.update({"User-Agent": FAKE_USER_AGENT})
-    garmin.login(tokenstore=token_dir)
+    garmin.login(token_dir)
     log("[Garmin] Authenticated.")
     return garmin
 

--- a/garmin-scripts/setup_garmin.py
+++ b/garmin-scripts/setup_garmin.py
@@ -10,12 +10,6 @@ from garminconnect import Garmin
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 load_dotenv(PROJECT_ROOT / ".env")
 
-FAKE_USER_AGENT = (
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-    "AppleWebKit/537.36 (KHTML, like Gecko) "
-    "Chrome/121.0.0.0 Safari/537.36"
-)
-
 
 def get_token_dir(token_dir=None):
     if token_dir:
@@ -28,6 +22,29 @@ def get_token_dir(token_dir=None):
     if old.is_dir() and not new.is_dir():
         return str(old)
     return str(new)
+
+
+def cleanup_legacy_tokens(token_dir):
+    """Remove pre-0.3 garth token files (oauth1_token.json, oauth2_token.json).
+
+    garminconnect 0.3.x replaced garth with native auth and the old token
+    format is incompatible. Leaving legacy files around is harmless but
+    confusing, so wipe them on fresh auth.
+    """
+    path = Path(token_dir)
+    if not path.is_dir():
+        return
+    legacy = list(path.glob("oauth*_token.json"))
+    if legacy:
+        print(
+            "[Setup] Removing legacy token files from pre-0.3 garminconnect: "
+            f"{[f.name for f in legacy]}"
+        )
+        for f in legacy:
+            try:
+                f.unlink()
+            except OSError as e:
+                print(f"[Setup] Warning: failed to remove {f.name}: {e}")
 
 
 def resolve_env_ref(value):
@@ -54,11 +71,15 @@ def authenticate(email, password, token_dir):
     print(f"[Setup] Authenticating as {email}...")
 
     try:
+        os.makedirs(token_dir, exist_ok=True)
+        cleanup_legacy_tokens(token_dir)
+
         garmin = Garmin(email, password, return_on_mfa=True)
-        garmin.garth.sess.headers.update({"User-Agent": FAKE_USER_AGENT})
 
         print("[Setup] Logging in...")
-        result = garmin.login()
+        # In 0.3.x, login(tokenstore) auto-dumps tokens on successful
+        # credential login (swallows dump errors silently via contextlib).
+        result = garmin.login(token_dir)
 
         # Handle 2FA/MFA challenge
         if isinstance(result, tuple) and result[0] == "needs_mfa":
@@ -66,9 +87,12 @@ def authenticate(email, password, token_dir):
             mfa_code = input("[Setup] Enter the MFA code from your authenticator app: ").strip()
             garmin.resume_login(result[1], mfa_code)
             print("[Setup] MFA verification successful.")
-
-        os.makedirs(token_dir, exist_ok=True)
-        garmin.garth.dump(token_dir)
+            # resume_login() does NOT auto-save; dump explicitly.
+            garmin.client.dump(token_dir)
+        else:
+            # Belt-and-suspenders: login()'s auto-dump suppresses exceptions,
+            # so re-dump to surface any write errors here.
+            garmin.client.dump(token_dir)
 
         print(f"[Setup] Tokens saved to: {token_dir}")
         return True

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ble-scale-sync",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ble-scale-sync",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@abandonware/noble": "^1.9.2-26",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ble-scale-sync",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Universal BLE Smart Scale bridge. Captures body composition from Renpho, Xiaomi & 20+ others, syncs to Garmin Connect, Strava, MQTT (Home Assistant), InfluxDB, Webhooks, Ntfy & local files. Headless CLI for Raspberry Pi, Linux, macOS & Windows.",
   "type": "module",
   "main": "src/index.ts",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-garminconnect>=0.2.25
+garminconnect>=0.3.2
 python-dotenv>=1.0.0
 pyyaml>=6.0


### PR DESCRIPTION
## Summary

Patch release v1.8.1. Fixes the Garmin upload regression introduced by `garminconnect` 0.3.0 (2026-04-02), which dropped the `garth` dependency and broke our Python bridge with `'Garmin' object has no attribute 'garth'`.

- Migrated `garmin_upload.py` and `setup_garmin.py` to the new native auth API
- `login(tokenstore)` auto-persists on credential success; `client.dump()` explicit after `resume_login()` for MFA
- Auto-cleanup of legacy `oauth*_token.json` files; single `garmin_tokens.json` from 0.3.x
- Docker: `libcurl4-openssl-dev` added so `curl_cffi` builds from source on armv7
- HA Add-on `run.sh` switched to new single-file token import path
- Docs updated (CHANGELOG, exporters.md, home-assistant-addon.md, DOCS.md)

## Test plan

- [x] `npm test` (1151/1151 passing)
- [x] `npm run lint`, `npx tsc --noEmit`, `npm run format -- --check` clean
- [x] CI green on `dev`
- [ ] Manual end-to-end on RPi after release (setup_garmin + upload)

## Breaking change

Existing installs must re-authenticate once. The setup script auto-removes the old token files before writing the new format, so for non-MFA users it's transparent; MFA users regenerate the single-file token and copy it to `/share/ble-scale-sync/garmin-tokens/`.

Closes #114
