### PR TITLE
fix(beurer-sanitas): parse SBF70 compact 0x58 frame (#112)

### DIFF
--- a/src/scales/beurer-sanitas.ts
+++ b/src/scales/beurer-sanitas.ts
@@ -40,14 +40,21 @@ interface CachedComp {
  *
  * Protocol ported from openScale's BeurerSanitasHandler:
  *   - Service 0xFFE0, characteristic 0xFFE1 (notify + write)
- *   - Weight at bytes [4-5] big-endian * 50 / 1000 (50g resolution)
- *   - Impedance at bytes [6-7] big-endian
- *   - Fat/water/muscle/bone in follow-up composition frame
+ *   - BF700/800 (start byte 0xF7): weight at bytes [4-5] BE, 16-byte composition frame
+ *   - BF710/SBF70/SBF75 (start byte 0xE7): weight at bytes [3-4] BE in compact 5-byte 0x58 frames
+ *   - Weight is big-endian * 50 / 1000 (50g resolution) in both variants
  *
  * The protocol uses a multi-step handshake (INIT, SET_TIME, SCALE_STATUS)
  * with alternating start bytes depending on device variant.
  * We simplify to a periodic INIT command as the unlock.
+ *
+ * For the BF710/SBF70 variant we apply a stability window (last N weights within
+ * tolerance) to ignore the initial metadata frame the scale sends before the
+ * user has stepped on.
  */
+const BF710_STABILITY_COUNT = 3;
+const BF710_STABILITY_TOLERANCE_KG = 0.3;
+
 export class BeurerSanitasScaleAdapter implements ScaleAdapter {
   readonly name = 'Beurer / Sanitas';
   readonly charNotifyUuid = CHR_FFE1;
@@ -56,8 +63,9 @@ export class BeurerSanitasScaleAdapter implements ScaleAdapter {
   readonly unlockIntervalMs = 5000;
 
   private isBf710Type = false;
+  private readingBuffer: number[] = [];
 
-  /** INIT command — F7 01 for BF700/800, E7 01 for BF710/Sanitas. */
+  /** INIT command: F7 01 for BF700/800, E7 01 for BF710/Sanitas. */
   get unlockCommand(): number[] {
     return this.isBf710Type ? [0xe7, 0x01] : [0xf7, 0x01];
   }
@@ -76,11 +84,11 @@ export class BeurerSanitasScaleAdapter implements ScaleAdapter {
   /**
    * Parse a Beurer/Sanitas notification frame.
    *
-   * Weight-only frame (command 0x58):
+   * BF700/BF800 weight-only frame (command 0x58):
    *   [0-3]   timestamp (BE uint32, Unix seconds)
    *   [4-5]   weight (BE uint16, * 50 / 1000 for kg)
    *
-   * Full composition frame (command 0x59, two parts merged):
+   * BF700/BF800 full composition frame (command 0x59, two parts merged):
    *   [0-3]   timestamp
    *   [4-5]   weight (BE uint16, * 50 / 1000)
    *   [6-7]   impedance (BE uint16)
@@ -88,8 +96,23 @@ export class BeurerSanitasScaleAdapter implements ScaleAdapter {
    *   [10-11] water (BE uint16, / 10)
    *   [12-13] muscle (BE uint16, / 10)
    *   [14-15] bone (BE uint16, * 50 / 1000)
+   *
+   * BF710/SBF70/SBF75 compact weight frame (5 bytes, command 0x58):
+   *   [0]     start byte 0xE7
+   *   [1]     cmd 0x58
+   *   [2]     flag (0x01 = user on scale, 0x00 = off)
+   *   [3-4]   weight (BE uint16, * 50 / 1000)
+   *
+   * BF710/SBF70/SBF75 finalize frame (command 0x59) carries composition only
+   * when the user is registered on the device via the manufacturer app.
+   * For unregistered users all composition bytes are zero, so we ignore it
+   * and rely on the stability window over 0x58 frames.
    */
   parseNotification(data: Buffer): ScaleReading | null {
+    if (this.isBf710Type) {
+      return this.parseBf710Notification(data);
+    }
+
     if (data.length < 6) return null;
 
     const weight = (data.readUInt16BE(4) * 50) / 1000;
@@ -112,7 +135,33 @@ export class BeurerSanitasScaleAdapter implements ScaleAdapter {
     return { weight, impedance };
   }
 
+  private parseBf710Notification(data: Buffer): ScaleReading | null {
+    if (data.length < 2 || data[0] !== 0xe7) return null;
+
+    const cmd = data[1];
+
+    if (cmd === 0x58 && data.length >= 5) {
+      const weight = (data.readUInt16BE(3) * 50) / 1000;
+      if (weight <= 0 || weight > 300 || !Number.isFinite(weight)) return null;
+
+      this.readingBuffer.push(weight);
+      if (this.readingBuffer.length > BF710_STABILITY_COUNT) {
+        this.readingBuffer.shift();
+      }
+      this.cachedComp = null;
+      return { weight, impedance: 0 };
+    }
+
+    return null;
+  }
+
   isComplete(reading: ScaleReading): boolean {
+    if (this.isBf710Type) {
+      if (this.readingBuffer.length < BF710_STABILITY_COUNT) return false;
+      const min = Math.min(...this.readingBuffer);
+      const max = Math.max(...this.readingBuffer);
+      return max - min <= BF710_STABILITY_TOLERANCE_KG && reading.weight > 0;
+    }
     return reading.weight > 0;
   }
 

--- a/tests/scales/beurer-sanitas.test.ts
+++ b/tests/scales/beurer-sanitas.test.ts
@@ -129,6 +129,77 @@ describe('BeurerSanitasScaleAdapter', () => {
     });
   });
 
+  describe('SBF70 / BF710 variant (issue #112)', () => {
+    function sbf70Adapter() {
+      const adapter = makeAdapter();
+      adapter.matches(mockPeripheral('SANITAS SBF70'));
+      return adapter;
+    }
+
+    it('parses 5-byte 0x58 frame with weight at bytes [3-4] BE', () => {
+      const adapter = sbf70Adapter();
+      // Real captured frame from issue #112: [E7 58 01 08 5E]
+      const frame = Buffer.from([0xe7, 0x58, 0x01, 0x08, 0x5e]);
+      const reading = adapter.parseNotification(frame);
+      expect(reading).not.toBeNull();
+      // 0x085E = 2142 * 50/1000 = 107.1 kg
+      expect(reading!.weight).toBeCloseTo(107.1, 2);
+      expect(reading!.impedance).toBe(0);
+    });
+
+    it('ignores frames that do not start with 0xE7', () => {
+      const adapter = sbf70Adapter();
+      const frame = Buffer.from([0xf7, 0x58, 0x01, 0x08, 0x5e]);
+      expect(adapter.parseNotification(frame)).toBeNull();
+    });
+
+    it('ignores 0x59 finalize frame for unregistered user (all composition zero)', () => {
+      const adapter = sbf70Adapter();
+      // Real captured frame from issue #112
+      const frame = Buffer.from([
+        0xe7, 0x59, 0x03, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x65,
+      ]);
+      expect(adapter.parseNotification(frame)).toBeNull();
+    });
+
+    it('requires 3 consecutive readings within 0.3 kg for completion', () => {
+      const adapter = sbf70Adapter();
+      // First bogus frame from issue #112 capture
+      const f0 = Buffer.from([0xe7, 0x58, 0x01, 0x01, 0x2b]); // 14.95 kg
+      const f1 = Buffer.from([0xe7, 0x58, 0x01, 0x08, 0x5e]); // 107.1 kg
+      const f2 = Buffer.from([0xe7, 0x58, 0x01, 0x08, 0x5f]); // 107.15 kg
+      const f3 = Buffer.from([0xe7, 0x58, 0x01, 0x08, 0x5e]); // 107.1 kg
+
+      const r0 = adapter.parseNotification(f0);
+      expect(r0).not.toBeNull();
+      expect(adapter.isComplete(r0!)).toBe(false); // only 1 reading buffered
+
+      const r1 = adapter.parseNotification(f1);
+      expect(adapter.isComplete(r1!)).toBe(false); // still drifting (14.95 vs 107.1)
+
+      const r2 = adapter.parseNotification(f2);
+      expect(adapter.isComplete(r2!)).toBe(false); // drift not yet cleared from buffer
+
+      const r3 = adapter.parseNotification(f3);
+      // Buffer now holds [107.1, 107.15, 107.1]: range 0.05 kg <= 0.3 kg
+      expect(adapter.isComplete(r3!)).toBe(true);
+      expect(r3!.weight).toBeCloseTo(107.1, 2);
+    });
+
+    it('rejects out-of-range weight in SBF70 frame', () => {
+      const adapter = sbf70Adapter();
+      // 0xFFFF * 50 / 1000 = 3276.75 kg -> too high
+      const frame = Buffer.from([0xe7, 0x58, 0x01, 0xff, 0xff]);
+      expect(adapter.parseNotification(frame)).toBeNull();
+    });
+
+    it('rejects zero weight in SBF70 frame', () => {
+      const adapter = sbf70Adapter();
+      const frame = Buffer.from([0xe7, 0x58, 0x00, 0x00, 0x00]);
+      expect(adapter.parseNotification(frame)).toBeNull();
+    });
+  });
+
   describe('computeMetrics()', () => {
     it('returns payload with cached body comp from full frame', () => {
       const adapter = makeAdapter();


### PR DESCRIPTION
Closes #112.

## Summary

- Parse the SBF70/BF710-family compact 5-byte `0x58` frame with weight at bytes `[3-4]` BE * 50/1000
- Apply a 3-reading stability window (0.3 kg tolerance) so the scale's initial metadata frame does not complete the measurement early
- Ignore the `0x59` finalize frame when composition bytes are zero (happens for users not registered on the device)

## Root cause

The BF710/SBF70/SBF75 variant (start byte `0xE7`) sends a compact 5-byte weight frame. The adapter rejected every live weight frame as too short (`< 6 bytes`) and then mis-parsed the `0x59` finalize frame at the BF700/BF800 offset, yielding the stuck `12.80 kg` reported by @flow778 regardless of the real weight on the scale.

Raw frames captured in issue #112 confirmed the layout:

```
[E7 58 01 08 5E]   stable weight
 |  |  |  |____|
 |  |  |  weight BE at [3-4]: 0x085E = 2142 * 50/1000 = 107.1 kg
 |  |  on-scale flag
 |  cmd
 start byte (BF710 family)
```

## Test plan

- [x] `npm test` - 1157 tests pass (60 files)
- [x] `npm run lint` - clean
- [x] `npx tsc --noEmit` - clean
- [x] Debug image `ghcr.io/kristianp26/ble-scale-sync:issue-112-fix` built and confirmed by @flow778 on real SBF70 hardware
- [x] CI passes on this PR

## Notes

The scale also emits a `0x59` finalize frame with body composition, but only when the user is registered in the device's user slot via the Beurer/Sanitas app. For unregistered users all composition bytes are zero, so we rely on the BIA calculation from weight and impedance. Registering the user slot is documented elsewhere and is consistent with how other Beurer/Sanitas scales behave.
