### PR TITLE
Release v1.9.0: Eufy P2 Pro adapter + wizard UX fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-04-21
+
 ### Added
 - **Eufy Smart Scale P2 (T9148) and P2 Pro (T9149)**: new dedicated adapter with the AES-128-CBC C0/C1/C2/C3 handshake required by these models. Weight + impedance over GATT FFF2 after authentication, passive weight reading from the 19-byte advertisement without connecting. Prevents the prior false match as a QN scale that crashed with `Operation is not supported` on FFF1 ([#98](https://github.com/KristianP26/ble-scale-sync/issues/98))
+
+### Fixed
+- **Setup wizard**: picking no exporter in the export-targets checkbox silently produced a config without any `global_exporters` block, so the first run emitted `All exports failed` and exited with code 1. The wizard now asks an explicit `Continue without exporters?` confirmation when the checkbox is submitted empty and re-prompts if the user declines ([#98](https://github.com/KristianP26/ble-scale-sync/issues/98))
+- **Orchestrator**: `dispatchExports([])` logged `All exports failed` because `allFailed` defaulted to `true` with zero iterations. Empty exporter lists now short-circuit with a clear warning (`No exporters configured — measurement processed but not sent anywhere`) and return `success`, so single-shot mode no longer exits with code 1 when the config has no exporters
 
 ### Thanks
 - [@mart1058](https://github.com/mart1058) and [@dbrb2](https://github.com/dbrb2) for diagnose output, HCI snoop logs, and testing the Eufy P2 Pro protocol reverse-engineering ([#98](https://github.com/KristianP26/ble-scale-sync/issues/98))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Eufy Smart Scale P2 (T9148) and P2 Pro (T9149)**: new dedicated adapter with the AES-128-CBC C0/C1/C2/C3 handshake required by these models. Weight + impedance over GATT FFF2 after authentication, passive weight reading from the 19-byte advertisement without connecting. Prevents the prior false match as a QN scale that crashed with `Operation is not supported` on FFF1 ([#98](https://github.com/KristianP26/ble-scale-sync/issues/98))
 - **HA Add-on**: `weight_unit` and `height_unit` are now exposed as add-on options (kg/lbs, cm/in). Previously hardcoded to metric regardless of user preference
 - **HA Add-on**: `last_known_weight` now persists across add-on restarts. The runtime config lives at `/data/config.yaml` and `merge_last_weights.py` copies preserved per-user weights from the previous run into the freshly generated config on every startup
 - **Docs**: new [Home Assistant Add-on guide](https://blescalesync.dev/guide/home-assistant-addon) covering install, configuration reference, MQTT auto-detection, Garmin setup including the MFA workaround, custom config mode, persistence, and troubleshooting. Linked from Getting Started and the MQTT exporter reference
+
+### Thanks
+- [@mart1058](https://github.com/mart1058) and [@dbrb2](https://github.com/dbrb2) for diagnose output, HCI snoop logs, and testing the Eufy P2 Pro protocol reverse-engineering ([#98](https://github.com/KristianP26/ble-scale-sync/issues/98))
+- [bdr99/eufylife-ble-client](https://github.com/bdr99/eufylife-ble-client) for the reference Python implementation of the Eufy T9148/T9149 auth handshake and frame formats
 
 ## [1.7.5] - 2026-04-15
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Unit tests use [Vitest](https://vitest.dev/) and cover:
 - **Config writing** — atomic file write, write lock serialization, YAML comment preservation, debounced weight updates
 - **User matching** — 4-tier weight matching, all strategies (nearest/log/ignore), overlapping ranges, drift detection
 - **Environment validation** — `validate-env.ts` (all validation rules and edge cases)
-- **Scale adapters** — `parseNotification()`, `matches()`, `isComplete()`, `computeMetrics()`, and `onConnected()` for all 23 adapters
+- **Scale adapters** — `parseNotification()`, `matches()`, `isComplete()`, `computeMetrics()`, and `onConnected()` for all 24 adapters
 - **Exporters** — config parsing, MQTT publish/HA discovery, MQTT multi-user topic routing + per-user HA discovery, Garmin subprocess, Webhook/InfluxDB/Ntfy delivery, ExportContext, ntfy drift warning
 - **Multi-user flow** — matching → profile resolution → exporter resolution → ExportContext construction, strategy fallback, tiebreak with last_known_weight
 - **Orchestrator** — healthcheck runner, export dispatch, parallel execution, partial/total failure handling

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![Node.js](https://img.shields.io/badge/node-%3E%3D20.19-brightgreen?logo=node.js&logoColor=white)
 ![Docker](https://img.shields.io/badge/docker-ghcr.io-blue?logo=docker&logoColor=white)
 
-A cross-platform CLI tool that reads body composition data from **23 BLE smart scales** and exports to **Garmin Connect**, **Strava**, **MQTT** (Home Assistant), **InfluxDB**, **Webhooks**, **Ntfy**, and **local files** (CSV/JSONL). No phone app needed. Your data stays on your device.
+A cross-platform CLI tool that reads body composition data from **24 BLE smart scales** and exports to **Garmin Connect**, **Strava**, **MQTT** (Home Assistant), **InfluxDB**, **Webhooks**, **Ntfy**, and **local files** (CSV/JSONL). No phone app needed. Your data stays on your device.
 
 **[Documentation](https://blescalesync.dev)** · **[Getting Started](https://blescalesync.dev/guide/getting-started)** · **[Supported Scales](https://blescalesync.dev/guide/supported-scales)** · **[Exporters](https://blescalesync.dev/exporters)**
 
@@ -63,7 +63,7 @@ Requires Node.js v20.19+ and a BLE adapter. See the **[full install guide](https
 
 ## Features
 
-- **[23 scale brands](https://blescalesync.dev/guide/supported-scales)** — Xiaomi, Renpho (Elis 1), Eufy, Yunmai, Beurer, Sanitas, Medisana, and more
+- **[24 scale brands](https://blescalesync.dev/guide/supported-scales)** — Xiaomi, Renpho (Elis 1), Eufy (incl. P2 Pro T9149), Yunmai, Beurer, Sanitas, Medisana, and more
 - **[7 export targets](https://blescalesync.dev/exporters)** — Garmin Connect, Strava, MQTT (Home Assistant), InfluxDB, Webhook, Ntfy, File (CSV/JSONL)
 - **[10 body metrics](https://blescalesync.dev/body-composition)** — BIA-based body composition from weight + impedance
 - **[Multi-user](https://blescalesync.dev/multi-user)** — automatic weight-based identification with per-user exporters

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Requires Node.js v20.19+ and a BLE adapter. See the **[full install guide](https
 
 ## Credits
 
-- **Scale protocols** - ported from [openScale](https://github.com/oliexdev/openScale) by oliexdev and contributors
+- **Scale protocols** - many adapters ported from [openScale](https://github.com/oliexdev/openScale) (oliexdev and contributors); Eufy P2 / P2 Pro ported from [bdr99/eufylife-ble-client](https://github.com/bdr99/eufylife-ble-client); QN-Scale / FITINDEX and a few others reverse-engineered in this project
 - **Garmin upload** - powered by [garminconnect](https://github.com/cyberjunky/python-garminconnect) by cyberjunky
 - **BLE** - [node-ble](https://github.com/chrvadala/node-ble) (Linux), [@abandonware/noble](https://github.com/abandonware/noble) (Windows), [@stoprocent/noble](https://github.com/stoprocent/noble) (macOS)
 - **ESP32 proxy** - [mqtt_as](https://github.com/peterhinch/micropython-mqtt) by peterhinch, [aioble](https://github.com/micropython/micropython-lib/tree/master/micropython/bluetooth/aioble)

--- a/ble-scale-sync-addon/config.yaml
+++ b/ble-scale-sync-addon/config.yaml
@@ -1,5 +1,5 @@
 name: BLE Scale Sync
-version: "1.8.2"
+version: "1.9.0"
 slug: ble-scale-sync
 description: Read BLE smart scales and export to Garmin Connect, MQTT (HA auto-discovery), InfluxDB, and more
 url: https://github.com/KristianP26/ble-scale-sync

--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -25,7 +25,7 @@ head:
 | **Push notifications** | Ntfy | No | No | App only |
 | **Local file export** | CSV and JSONL | SQLite | No | No |
 | **Multi-user** | Automatic weight matching | Manual selection | Per-user sync | Per-account |
-| **Supported scales** | 23 protocol adapters | 20+ brands | Via openScale | 1 (own brand) |
+| **Supported scales** | 24 protocol adapters | 20+ brands | Via openScale | 1 (own brand) |
 | **Body composition** | 10 metrics (BIA) | Varies | 4 metrics | Varies |
 | **Docker** | Multi-arch images | No | No | No |
 | **Open source** | GPL-3.0 | GPL-3.0 | GPL-3.0 | No |

--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -50,7 +50,7 @@ head:
 - Users who want a local-first scale tracker on their phone
 
 ::: info
-BLE Scale Sync's scale protocols were ported from openScale. Both projects benefit from the same reverse-engineering work by the open-source community.
+Many of BLE Scale Sync's scale adapters were ported from openScale. Others (QN-Scale / FITINDEX, Eufy P2 / P2 Pro, and a few more) were reverse-engineered in this project or ported from dedicated upstream references (e.g. [bdr99/eufylife-ble-client](https://github.com/bdr99/eufylife-ble-client) for the Eufy P2/P2 Pro AES handshake). Both projects benefit from the broader reverse-engineering work by the open-source community.
 :::
 
 ## openScale-sync

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,14 +9,22 @@ All notable changes to this project are documented here. Format based on [Keep a
 
 ## Unreleased {#unreleased}
 
+## v1.9.0 <Badge type="tip" text="latest" /> {#v1-9-0}
+
+_2026-04-21_
+
 ### Added
 - **Eufy Smart Scale P2 (T9148) and P2 Pro (T9149)**: new dedicated adapter with the AES-128-CBC C0/C1/C2/C3 handshake these models require. Weight + impedance over GATT FFF2 after auth, plus passive weight reading from the 19-byte advertisement without connecting. The scale is no longer mis-matched as a QN scale (prior crash: `Operation is not supported`) ([#98](https://github.com/KristianP26/ble-scale-sync/issues/98))
+
+### Fixed
+- **Setup wizard**: picking no exporter in the export-targets checkbox silently produced a config without any `global_exporters` block, so the first run emitted `All exports failed` and exited. The wizard now asks an explicit `Continue without exporters?` confirmation when the checkbox is submitted empty and re-prompts if the user declines ([#98](https://github.com/KristianP26/ble-scale-sync/issues/98))
+- **Orchestrator**: empty exporter lists no longer trigger a misleading `All exports failed` message. A clear warning is logged and the cycle returns success so single-shot mode does not exit with code 1 when the config has no exporters
 
 ### Thanks
 - [@mart1058](https://github.com/mart1058) and [@dbrb2](https://github.com/dbrb2) for diagnose output, HCI snoop logs, and testing the Eufy P2 Pro protocol reverse-engineering ([#98](https://github.com/KristianP26/ble-scale-sync/issues/98))
 - [bdr99/eufylife-ble-client](https://github.com/bdr99/eufylife-ble-client) for the reference Python implementation of the Eufy T9148/T9149 auth handshake and frame formats
 
-## v1.8.2 <Badge type="tip" text="latest" /> {#v1-8-2}
+## v1.8.2 {#v1-8-2}
 
 _2026-04-20_
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,9 +10,14 @@ All notable changes to this project are documented here. Format based on [Keep a
 ## Unreleased {#unreleased}
 
 ### Added
+- **Eufy Smart Scale P2 (T9148) and P2 Pro (T9149)**: new dedicated adapter with the AES-128-CBC C0/C1/C2/C3 handshake these models require. Weight + impedance over GATT FFF2 after auth, plus passive weight reading from the 19-byte advertisement without connecting. The scale is no longer mis-matched as a QN scale (prior crash: `Operation is not supported`) ([#98](https://github.com/KristianP26/ble-scale-sync/issues/98))
 - **HA Add-on**: `weight_unit` and `height_unit` exposed as add-on options (kg/lbs, cm/in), no longer hardcoded
 - **HA Add-on**: `last_known_weight` persists across restarts. Runtime config lives at `/data/config.yaml`; a small Python helper merges preserved per-user weights into the freshly generated config on every startup
 - **Docs**: new [Home Assistant Add-on guide](/guide/home-assistant-addon) with install, configuration reference, MQTT auto-detection, Garmin setup, MFA workaround, custom config mode, and troubleshooting
+
+### Thanks
+- [@mart1058](https://github.com/mart1058) and [@dbrb2](https://github.com/dbrb2) for diagnose output, HCI snoop logs, and testing the Eufy P2 Pro protocol reverse-engineering ([#98](https://github.com/KristianP26/ble-scale-sync/issues/98))
+- [bdr99/eufylife-ble-client](https://github.com/bdr99/eufylife-ble-client) for the reference Python implementation of the Eufy T9148/T9149 auth handshake and frame formats
 
 ## v1.7.5 <Badge type="tip" text="latest" /> {#v1-7-5}
 

--- a/docs/guide/supported-scales.md
+++ b/docs/guide/supported-scales.md
@@ -1,6 +1,6 @@
 ---
 title: Supported Scales
-description: All 23 BLE smart scale brands supported by BLE Scale Sync.
+description: All 24 BLE smart scale brands supported by BLE Scale Sync.
 head:
   - - meta
     - name: keywords
@@ -9,7 +9,7 @@ head:
 
 # Supported Scales
 
-BLE Scale Sync supports **23 scale brands** out of the box. All scales provide weight + impedance for full [body composition](/body-composition) calculation.
+BLE Scale Sync supports **24 scale brands** out of the box. All scales provide weight + impedance for full [body composition](/body-composition) calculation.
 
 ## Scale List
 
@@ -20,6 +20,7 @@ BLE Scale Sync supports **23 scale brands** out of the box. All scales provide w
 | **Renpho** ES-WBE28 | Standard GATT variant |
 | **Renpho** ES-26BB-B | |
 | **1byone** / **Eufy** C1 / P1 | |
+| **Eufy** Smart Scale P2 (T9148) / P2 Pro (T9149) | AES handshake over FFF1/FFF4, impedance via FFF2 |
 | **Yunmai** Signal / Mini / SE | Uses scale's own body comp values |
 | **Beurer** BF700 / BF710 / BF800 | |
 | **Sanitas** SBF70 / SBF75 | Same protocol as Beurer |

--- a/docs/public/logo.svg
+++ b/docs/public/logo.svg
@@ -3,7 +3,7 @@
   <rect x="14" y="14" width="100" height="100" rx="18" fill="#1e293b"/>
   <!-- Display -->
   <rect x="30" y="34" width="68" height="28" rx="4" fill="#0c4a6e"/>
-  <text x="64" y="54" text-anchor="middle" font-family="monospace" font-size="18" font-weight="700" fill="#38bdf8">23.7</text>
+  <text x="64" y="54" text-anchor="middle" font-family="monospace" font-size="18" font-weight="700" fill="#38bdf8">24.7</text>
   <!-- Bluetooth rune (bold, simplified) -->
   <g transform="translate(64, 84)" stroke="#38bdf8" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" fill="none">
     <line x1="0" y1="-9" x2="0" y2="9"/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ble-scale-sync",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ble-scale-sync",
-      "version": "1.8.2",
+      "version": "1.9.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@abandonware/noble": "^1.9.2-26",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ble-scale-sync",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "description": "Universal BLE Smart Scale bridge. Captures body composition from Renpho, Xiaomi & 20+ others, syncs to Garmin Connect, Strava, MQTT (Home Assistant), InfluxDB, Webhooks, Ntfy & local files. Headless CLI for Raspberry Pi, Linux, macOS & Windows.",
   "type": "module",
   "main": "src/index.ts",

--- a/src/ble/handler-mqtt-proxy.ts
+++ b/src/ble/handler-mqtt-proxy.ts
@@ -486,6 +486,7 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
           device,
           adapter,
           opts.profile,
+          entry.address.replace(/[:-]/g, '').toUpperCase(),
           opts.weightUnit,
           opts.onLiveData,
         );
@@ -732,7 +733,13 @@ export class ReadingWatcher {
     );
     try {
       const raw = await withTimeout(
-        waitForRawReading(charMap, device, adapter, profile),
+        waitForRawReading(
+          charMap,
+          device,
+          adapter,
+          profile,
+          entry.address.replace(/[:-]/g, '').toUpperCase(),
+        ),
         60_000,
         `GATT reading timeout for ${entry.address}`,
       );

--- a/src/ble/handler-noble-legacy.ts
+++ b/src/ble/handler-noble-legacy.ts
@@ -467,6 +467,7 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
         profile,
         weightUnit,
         onLiveData,
+        peripheralAddress(peripheral).replace(/[:-]/g, '').toUpperCase(),
       );
 
       return raw;

--- a/src/ble/handler-noble-legacy.ts
+++ b/src/ble/handler-noble-legacy.ts
@@ -465,9 +465,9 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
         wrapPeripheral(peripheral),
         matchedAdapter,
         profile,
+        peripheralAddress(peripheral).replace(/[:-]/g, '').toUpperCase(),
         weightUnit,
         onLiveData,
-        peripheralAddress(peripheral).replace(/[:-]/g, '').toUpperCase(),
       );
 
       return raw;

--- a/src/ble/handler-noble.ts
+++ b/src/ble/handler-noble.ts
@@ -465,6 +465,7 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
         wrapPeripheral(peripheral),
         matchedAdapter,
         profile,
+        peripheralAddress(peripheral).replace(/[:-]/g, '').toUpperCase(),
         weightUnit,
         onLiveData,
       );

--- a/src/ble/handler-node-ble.ts
+++ b/src/ble/handler-node-ble.ts
@@ -435,6 +435,7 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
     if (discoveryResult) btAdapter = discoveryResult;
 
     let matchedAdapter: ScaleAdapter;
+    let deviceMac = targetMac ?? '';
 
     if (targetMac) {
       const mac = formatMac(targetMac);
@@ -515,6 +516,7 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
       const result = await autoDiscover(btAdapter, adapters, abortSignal);
       device = result.device;
       matchedAdapter = result.adapter;
+      deviceMac = result.mac;
 
       // Stop discovery before connecting — BlueZ on low-power devices (e.g. Pi Zero)
       // often fails with le-connection-abort-by-local while discovery is still active.
@@ -545,6 +547,7 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
       profile,
       weightUnit,
       onLiveData,
+      deviceMac.replace(/[:-]/g, '').toUpperCase(),
     );
 
     try {

--- a/src/ble/handler-node-ble.ts
+++ b/src/ble/handler-node-ble.ts
@@ -572,9 +572,9 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
       wrapDevice(device),
       matchedAdapter,
       profile,
+      deviceMac.replace(/[:-]/g, '').toUpperCase(),
       weightUnit,
       onLiveData,
-      deviceMac.replace(/[:-]/g, '').toUpperCase(),
     );
 
     try {

--- a/src/ble/handler-node-ble.ts
+++ b/src/ble/handler-node-ble.ts
@@ -2,7 +2,7 @@ import NodeBle from 'node-ble';
 import type { ScaleAdapter, BleDeviceInfo, BodyComposition } from '../interfaces/scale-adapter.js';
 import type { ScanOptions, ScanResult } from './types.js';
 import type { BleChar, BleDevice, RawReading } from './shared.js';
-import { waitForRawReading } from './shared.js';
+import { waitForRawReading, findMissingCharacteristics } from './shared.js';
 import {
   bleLog,
   normalizeUuid,
@@ -17,6 +17,8 @@ import {
   DISCOVERY_POLL_MS,
   POST_DISCOVERY_QUIESCE_MS,
   GATT_DISCOVERY_TIMEOUT_MS,
+  CHAR_DISCOVERY_MAX_RETRIES,
+  CHAR_DISCOVERY_RETRY_DELAY_MS,
 } from './types.js';
 
 type Device = NodeBle.Device;
@@ -533,13 +535,38 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
       bleLog.info('Connected. Discovering services...');
     }
 
-    // Setup GATT characteristics and wait for a complete reading
+    // Setup GATT characteristics and wait for a complete reading.
+    // BlueZ has a known race ([bluez/bluez#1489]) where ServicesResolved=true
+    // fires before all characteristic interfaces are exported over D-Bus, so
+    // the first enumeration can be missing chars the scale actually exposes.
+    // Retry the enumeration a few times with a short backoff when we detect
+    // that the adapter's required chars are not yet present.
     const gatt = await device.gatt();
-    const charMap = await withTimeout(
+    let charMap = await withTimeout(
       buildCharMap(gatt),
       GATT_DISCOVERY_TIMEOUT_MS,
       'GATT service discovery timed out',
     );
+    for (let attempt = 1; attempt <= CHAR_DISCOVERY_MAX_RETRIES; attempt++) {
+      const missing = findMissingCharacteristics(charMap, matchedAdapter);
+      if (missing.length === 0) break;
+      if (attempt === CHAR_DISCOVERY_MAX_RETRIES) {
+        bleLog.warn(
+          `GATT enumeration incomplete after ${attempt} attempt(s). ` +
+            `Missing: [${missing.join(', ')}]. Discovered: [${[...charMap.keys()].join(', ')}]`,
+        );
+        break;
+      }
+      bleLog.debug(
+        `GATT enumeration missing [${missing.join(', ')}], retry ${attempt}/${CHAR_DISCOVERY_MAX_RETRIES - 1} in ${CHAR_DISCOVERY_RETRY_DELAY_MS}ms...`,
+      );
+      await new Promise<void>((r) => setTimeout(r, CHAR_DISCOVERY_RETRY_DELAY_MS));
+      charMap = await withTimeout(
+        buildCharMap(gatt),
+        GATT_DISCOVERY_TIMEOUT_MS,
+        'GATT service discovery timed out',
+      );
+    }
     const raw = await waitForRawReading(
       charMap,
       wrapDevice(device),

--- a/src/ble/shared.ts
+++ b/src/ble/shared.ts
@@ -45,6 +45,7 @@ function initializeAdapter(
   charMap: Map<string, BleChar>,
   adapter: ScaleAdapter,
   profile: UserProfile,
+  deviceAddress: string,
   isResolved: () => boolean,
   onNotification: (sourceUuid: string, data: Buffer) => void,
   unsubscribers: (() => void)[],
@@ -64,6 +65,7 @@ function initializeAdapter(
     if (adapter.onConnected) {
       const ctx: ConnectionContext = {
         profile,
+        deviceAddress,
         write: async (charUuid, data, withResponse = true) => {
           const char = resolveChar(charMap, charUuid);
           if (!char) throw new Error(`Characteristic ${charUuid} not found`);
@@ -199,6 +201,7 @@ export function waitForRawReading(
   profile: UserProfile,
   weightUnit?: WeightUnit,
   onLiveData?: (reading: ScaleReading) => void,
+  deviceAddress = '',
 ): Promise<RawReading> {
   return new Promise<RawReading>((resolve, reject) => {
     let resolved = false;
@@ -232,6 +235,7 @@ export function waitForRawReading(
       charMap,
       adapter,
       profile,
+      deviceAddress,
       () => resolved,
       handleNotification,
       unsubscribers,
@@ -268,8 +272,15 @@ export function waitForReading(
   profile: UserProfile,
   weightUnit?: WeightUnit,
   onLiveData?: (reading: ScaleReading) => void,
+  deviceAddress = '',
 ): Promise<BodyComposition> {
-  return waitForRawReading(charMap, bleDevice, adapter, profile, weightUnit, onLiveData).then(
-    ({ reading, adapter: matched }) => matched.computeMetrics(reading, profile),
-  );
+  return waitForRawReading(
+    charMap,
+    bleDevice,
+    adapter,
+    profile,
+    weightUnit,
+    onLiveData,
+    deviceAddress,
+  ).then(({ reading, adapter: matched }) => matched.computeMetrics(reading, profile));
 }

--- a/src/ble/shared.ts
+++ b/src/ble/shared.ts
@@ -27,6 +27,45 @@ function resolveChar(charMap: Map<string, BleChar>, uuid: string): BleChar | und
   return charMap.get(normalizeUuid(uuid));
 }
 
+/**
+ * Validate that a charMap contains every characteristic the adapter needs.
+ *
+ * Returns the list of missing UUIDs (empty when the map is complete). Handles
+ * both multi-char adapters (`characteristics` bindings) and legacy adapters
+ * (single notify + write with optional alt UUIDs).
+ *
+ * Callers use this after `buildCharMap` to detect the BlueZ `ServicesResolved`
+ * race ([bluez/bluez#1489](https://github.com/bluez/bluez/issues/1489)) where
+ * `ServicesResolved=true` fires before all GATT characteristics are exported
+ * over D-Bus, yielding a charMap that is missing entries the scale actually
+ * exposes. The typical workaround is to wait a few hundred ms and rebuild.
+ */
+export function findMissingCharacteristics(
+  charMap: Map<string, BleChar>,
+  adapter: ScaleAdapter,
+): string[] {
+  const missing: string[] = [];
+
+  if (adapter.characteristics) {
+    for (const binding of adapter.characteristics) {
+      if (!resolveChar(charMap, binding.uuid)) missing.push(binding.uuid);
+    }
+    return missing;
+  }
+
+  const hasNotify =
+    !!resolveChar(charMap, adapter.charNotifyUuid) ||
+    (!!adapter.altCharNotifyUuid && !!resolveChar(charMap, adapter.altCharNotifyUuid));
+  if (!hasNotify) missing.push(adapter.charNotifyUuid);
+
+  const hasWrite =
+    !!resolveChar(charMap, adapter.charWriteUuid) ||
+    (!!adapter.altCharWriteUuid && !!resolveChar(charMap, adapter.altCharWriteUuid));
+  if (!hasWrite) missing.push(adapter.charWriteUuid);
+
+  return missing;
+}
+
 /** Subscribe to a GATT characteristic and forward notifications to the handler.
  *  Returns the unsubscribe function from the BleChar. */
 async function subscribeToChar(

--- a/src/ble/shared.ts
+++ b/src/ble/shared.ts
@@ -238,9 +238,9 @@ export function waitForRawReading(
   bleDevice: BleDevice,
   adapter: ScaleAdapter,
   profile: UserProfile,
+  deviceAddress: string,
   weightUnit?: WeightUnit,
   onLiveData?: (reading: ScaleReading) => void,
-  deviceAddress = '',
 ): Promise<RawReading> {
   return new Promise<RawReading>((resolve, reject) => {
     let resolved = false;
@@ -309,17 +309,17 @@ export function waitForReading(
   bleDevice: BleDevice,
   adapter: ScaleAdapter,
   profile: UserProfile,
+  deviceAddress: string,
   weightUnit?: WeightUnit,
   onLiveData?: (reading: ScaleReading) => void,
-  deviceAddress = '',
 ): Promise<BodyComposition> {
   return waitForRawReading(
     charMap,
     bleDevice,
     adapter,
     profile,
+    deviceAddress,
     weightUnit,
     onLiveData,
-    deviceAddress,
   ).then(({ reading, adapter: matched }) => matched.computeMetrics(reading, profile));
 }

--- a/src/ble/types.ts
+++ b/src/ble/types.ts
@@ -16,6 +16,18 @@ export const DISCOVERY_POLL_MS = 2_000;
 /** Timeout for GATT service/characteristic enumeration after connecting. */
 export const GATT_DISCOVERY_TIMEOUT_MS = 30_000;
 
+/**
+ * Max attempts to enumerate GATT characteristics. BlueZ can signal
+ * `ServicesResolved=true` before all characteristic interfaces are exported
+ * over D-Bus ([bluez/bluez#1489](https://github.com/bluez/bluez/issues/1489)),
+ * so the first enumeration can return a partial map. Retrying with a short
+ * backoff lets BlueZ finish exporting before we validate the map.
+ */
+export const CHAR_DISCOVERY_MAX_RETRIES = 3;
+
+/** Backoff between characteristic-enumeration retries. */
+export const CHAR_DISCOVERY_RETRY_DELAY_MS = 500;
+
 /** Delay after stopping BlueZ discovery to let the radio quiesce before connecting. */
 export const POST_DISCOVERY_QUIESCE_MS = 500;
 

--- a/src/interfaces/scale-adapter.ts
+++ b/src/interfaces/scale-adapter.ts
@@ -57,6 +57,11 @@ export interface ConnectionContext {
   subscribe(charUuid: string): Promise<void>;
   /** User profile from .env configuration. */
   profile: UserProfile;
+  /**
+   * Device identifier used by adapters that derive keys from MAC (e.g. Eufy T9148/T9149).
+   * Uppercase, no separators. Empty string when unavailable (e.g. macOS CoreBluetooth UUID).
+   */
+  deviceAddress: string;
 }
 
 export interface ScaleAdapter {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -54,6 +54,12 @@ export async function dispatchExports(
   payload: BodyComposition,
   context?: ExportContext,
 ): Promise<DispatchResult> {
+  if (exporters.length === 0) {
+    log.warn('No exporters configured — measurement processed but not sent anywhere.');
+    log.warn('  Run `npm run setup` and pick at least one export target, or edit config.yaml.');
+    return { success: true, details: [] };
+  }
+
   log.info(`Exporting to: ${exporters.map((e) => e.name).join(', ')}...`);
 
   const results = await Promise.allSettled(

--- a/src/scales/eufy-p2.ts
+++ b/src/scales/eufy-p2.ts
@@ -66,6 +66,14 @@ const MAX_WEIGHT_KG = 200;
 /** Company ID used in Eufy P2/P2 Pro advertisement manufacturer data. */
 const EUFY_COMPANY_ID = 0xff48;
 
+/**
+ * Delay between successive sub-contract writes during the C0 and C2 handshake.
+ * Matches the bdr99/eufylife-ble-client Python reference (1s `asyncio.sleep`),
+ * which is what the EufyLife app effectively uses. Shorter delays (200 ms)
+ * were observed to trigger disconnects on some T9149 units.
+ */
+const EUFY_WRITE_DELAY_MS = 1000;
+
 /** XOR checksum over every byte of a frame (matches Python util.compute_checksum). */
 function xor(bytes: Buffer): number {
   return xorChecksum(bytes, 0, bytes.length);
@@ -282,7 +290,7 @@ export class EufyP2Adapter implements ScaleAdapter {
     bleLog.debug('Eufy: sending C0 handshake');
     for (const frame of this.auth.buildC0()) {
       await ctx.write(CHR_WRITE, frame, true);
-      await new Promise<void>((r) => setTimeout(r, 200));
+      await new Promise<void>((r) => setTimeout(r, EUFY_WRITE_DELAY_MS));
     }
   }
 
@@ -352,7 +360,7 @@ export class EufyP2Adapter implements ScaleAdapter {
     if (!this.auth || !this.ctx) return;
     for (const frame of this.auth.buildC2()) {
       await this.ctx.write(CHR_WRITE, frame, true);
-      await new Promise<void>((r) => setTimeout(r, 200));
+      await new Promise<void>((r) => setTimeout(r, EUFY_WRITE_DELAY_MS));
     }
   }
 }

--- a/src/scales/eufy-p2.ts
+++ b/src/scales/eufy-p2.ts
@@ -1,0 +1,358 @@
+import { createHash, createCipheriv, createDecipheriv, randomUUID } from 'node:crypto';
+import { computeBiaFat, buildPayload, uuid16, xorChecksum } from './body-comp-helpers.js';
+import type {
+  BleDeviceInfo,
+  CharacteristicBinding,
+  ConnectionContext,
+  ScaleAdapter,
+  ScaleReading,
+  UserProfile,
+  BodyComposition,
+} from '../interfaces/scale-adapter.js';
+import { bleLog, normalizeUuid } from '../ble/types.js';
+
+/**
+ * Eufy Smart Scale P2 (T9148) and P2 Pro (T9149).
+ *
+ * Ported from bdr99/eufylife-ble-client (MIT). The P2/P2 Pro use FFF0 service
+ * with three characteristics: FFF1 write (commands + auth), FFF2 notify (weight
+ * data), FFF4 notify (auth responses). Before the scale streams weight data on
+ * FFF2, the client must complete a C0/C1/C2/C3 handshake over FFF1 -> FFF4.
+ *
+ * Handshake:
+ *   key = MD5(MAC without separators, uppercase ASCII)
+ *   iv  = "0000000000000000"  (16 ASCII '0' bytes, NOT 16 zero bytes)
+ *
+ *   1. client -> scale on FFF1:   C0 <segs> <seg_idx> <total_len> <payload> <XOR>
+ *      payload = hex of ASCII-base64(AES-128-CBC(random 15-char UUID))
+ *      15 chars of base64 per segment; total_len = total bytes of base64 string
+ *
+ *   2. scale  -> client on FFF4:  C1 <segs> <seg_idx> <total_len> <payload> <XOR>
+ *      reassemble, base64-decode, AES-decrypt -> device UUID (arbitrary text)
+ *
+ *   3. client -> scale on FFF1:   C2 ... = AES-CBC(f"{clientUuid}_{deviceUuid}")
+ *
+ *   4. scale  -> client on FFF4:  C3 01 00 01 <status> <XOR>
+ *      status == 0 means auth successful. From then on FFF2 yields weight frames.
+ *
+ * Weight frame (FFF2, 16 bytes):
+ *   [0]    0xCF signature
+ *   [2]    0x00
+ *   [6..7] weight LE  / 100 = kg
+ *   [8..10] impedance LE24
+ *   [12]   0x00 when final (stable) reading
+ *
+ * Advertisement frame (19 bytes of vendor data, company ID 0xFF48):
+ *   [0..5] scale MAC
+ *   [6]    0xCF signature
+ *   [7]    heart rate (valid only when (byte[8] >> 6) == 0b11)
+ *   [8]    flags
+ *   [9..10] weight LE / 100 = kg
+ *   [15]   0x00 when final (stable) reading
+ *
+ * Advertisement mode works without authentication (passive broadcast), so
+ * devices that refuse connection still yield weight (no BIA/impedance).
+ */
+
+const CHR_WRITE = uuid16(0xfff1);
+const CHR_DATA = uuid16(0xfff2);
+const CHR_AUTH = uuid16(0xfff4);
+const SVC_UUID = uuid16(0xfff0);
+
+const AES_IV = Buffer.from('0000000000000000', 'ascii');
+const MIN_WEIGHT_KG = 2;
+const MAX_WEIGHT_KG = 200;
+
+/** Company ID used in Eufy P2/P2 Pro advertisement manufacturer data. */
+const EUFY_COMPANY_ID = 0xff48;
+
+/** XOR checksum over every byte of a frame (matches Python util.compute_checksum). */
+function xor(bytes: Buffer): number {
+  return xorChecksum(bytes, 0, bytes.length);
+}
+
+/**
+ * Split encrypted payload (already hex of ASCII-base64) into sub-contract frames.
+ *
+ * Each segment carries up to 15 base64 ASCII chars (30 hex chars). Frame layout
+ * matches Python `get_sub_contract_bytes`:
+ *   <prefix 1B> <num_segments 1B> <seg_idx 1B> <base64_total_bytes 1B> <payload...> <XOR 1B>
+ */
+export function buildSubContract(dataHex: string, prefix: number): Buffer[] {
+  const origLen = dataHex.length;
+  const numSegments = Math.ceil(origLen / 30) || 1;
+  const base64Bytes = origLen / 2; // dataHex encodes a base64 ASCII string
+  const frames: Buffer[] = [];
+
+  for (let i = 0; i < numSegments; i++) {
+    const slice = dataHex.slice(i * 30, (i + 1) * 30);
+    const header = Buffer.from([prefix, numSegments, i, base64Bytes]);
+    const payload = Buffer.from(slice, 'hex');
+    const body = Buffer.concat([header, payload]);
+    const frame = Buffer.concat([body, Buffer.from([xor(body)])]);
+    frames.push(frame);
+  }
+  return frames;
+}
+
+/** Reassemble segmented payload across multiple notifications keyed by prefix. */
+class SegmentReassembler {
+  private readonly prefix: number;
+  private buffer: Buffer = Buffer.alloc(0);
+  private expectedSegments = 0;
+  private nextSegment = 0;
+
+  constructor(prefix: number) {
+    this.prefix = prefix;
+  }
+
+  /** Feed a single notification frame. Returns the full payload once last segment arrives. */
+  feed(frame: Buffer): Buffer | null {
+    if (frame.length < 5 || frame[0] !== this.prefix) return null;
+    const numSegments = frame[1];
+    const segIdx = frame[2];
+
+    if (segIdx === 0) {
+      this.buffer = Buffer.alloc(0);
+      this.expectedSegments = numSegments;
+      this.nextSegment = 0;
+    }
+
+    if (segIdx !== this.nextSegment) {
+      bleLog.debug(`Eufy: out-of-order segment (expected ${this.nextSegment}, got ${segIdx})`);
+      return null;
+    }
+
+    // Payload is between header (4 bytes) and trailing checksum (1 byte)
+    const payload = frame.subarray(4, frame.length - 1);
+    this.buffer = Buffer.concat([this.buffer, payload]);
+    this.nextSegment += 1;
+
+    if (segIdx === numSegments - 1) {
+      const out = this.buffer;
+      this.buffer = Buffer.alloc(0);
+      this.expectedSegments = 0;
+      this.nextSegment = 0;
+      return out;
+    }
+    return null;
+  }
+}
+
+/**
+ * Authentication helper. Encapsulates key generation and C0/C1/C2/C3 handling.
+ * Exported so tests can verify frame assembly independently.
+ */
+export class EufyAuthHandler {
+  readonly key: Buffer;
+  readonly clientUuid: string;
+  private readonly c1Reassembler = new SegmentReassembler(0xc1);
+  private deviceUuid: string | null = null;
+  private authSuccess = false;
+
+  constructor(mac: string, clientUuid?: string) {
+    const macClean = mac.replace(/[:-]/g, '').toUpperCase();
+    if (!/^[0-9A-F]{12}$/.test(macClean)) {
+      throw new Error(`Eufy: invalid MAC "${mac}" (need 6 hex octets)`);
+    }
+    this.key = createHash('md5').update(macClean, 'utf8').digest();
+    this.clientUuid = clientUuid ?? randomUUID().slice(0, 15);
+  }
+
+  get deviceUuidOrNull(): string | null {
+    return this.deviceUuid;
+  }
+
+  get isAuthenticated(): boolean {
+    return this.authSuccess;
+  }
+
+  /** Encrypt + base64 + hex + sub-contract to C0 frames. */
+  buildC0(): Buffer[] {
+    return buildSubContract(this.encryptToHex(this.clientUuid), 0xc0);
+  }
+
+  /** Feed a C1 notification. Returns true once the full device UUID is assembled. */
+  handleC1(frame: Buffer): boolean {
+    const payload = this.c1Reassembler.feed(frame);
+    if (!payload) return false;
+    // Payload is ASCII base64 of encrypted device UUID
+    const encrypted = Buffer.from(payload.toString('ascii'), 'base64');
+    this.deviceUuid = this.decrypt(encrypted);
+    return true;
+  }
+
+  /** Encrypt combined `{clientUuid}_{deviceUuid}` + base64 + hex + sub-contract to C2 frames. */
+  buildC2(): Buffer[] {
+    if (!this.deviceUuid) throw new Error('Eufy: buildC2 called before C1 received');
+    const combined = `${this.clientUuid}_${this.deviceUuid}`;
+    return buildSubContract(this.encryptToHex(combined), 0xc2);
+  }
+
+  /** Feed a C3 notification. Returns true when result byte is present. */
+  handleC3(frame: Buffer): boolean {
+    if (frame.length < 5 || frame[0] !== 0xc3) return false;
+    this.authSuccess = frame[4] === 0;
+    return true;
+  }
+
+  private encryptToHex(plaintext: string): string {
+    const cipher = createCipheriv('aes-128-cbc', this.key, AES_IV);
+    const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+    return Buffer.from(encrypted.toString('base64'), 'ascii').toString('hex');
+  }
+
+  private decrypt(encrypted: Buffer): string {
+    const decipher = createDecipheriv('aes-128-cbc', this.key, AES_IV);
+    const plaintext = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+    return plaintext.toString('utf8');
+  }
+}
+
+/** Parse a 16-byte weight notification frame from FFF2. Returns null if malformed. */
+export function parseWeightNotification(data: Buffer): ScaleReading | null {
+  if (data.length !== 16 || data[0] !== 0xcf || data[2] !== 0x00) return null;
+
+  const weight = ((data[7] << 8) | data[6]) / 100;
+  if (!Number.isFinite(weight) || weight < MIN_WEIGHT_KG || weight > MAX_WEIGHT_KG) return null;
+
+  const isFinal = data[12] === 0x00;
+  if (!isFinal) return null;
+
+  const impedance = (data[10] << 16) | (data[9] << 8) | data[8];
+  return { weight, impedance };
+}
+
+/** Parse 19-byte advertisement vendor payload. Returns null if not a final reading. */
+export function parseEufyAdvertisement(vendor: Buffer): ScaleReading | null {
+  if (vendor.length < 19 || vendor[6] !== 0xcf) return null;
+
+  // Final flag is at byte[15] in full 19-byte vendor payload (offset 9 after 6-byte header)
+  const isFinal = vendor[15] === 0x00;
+  if (!isFinal) return null;
+
+  const weight = ((vendor[10] << 8) | vendor[9]) / 100;
+  if (!Number.isFinite(weight) || weight < MIN_WEIGHT_KG || weight > MAX_WEIGHT_KG) return null;
+
+  return { weight, impedance: 0 };
+}
+
+export class EufyP2Adapter implements ScaleAdapter {
+  readonly name = 'Eufy Smart Scale P2/P2 Pro';
+  readonly charNotifyUuid = CHR_DATA;
+  readonly charWriteUuid = CHR_WRITE;
+  readonly unlockCommand: number[] = [];
+  readonly unlockIntervalMs = 0;
+  readonly normalizesWeight = true;
+
+  readonly characteristics: CharacteristicBinding[] = [
+    { service: SVC_UUID, uuid: CHR_WRITE, type: 'write' },
+    { service: SVC_UUID, uuid: CHR_DATA, type: 'notify' },
+    { service: SVC_UUID, uuid: CHR_AUTH, type: 'notify' },
+  ];
+
+  private auth: EufyAuthHandler | null = null;
+  private ctx: ConnectionContext | null = null;
+  private readonly c3Seen = { done: false };
+
+  matches(device: BleDeviceInfo): boolean {
+    const name = (device.localName || '').toLowerCase();
+    if (name.startsWith('eufy t9148') || name.startsWith('eufy t9149')) return true;
+    if (name === 'eufy t9148' || name === 'eufy t9149') return true;
+
+    // Passive (broadcast) identification via manufacturer data: company 0xFF48
+    // + 0xCF signature at offset 6 of the 19-byte vendor payload.
+    if (device.manufacturerData) {
+      const { id, data } = device.manufacturerData;
+      if (id === EUFY_COMPANY_ID && data.length >= 19 && data[6] === 0xcf) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  async onConnected(ctx: ConnectionContext): Promise<void> {
+    this.ctx = ctx;
+    this.c3Seen.done = false;
+    if (!ctx.deviceAddress) {
+      bleLog.warn('Eufy: no device address available — auth will fail without MAC');
+      return;
+    }
+    this.auth = new EufyAuthHandler(ctx.deviceAddress);
+    bleLog.debug('Eufy: sending C0 handshake');
+    for (const frame of this.auth.buildC0()) {
+      await ctx.write(CHR_WRITE, frame, true);
+      await new Promise<void>((r) => setTimeout(r, 200));
+    }
+  }
+
+  /** Multi-char dispatch: route FFF4 to auth handler, FFF2 to weight parser. */
+  parseCharNotification(charUuid: string, data: Buffer): ScaleReading | null {
+    const uuid = normalizeUuid(charUuid);
+    if (uuid === normalizeUuid(CHR_AUTH)) {
+      this.handleAuthFrame(data);
+      return null;
+    }
+    if (uuid === normalizeUuid(CHR_DATA)) {
+      if (!this.auth?.isAuthenticated) {
+        bleLog.debug('Eufy: FFF2 frame received before auth complete — ignoring');
+        return null;
+      }
+      return parseWeightNotification(data);
+    }
+    return null;
+  }
+
+  /** Fallback single-char path (not used when parseCharNotification is defined). */
+  parseNotification(data: Buffer): ScaleReading | null {
+    return parseWeightNotification(data);
+  }
+
+  parseBroadcast(manufacturerData: Buffer): ScaleReading | null {
+    return parseEufyAdvertisement(manufacturerData);
+  }
+
+  isComplete(reading: ScaleReading): boolean {
+    // Broadcast readings have impedance=0 (passive mode, no BIA).
+    // Authenticated GATT readings have non-zero impedance from the scale.
+    if (reading.impedance === 0) return reading.weight > 0;
+    return reading.weight > MIN_WEIGHT_KG && reading.impedance > 200;
+  }
+
+  computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {
+    const fat =
+      reading.impedance > 0 ? computeBiaFat(reading.weight, reading.impedance, profile) : undefined;
+    return buildPayload(reading.weight, reading.impedance, { fat }, profile);
+  }
+
+  private handleAuthFrame(data: Buffer): void {
+    if (!this.auth || !this.ctx) return;
+    if (data.length === 0) return;
+
+    if (data[0] === 0xc1) {
+      if (!this.auth.handleC1(data)) return;
+      bleLog.debug(`Eufy: C1 complete, device uuid received, sending C2`);
+      void this.sendC2();
+      return;
+    }
+
+    if (data[0] === 0xc3) {
+      if (this.c3Seen.done) return;
+      this.c3Seen.done = true;
+      this.auth.handleC3(data);
+      if (this.auth.isAuthenticated) {
+        bleLog.info('Eufy: authentication successful, waiting for weight on FFF2');
+      } else {
+        bleLog.warn('Eufy: authentication failed (scale rejected credentials)');
+      }
+    }
+  }
+
+  private async sendC2(): Promise<void> {
+    if (!this.auth || !this.ctx) return;
+    for (const frame of this.auth.buildC2()) {
+      await this.ctx.write(CHR_WRITE, frame, true);
+      await new Promise<void>((r) => setTimeout(r, 200));
+    }
+  }
+}

--- a/src/scales/eufy-p2.ts
+++ b/src/scales/eufy-p2.ts
@@ -108,22 +108,42 @@ class SegmentReassembler {
   private readonly prefix: number;
   private buffer: Buffer = Buffer.alloc(0);
   private expectedSegments = 0;
+  private expectedTotalBytes = 0;
   private nextSegment = 0;
 
   constructor(prefix: number) {
     this.prefix = prefix;
   }
 
+  private reset(): void {
+    this.buffer = Buffer.alloc(0);
+    this.expectedSegments = 0;
+    this.expectedTotalBytes = 0;
+    this.nextSegment = 0;
+  }
+
   /** Feed a single notification frame. Returns the full payload once last segment arrives. */
   feed(frame: Buffer): Buffer | null {
     if (frame.length < 5 || frame[0] !== this.prefix) return null;
+
+    // Validate trailing XOR checksum over header + payload.
+    const body = frame.subarray(0, frame.length - 1);
+    const expectedXor = frame[frame.length - 1];
+    if (xor(body) !== expectedXor) {
+      bleLog.debug(
+        `Eufy: dropping segment with bad XOR (got 0x${expectedXor.toString(16)}, expected 0x${xor(body).toString(16)})`,
+      );
+      return null;
+    }
+
     const numSegments = frame[1];
     const segIdx = frame[2];
+    const totalBytes = frame[3];
 
     if (segIdx === 0) {
-      this.buffer = Buffer.alloc(0);
+      this.reset();
       this.expectedSegments = numSegments;
-      this.nextSegment = 0;
+      this.expectedTotalBytes = totalBytes;
     }
 
     if (segIdx !== this.nextSegment) {
@@ -138,9 +158,14 @@ class SegmentReassembler {
 
     if (segIdx === numSegments - 1) {
       const out = this.buffer;
-      this.buffer = Buffer.alloc(0);
-      this.expectedSegments = 0;
-      this.nextSegment = 0;
+      const expected = this.expectedTotalBytes;
+      this.reset();
+      if (out.length !== expected) {
+        bleLog.debug(
+          `Eufy: reassembled payload length ${out.length} differs from advertised ${expected}; dropping frame`,
+        );
+        return null;
+      }
       return out;
     }
     return null;
@@ -280,7 +305,10 @@ export class EufyP2Adapter implements ScaleAdapter {
   }
 
   async onConnected(ctx: ConnectionContext): Promise<void> {
+    // Reset per-connection state first so a missing deviceAddress or a fresh
+    // scan cannot inherit a prior session's authenticated EufyAuthHandler.
     this.ctx = ctx;
+    this.auth = null;
     this.c3Seen.done = false;
     if (!ctx.deviceAddress) {
       bleLog.warn('Eufy: no device address available — auth will fail without MAC');
@@ -340,7 +368,11 @@ export class EufyP2Adapter implements ScaleAdapter {
     if (data[0] === 0xc1) {
       if (!this.auth.handleC1(data)) return;
       bleLog.debug(`Eufy: C1 complete, device uuid received, sending C2`);
-      void this.sendC2();
+      void this.sendC2().catch((error: unknown) => {
+        bleLog.warn(
+          `Eufy: failed to send C2 authentication frame (${error instanceof Error ? error.message : String(error)})`,
+        );
+      });
       return;
     }
 

--- a/src/scales/index.ts
+++ b/src/scales/index.ts
@@ -21,12 +21,16 @@ import { ActiveEraAdapter } from './active-era.js';
 import { MgbAdapter } from './mgb.js';
 import { HoffenAdapter } from './hoffen.js';
 import { SenssunAdapter } from './senssun.js';
+import { EufyP2Adapter } from './eufy-p2.js';
 import { StandardGattScaleAdapter } from './standard-gatt.js';
 
 export const adapters: ScaleAdapter[] = [
   // Specific adapters first — they match by device name before the generic one.
   // Order matters: SenssunAdapter before QnScaleAdapter (QN matches 'senssun'),
-  // QnScaleAdapter before RenphoScaleAdapter (mutual exclusion by service UUID).
+  // QnScaleAdapter before RenphoScaleAdapter (mutual exclusion by service UUID),
+  // EufyP2Adapter before QnScaleAdapter (P2/P2 Pro advertise FFF0 and would be
+  // mis-detected as a QN scale; Eufy's company ID 0xFF48 + "eufy T914x" name is specific).
+  new EufyP2Adapter(),
   new SenssunAdapter(),
   new QnScaleAdapter(),
   new RenphoScaleAdapter(),

--- a/src/wizard/steps/exporters.ts
+++ b/src/wizard/steps/exporters.ts
@@ -110,11 +110,19 @@ export const exportersStep: WizardStep = {
     });
 
     console.log('\nSelect export targets:\n');
-    const selected = await ctx.prompts.checkbox('Exporters:', choices);
+    let selected = await ctx.prompts.checkbox('Exporters:', choices);
 
-    if (selected.length === 0) {
-      console.log(dim('\n  No exporters selected.'));
-      return;
+    while (selected.length === 0) {
+      const proceedEmpty = await ctx.prompts.confirm(
+        'No exporters selected. Measurements will not be sent anywhere. Continue without exporters?',
+        { default: false },
+      );
+      if (proceedEmpty) {
+        console.log(dim('\n  No exporters selected — measurements will not be exported.'));
+        return;
+      }
+      console.log(dim('\n  Pick at least one export target (space to toggle, enter to confirm):'));
+      selected = await ctx.prompts.checkbox('Exporters:', choices);
     }
 
     const selectedSchemas = selected.map((n) => EXPORTER_SCHEMAS.find((s) => s.name === n)!);

--- a/tests/ble/shared.test.ts
+++ b/tests/ble/shared.test.ts
@@ -145,7 +145,7 @@ describe('waitForReading() — legacy mode', () => {
       }),
     });
 
-    const promise = waitForReading(charMap, device, adapter, PROFILE);
+    const promise = waitForReading(charMap, device, adapter, PROFILE, '');
 
     // Wait for subscription to be set up
     await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
@@ -176,7 +176,7 @@ describe('waitForReading() — legacy mode', () => {
       }),
     });
 
-    const promise = waitForReading(charMap, device, adapter, PROFILE);
+    const promise = waitForReading(charMap, device, adapter, PROFILE, '');
     await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
 
     // First two notifications return null — ignored
@@ -205,7 +205,7 @@ describe('waitForReading() — legacy mode', () => {
       // isComplete requires weight > 10 AND impedance > 200
     });
 
-    const promise = waitForReading(charMap, device, adapter, PROFILE);
+    const promise = waitForReading(charMap, device, adapter, PROFILE, '');
     await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
 
     // Incomplete reading — weight too low
@@ -232,7 +232,7 @@ describe('waitForReading() — legacy mode', () => {
       parseNotification: vi.fn(() => ({ weight: 75, impedance: 500 })),
     });
 
-    const promise = waitForReading(charMap, device, adapter, PROFILE);
+    const promise = waitForReading(charMap, device, adapter, PROFILE, '');
     await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
 
     // Unlock command should have been sent
@@ -262,7 +262,7 @@ describe('waitForReading() — legacy mode', () => {
       }),
     });
 
-    const promise = waitForReading(charMap, device, adapter, PROFILE, undefined, onLiveData);
+    const promise = waitForReading(charMap, device, adapter, PROFILE, '', undefined, onLiveData);
     await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
 
     notifyChar.triggerData(Buffer.from([0x01])); // incomplete
@@ -292,7 +292,7 @@ describe('waitForReading() — legacy mode', () => {
       parseNotification: vi.fn(() => ({ weight: 75, impedance: 500 })),
     });
 
-    const promise = waitForReading(charMap, device, adapter, PROFILE);
+    const promise = waitForReading(charMap, device, adapter, PROFILE, '');
     await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
 
     // Both unlock commands should have been sent
@@ -317,7 +317,7 @@ describe('waitForReading() — legacy mode', () => {
 
     const adapter = createLegacyAdapter();
 
-    const promise = waitForReading(charMap, device, adapter, PROFILE);
+    const promise = waitForReading(charMap, device, adapter, PROFILE, '');
     await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
 
     device.triggerDisconnect();
@@ -333,7 +333,7 @@ describe('waitForReading() — legacy mode', () => {
 
     const adapter = createLegacyAdapter();
 
-    await expect(waitForReading(charMap, device, adapter, PROFILE)).rejects.toThrow(
+    await expect(waitForReading(charMap, device, adapter, PROFILE, '')).rejects.toThrow(
       'Required characteristics not found',
     );
   });
@@ -346,7 +346,7 @@ describe('waitForReading() — legacy mode', () => {
 
     const adapter = createLegacyAdapter();
 
-    await expect(waitForReading(charMap, device, adapter, PROFILE)).rejects.toThrow(
+    await expect(waitForReading(charMap, device, adapter, PROFILE, '')).rejects.toThrow(
       'Required characteristics not found',
     );
   });
@@ -370,7 +370,7 @@ describe('waitForReading() — legacy mode', () => {
       parseNotification: vi.fn(() => ({ weight: 75, impedance: 500 })),
     });
 
-    const promise = waitForReading(charMap, device, adapter, PROFILE);
+    const promise = waitForReading(charMap, device, adapter, PROFILE, '');
     await vi.waitFor(() => expect(altNotifyChar.subscribeCalled).toBe(true));
 
     altNotifyChar.triggerData(Buffer.from([0x01]));
@@ -393,7 +393,7 @@ describe('waitForReading() — legacy mode', () => {
       }),
     });
 
-    const promise = waitForReading(charMap, device, adapter, PROFILE);
+    const promise = waitForReading(charMap, device, adapter, PROFILE, '');
     await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
 
     notifyChar.triggerData(Buffer.from([0x01]));
@@ -427,7 +427,7 @@ describe('waitForReading() — onConnected mode', () => {
       parseNotification: vi.fn(() => ({ weight: 75, impedance: 500 })),
     });
 
-    const promise = waitForReading(charMap, device, adapter, PROFILE);
+    const promise = waitForReading(charMap, device, adapter, PROFILE, '');
     await vi.waitFor(() => expect(onConnected).toHaveBeenCalled());
 
     // Trigger data through the subscription set up by characteristics bindings
@@ -459,7 +459,7 @@ describe('waitForReading() — onConnected mode', () => {
       parseNotification: vi.fn(() => ({ weight: 75, impedance: 500 })),
     });
 
-    const promise = waitForReading(charMap, device, adapter, PROFILE);
+    const promise = waitForReading(charMap, device, adapter, PROFILE, '');
     await vi.waitFor(() => expect(writeChar.writtenData.length).toBeGreaterThanOrEqual(1));
     expect(writeChar.writtenData[0]).toEqual(Buffer.from([0xab, 0xcd]));
 
@@ -490,7 +490,7 @@ describe('waitForReading() — onConnected mode', () => {
       parseNotification: vi.fn(() => ({ weight: 75, impedance: 500 })),
     });
 
-    const promise = waitForReading(charMap, device, adapter, PROFILE);
+    const promise = waitForReading(charMap, device, adapter, PROFILE, '');
     await vi.waitFor(() => expect(writeChar.writtenData.length).toBeGreaterThanOrEqual(1));
     expect(writeChar.writtenData[0]).toEqual(Buffer.from([0x01, 0x02, 0x03]));
 
@@ -525,7 +525,7 @@ describe('waitForReading() — multi-char mode (characteristics[])', () => {
       parseNotification: vi.fn(() => ({ weight: 75, impedance: 500 })),
     });
 
-    const promise = waitForReading(charMap, device, adapter, PROFILE);
+    const promise = waitForReading(charMap, device, adapter, PROFILE, '');
     await vi.waitFor(() => {
       expect(char1.subscribeCalled).toBe(true);
       expect(char2.subscribeCalled).toBe(true);
@@ -551,7 +551,7 @@ describe('waitForReading() — multi-char mode (characteristics[])', () => {
       parseCharNotification,
     });
 
-    const promise = waitForReading(charMap, device, adapter, PROFILE);
+    const promise = waitForReading(charMap, device, adapter, PROFILE, '');
     await vi.waitFor(() => expect(char1.subscribeCalled).toBe(true));
 
     char1.triggerData(Buffer.from([0x01]));
@@ -572,7 +572,7 @@ describe('waitForReading() — multi-char mode (characteristics[])', () => {
       onConnected: vi.fn(),
     });
 
-    await expect(waitForReading(charMap, device, adapter, PROFILE)).rejects.toThrow(
+    await expect(waitForReading(charMap, device, adapter, PROFILE, '')).rejects.toThrow(
       'No notify characteristics',
     );
   });
@@ -594,7 +594,7 @@ describe('waitForRawReading()', () => {
       parseNotification: vi.fn(() => ({ weight: 75.5, impedance: 500 })),
     });
 
-    const promise = waitForRawReading(charMap, device, adapter, PROFILE);
+    const promise = waitForRawReading(charMap, device, adapter, PROFILE, '');
     await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
 
     notifyChar.triggerData(Buffer.from([0x01]));
@@ -619,7 +619,7 @@ describe('waitForRawReading()', () => {
       parseNotification: vi.fn(() => ({ weight: 166.45, impedance: 500 })),
     });
 
-    const promise = waitForRawReading(charMap, device, adapter, PROFILE, 'lbs');
+    const promise = waitForRawReading(charMap, device, adapter, PROFILE, '', 'lbs');
     await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
 
     notifyChar.triggerData(Buffer.from([0x01]));
@@ -640,7 +640,7 @@ describe('waitForRawReading()', () => {
 
     const adapter = createLegacyAdapter();
 
-    const promise = waitForRawReading(charMap, device, adapter, PROFILE);
+    const promise = waitForRawReading(charMap, device, adapter, PROFILE, '');
     await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
 
     device.triggerDisconnect();
@@ -667,7 +667,7 @@ describe('waitForRawReading()', () => {
       }),
     });
 
-    const promise = waitForRawReading(charMap, device, adapter, PROFILE, undefined, onLiveData);
+    const promise = waitForRawReading(charMap, device, adapter, PROFILE, '', undefined, onLiveData);
     await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
 
     notifyChar.triggerData(Buffer.from([0x01])); // incomplete
@@ -696,7 +696,7 @@ describe('waitForReading() — weight normalization', () => {
       parseNotification: vi.fn(() => ({ weight: 166.45, impedance: 500 })),
     });
 
-    const promise = waitForReading(charMap, device, adapter, PROFILE, 'lbs');
+    const promise = waitForReading(charMap, device, adapter, PROFILE, '', 'lbs');
     await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
 
     notifyChar.triggerData(Buffer.from([0x01]));
@@ -721,7 +721,7 @@ describe('waitForReading() — weight normalization', () => {
       parseNotification: vi.fn(() => ({ weight: 75.5, impedance: 500 })),
     });
 
-    const promise = waitForReading(charMap, device, adapter, PROFILE, 'lbs');
+    const promise = waitForReading(charMap, device, adapter, PROFILE, '', 'lbs');
     await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
 
     notifyChar.triggerData(Buffer.from([0x01]));
@@ -745,7 +745,7 @@ describe('waitForReading() — weight normalization', () => {
       parseNotification: vi.fn(() => ({ weight: 75.5, impedance: 500 })),
     });
 
-    const promise = waitForReading(charMap, device, adapter, PROFILE, 'kg');
+    const promise = waitForReading(charMap, device, adapter, PROFILE, '', 'kg');
     await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
 
     notifyChar.triggerData(Buffer.from([0x01]));

--- a/tests/ble/shared.test.ts
+++ b/tests/ble/shared.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { waitForReading, waitForRawReading } from '../../src/ble/shared.js';
+import {
+  waitForReading,
+  waitForRawReading,
+  findMissingCharacteristics,
+} from '../../src/ble/shared.js';
 import type { BleChar, BleDevice } from '../../src/ble/shared.js';
 import { normalizeUuid } from '../../src/ble/types.js';
 import type {
@@ -749,5 +753,71 @@ describe('waitForReading() — weight normalization', () => {
     await promise;
     const call = vi.mocked(adapter.computeMetrics).mock.calls[0];
     expect(call[0].weight).toBe(75.5); // unchanged
+  });
+});
+
+describe('findMissingCharacteristics()', () => {
+  const SERVICE_UUID = '0000fff000001000800000805f9b34fb';
+  const OTHER_UUID = '0000fff400001000800000805f9b34fb';
+
+  it('returns empty array when legacy adapter has both notify and write chars', () => {
+    const { charMap } = createCharMap([
+      [NOTIFY_UUID, createMockChar()],
+      [WRITE_UUID, createMockChar()],
+    ]);
+    const adapter = createLegacyAdapter();
+    expect(findMissingCharacteristics(charMap, adapter)).toEqual([]);
+  });
+
+  it('returns missing notify UUID when legacy notify char absent', () => {
+    const { charMap } = createCharMap([[WRITE_UUID, createMockChar()]]);
+    const adapter = createLegacyAdapter();
+    expect(findMissingCharacteristics(charMap, adapter)).toEqual([NOTIFY_UUID]);
+  });
+
+  it('returns missing write UUID when legacy write char absent', () => {
+    const { charMap } = createCharMap([[NOTIFY_UUID, createMockChar()]]);
+    const adapter = createLegacyAdapter();
+    expect(findMissingCharacteristics(charMap, adapter)).toEqual([WRITE_UUID]);
+  });
+
+  it('accepts altCharNotifyUuid when primary notify absent', () => {
+    const altNotify = '0000fff300001000800000805f9b34fb';
+    const { charMap } = createCharMap([
+      [altNotify, createMockChar()],
+      [WRITE_UUID, createMockChar()],
+    ]);
+    const adapter = createLegacyAdapter({ altCharNotifyUuid: altNotify });
+    expect(findMissingCharacteristics(charMap, adapter)).toEqual([]);
+  });
+
+  it('returns empty array when multi-char adapter has all bindings', () => {
+    const { charMap } = createCharMap([
+      [NOTIFY_UUID, createMockChar()],
+      [WRITE_UUID, createMockChar()],
+      [OTHER_UUID, createMockChar()],
+    ]);
+    const adapter = createLegacyAdapter({
+      characteristics: [
+        { service: SERVICE_UUID, uuid: NOTIFY_UUID, type: 'notify' },
+        { service: SERVICE_UUID, uuid: WRITE_UUID, type: 'write' },
+        { service: SERVICE_UUID, uuid: OTHER_UUID, type: 'notify' },
+      ],
+    });
+    expect(findMissingCharacteristics(charMap, adapter)).toEqual([]);
+  });
+
+  it('returns every missing UUID from a multi-char adapter', () => {
+    const { charMap } = createCharMap([[NOTIFY_UUID, createMockChar()]]);
+    const adapter = createLegacyAdapter({
+      characteristics: [
+        { service: SERVICE_UUID, uuid: NOTIFY_UUID, type: 'notify' },
+        { service: SERVICE_UUID, uuid: WRITE_UUID, type: 'write' },
+        { service: SERVICE_UUID, uuid: OTHER_UUID, type: 'notify' },
+      ],
+    });
+    expect(findMissingCharacteristics(charMap, adapter).sort()).toEqual(
+      [WRITE_UUID, OTHER_UUID].sort(),
+    );
   });
 });

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -206,4 +206,10 @@ describe('dispatchExports()', () => {
     expect(arg).toHaveProperty('impedance', 500);
     expect(arg).toHaveProperty('metabolicAge', 28);
   });
+
+  it('returns success true with empty details when no exporters are configured', async () => {
+    const result = await dispatchExports([], SAMPLE_PAYLOAD);
+    expect(result.success).toBe(true);
+    expect(result.details).toEqual([]);
+  });
 });

--- a/tests/scales/eufy-p2.test.ts
+++ b/tests/scales/eufy-p2.test.ts
@@ -227,4 +227,64 @@ describe('EufyP2Adapter', () => {
     expect(payload.impedance).toBe(0);
     assertPayloadRanges(payload);
   });
+
+  it('rejects FFF2 weight frames when onConnected had no deviceAddress (no stale auth)', async () => {
+    const adapter = new EufyP2Adapter();
+
+    // First session: authenticate fully so adapter holds a live EufyAuthHandler.
+    const writes: Buffer[] = [];
+    const ctx = {
+      write: async (_uuid: string, data: Buffer | number[]) => {
+        writes.push(Buffer.isBuffer(data) ? data : Buffer.from(data));
+      },
+      read: async () => Buffer.alloc(0),
+      subscribe: async () => {},
+      profile: defaultProfile(),
+      deviceAddress: TEST_MAC_FLAT,
+    };
+    await adapter.onConnected(ctx);
+    const c1 = makeC1Frames(TEST_MAC, 'DEVICEUUID12345');
+    for (const f of c1) adapter.parseCharNotification!('fff4', f);
+    adapter.parseCharNotification!('fff4', Buffer.from([0xc3, 0x01, 0x00, 0x01, 0x00, 0xc3]));
+    expect(adapter.parseCharNotification!('fff2', makeNotification(75, 500))).not.toBeNull();
+
+    // Second session without a MAC: adapter must NOT keep the old auth.
+    await adapter.onConnected({ ...ctx, deviceAddress: '' });
+    expect(adapter.parseCharNotification!('fff2', makeNotification(75, 500))).toBeNull();
+  });
+});
+
+// ─── SegmentReassembler integrity (via handleC1 which uses it) ─────────────
+
+describe('SegmentReassembler', () => {
+  it('rejects C1 segment with a tampered XOR checksum', () => {
+    const h = new EufyAuthHandler(TEST_MAC, 'abcdef123456789');
+    const c1Frames = makeC1Frames(TEST_MAC, 'DEVICEUUID12345');
+    // Corrupt the last byte (XOR) on the first segment
+    const bad = Buffer.from(c1Frames[0]);
+    bad[bad.length - 1] ^= 0xff;
+    expect(h.handleC1(bad)).toBe(false);
+    // A valid follow-up frame for segment 0 should still work
+    expect(h.handleC1(c1Frames[0])).toBe(c1Frames.length === 1);
+  });
+
+  it('rejects C1 reassembly when total length does not match advertised', () => {
+    const h = new EufyAuthHandler(TEST_MAC, 'abcdef123456789');
+    const c1Frames = makeC1Frames(TEST_MAC, 'DEVICEUUID12345');
+    if (c1Frames.length < 2) return; // only meaningful with multi-segment
+
+    // Mutate frame[3] (totalBytes) on first segment so reassembled length mismatches
+    const tampered = Buffer.from(c1Frames[0]);
+    tampered[3] = (tampered[3] + 1) & 0xff;
+    // Recompute XOR so the segment itself passes the checksum
+    let x = 0;
+    for (let i = 0; i < tampered.length - 1; i++) x ^= tampered[i];
+    tampered[tampered.length - 1] = x;
+
+    expect(h.handleC1(tampered)).toBe(false);
+    // Feed remaining untouched segments; the final one should drop on length mismatch
+    for (let i = 1; i < c1Frames.length; i++) {
+      expect(h.handleC1(c1Frames[i])).toBe(false);
+    }
+  });
 });

--- a/tests/scales/eufy-p2.test.ts
+++ b/tests/scales/eufy-p2.test.ts
@@ -40,9 +40,7 @@ function makeNotification(weightKg: number, impedance: number, isFinal = true): 
 
 /** Emulate scale side: respond to C0 with a C1 carrying an AES-encrypted device UUID. */
 function makeC1Frames(mac: string, deviceUuid: string): Buffer[] {
-  const key = createHash('md5')
-    .update(mac.replace(/[:-]/g, '').toUpperCase(), 'utf8')
-    .digest();
+  const key = createHash('md5').update(mac.replace(/[:-]/g, '').toUpperCase(), 'utf8').digest();
   const cipher = createCipheriv('aes-128-cbc', key, IV);
   const encrypted = Buffer.concat([cipher.update(deviceUuid, 'utf8'), cipher.final()]);
   const base64Ascii = Buffer.from(encrypted.toString('base64'), 'ascii');

--- a/tests/scales/eufy-p2.test.ts
+++ b/tests/scales/eufy-p2.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest';
+import { createCipheriv, createHash } from 'node:crypto';
+import {
+  EufyAuthHandler,
+  EufyP2Adapter,
+  buildSubContract,
+  parseEufyAdvertisement,
+  parseWeightNotification,
+} from '../../src/scales/eufy-p2.js';
+import type { BleDeviceInfo } from '../../src/interfaces/scale-adapter.js';
+import { defaultProfile, assertPayloadRanges } from '../helpers/scale-test-utils.js';
+
+const TEST_MAC = 'CF:E6:03:1D:09:F7';
+const TEST_MAC_FLAT = 'CFE6031D09F7';
+const IV = Buffer.from('0000000000000000', 'ascii');
+
+/** Build a vendor advertisement payload (19 bytes) for a given weight + final flag. */
+function makeVendor(weightKg: number, finalFlag = 0x00): Buffer {
+  const buf = Buffer.alloc(19);
+  // [0..5] MAC, [6] 0xCF, [7] HR, [8] flags, [9..10] weight LE, [15] final
+  Buffer.from(TEST_MAC_FLAT, 'hex').copy(buf, 0);
+  buf[6] = 0xcf;
+  buf.writeUInt16LE(Math.round(weightKg * 100), 9);
+  buf[15] = finalFlag;
+  return buf;
+}
+
+/** Build a 16-byte FFF2 weight notification. */
+function makeNotification(weightKg: number, impedance: number, isFinal = true): Buffer {
+  const buf = Buffer.alloc(16);
+  buf[0] = 0xcf;
+  buf[2] = 0x00;
+  buf.writeUInt16LE(Math.round(weightKg * 100), 6);
+  buf[8] = impedance & 0xff;
+  buf[9] = (impedance >> 8) & 0xff;
+  buf[10] = (impedance >> 16) & 0xff;
+  buf[12] = isFinal ? 0x00 : 0x01;
+  return buf;
+}
+
+/** Emulate scale side: respond to C0 with a C1 carrying an AES-encrypted device UUID. */
+function makeC1Frames(mac: string, deviceUuid: string): Buffer[] {
+  const key = createHash('md5')
+    .update(mac.replace(/[:-]/g, '').toUpperCase(), 'utf8')
+    .digest();
+  const cipher = createCipheriv('aes-128-cbc', key, IV);
+  const encrypted = Buffer.concat([cipher.update(deviceUuid, 'utf8'), cipher.final()]);
+  const base64Ascii = Buffer.from(encrypted.toString('base64'), 'ascii');
+  const base64Hex = base64Ascii.toString('hex');
+  return buildSubContract(base64Hex, 0xc1);
+}
+
+describe('EufyAuthHandler', () => {
+  it('derives AES key from MAC via MD5', () => {
+    const h = new EufyAuthHandler(TEST_MAC);
+    const expected = createHash('md5').update(TEST_MAC_FLAT, 'utf8').digest();
+    expect(h.key.equals(expected)).toBe(true);
+  });
+
+  it('rejects invalid MAC', () => {
+    expect(() => new EufyAuthHandler('not-a-mac')).toThrow(/invalid MAC/);
+  });
+
+  it('generates a 15-char client uuid by default', () => {
+    const h = new EufyAuthHandler(TEST_MAC);
+    expect(h.clientUuid).toHaveLength(15);
+  });
+
+  it('builds C0 frames with correct header and XOR checksum', () => {
+    const h = new EufyAuthHandler(TEST_MAC, 'abcdef123456789');
+    const frames = h.buildC0();
+    expect(frames).toHaveLength(2);
+    // Each frame: C0 <numSegs=2> <segIdx> <totalBytes=24> <15 payload> <XOR>
+    expect(frames[0][0]).toBe(0xc0);
+    expect(frames[0][1]).toBe(0x02);
+    expect(frames[0][2]).toBe(0x00);
+    expect(frames[0][3]).toBe(0x18);
+    expect(frames[1][2]).toBe(0x01);
+    // XOR of all preceding bytes == last byte
+    for (const frame of frames) {
+      const body = frame.subarray(0, frame.length - 1);
+      let xor = 0;
+      for (const b of body) xor ^= b;
+      expect(frame[frame.length - 1]).toBe(xor);
+    }
+  });
+
+  it('completes full C0/C1/C2/C3 handshake', () => {
+    const h = new EufyAuthHandler(TEST_MAC, 'abcdef123456789');
+    const c0 = h.buildC0();
+    expect(c0.length).toBeGreaterThan(0);
+
+    // Scale responds with C1 carrying an AES-encrypted device UUID
+    const c1Frames = makeC1Frames(TEST_MAC, 'DEVICEUUID12345');
+    let c1Done = false;
+    for (const f of c1Frames) c1Done = h.handleC1(f) || c1Done;
+    expect(c1Done).toBe(true);
+    expect(h.deviceUuidOrNull).toBe('DEVICEUUID12345');
+
+    const c2 = h.buildC2();
+    expect(c2.length).toBeGreaterThan(0);
+    expect(c2[0][0]).toBe(0xc2);
+
+    const c3 = Buffer.from([0xc3, 0x01, 0x00, 0x01, 0x00, 0xc3]);
+    expect(h.handleC3(c3)).toBe(true);
+    expect(h.isAuthenticated).toBe(true);
+
+    const c3Fail = Buffer.from([0xc3, 0x01, 0x00, 0x01, 0x01, 0xc2]);
+    const h2 = new EufyAuthHandler(TEST_MAC);
+    h2.handleC3(c3Fail);
+    expect(h2.isAuthenticated).toBe(false);
+  });
+
+  it('buildC2 before C1 throws', () => {
+    const h = new EufyAuthHandler(TEST_MAC);
+    expect(() => h.buildC2()).toThrow(/before C1/);
+  });
+});
+
+describe('buildSubContract', () => {
+  it('fragments at 15 bytes of base64 ASCII per segment', () => {
+    // 44-char base64 -> 88 hex chars -> 3 segments (30+30+28)
+    const dataHex = Buffer.from('A'.repeat(44), 'ascii').toString('hex');
+    const frames = buildSubContract(dataHex, 0xc2);
+    expect(frames).toHaveLength(3);
+    expect(frames[0][1]).toBe(3);
+    expect(frames[0][3]).toBe(44);
+    expect(frames.map((f) => f[2])).toEqual([0, 1, 2]);
+  });
+
+  it('single-segment payload when short', () => {
+    const dataHex = Buffer.from('ABCDE', 'ascii').toString('hex');
+    const frames = buildSubContract(dataHex, 0xc0);
+    expect(frames).toHaveLength(1);
+    expect(frames[0][3]).toBe(5);
+  });
+});
+
+describe('parseWeightNotification', () => {
+  it('parses final weight + impedance', () => {
+    const buf = makeNotification(83.45, 543);
+    expect(parseWeightNotification(buf)).toEqual({ weight: 83.45, impedance: 543 });
+  });
+
+  it('returns null for non-final frame', () => {
+    expect(parseWeightNotification(makeNotification(83.45, 543, false))).toBeNull();
+  });
+
+  it('returns null for wrong signature bytes', () => {
+    const buf = makeNotification(83.45, 543);
+    buf[0] = 0xee;
+    expect(parseWeightNotification(buf)).toBeNull();
+  });
+
+  it('returns null for wrong length', () => {
+    expect(parseWeightNotification(Buffer.alloc(10))).toBeNull();
+  });
+
+  it('returns null for out-of-range weight', () => {
+    const buf = makeNotification(0.5, 400);
+    expect(parseWeightNotification(buf)).toBeNull();
+  });
+});
+
+describe('parseEufyAdvertisement', () => {
+  it('parses final weight from 19-byte vendor payload', () => {
+    const buf = makeVendor(75.2);
+    expect(parseEufyAdvertisement(buf)).toEqual({ weight: 75.2, impedance: 0 });
+  });
+
+  it('returns null when not final', () => {
+    expect(parseEufyAdvertisement(makeVendor(75.2, 0x02))).toBeNull();
+  });
+
+  it('returns null without 0xCF signature', () => {
+    const buf = makeVendor(75.2);
+    buf[6] = 0x00;
+    expect(parseEufyAdvertisement(buf)).toBeNull();
+  });
+});
+
+describe('EufyP2Adapter', () => {
+  it('matches by device name', () => {
+    const adapter = new EufyP2Adapter();
+    const p: BleDeviceInfo = { localName: 'eufy T9149', serviceUuids: [] };
+    expect(adapter.matches(p)).toBe(true);
+  });
+
+  it('matches T9148', () => {
+    const adapter = new EufyP2Adapter();
+    const p: BleDeviceInfo = { localName: 'eufy T9148', serviceUuids: [] };
+    expect(adapter.matches(p)).toBe(true);
+  });
+
+  it('matches passive via company ID 0xFF48 + 0xCF signature', () => {
+    const adapter = new EufyP2Adapter();
+    const p: BleDeviceInfo = {
+      localName: '',
+      serviceUuids: [],
+      manufacturerData: { id: 0xff48, data: makeVendor(80) },
+    };
+    expect(adapter.matches(p)).toBe(true);
+  });
+
+  it('does not match QN scale names', () => {
+    const adapter = new EufyP2Adapter();
+    const p: BleDeviceInfo = { localName: 'QN-Scale', serviceUuids: ['fff0'] };
+    expect(adapter.matches(p)).toBe(false);
+  });
+
+  it('parseBroadcast produces valid ScaleReading', () => {
+    const adapter = new EufyP2Adapter();
+    const reading = adapter.parseBroadcast!(makeVendor(72.5));
+    expect(reading).toEqual({ weight: 72.5, impedance: 0 });
+    expect(adapter.isComplete(reading!)).toBe(true);
+  });
+
+  it('computeMetrics returns a well-formed payload with BIA impedance', () => {
+    const adapter = new EufyP2Adapter();
+    const payload = adapter.computeMetrics({ weight: 83.45, impedance: 543 }, defaultProfile());
+    expect(payload.weight).toBe(83.45);
+    expect(payload.impedance).toBe(543);
+    assertPayloadRanges(payload);
+  });
+
+  it('computeMetrics without impedance falls back to Deurenberg BMI formula', () => {
+    const adapter = new EufyP2Adapter();
+    const payload = adapter.computeMetrics({ weight: 72.5, impedance: 0 }, defaultProfile());
+    expect(payload.impedance).toBe(0);
+    assertPayloadRanges(payload);
+  });
+});

--- a/tests/wizard/exporters-logic.test.ts
+++ b/tests/wizard/exporters-logic.test.ts
@@ -207,15 +207,47 @@ describe('exportersStep — confirm skip', () => {
     expect(ctx.config.global_exporters![0].type).toBe('webhook');
   });
 
-  it('returns early when no exporters selected', async () => {
+  it('returns early when user confirms proceeding with no exporters', async () => {
     const ctx = makeCtx([
       [], // unified checkbox: select nothing
+      true, // confirm: "Continue without exporters?" → Yes
     ]);
     ctx.config.users = [{ name: 'Test', slug: 'test' }];
 
     await exportersStep.run(ctx);
 
     expect(ctx.config.global_exporters).toBeUndefined();
+  });
+
+  it('re-prompts when user declines empty selection, accepts on second try', async () => {
+    const webhookSchema = EXPORTER_SCHEMAS.find((s) => s.name === 'webhook')!;
+
+    const answers: (string | number | boolean | string[])[] = [
+      [], // first checkbox: empty
+      false, // confirm: "Continue without exporters?" → No
+      ['webhook'], // second checkbox: webhook
+      true, // confirm: "Configure Webhook?" → Yes
+    ];
+    for (const field of webhookSchema.fields) {
+      if (field.type === 'string' || field.type === 'password') {
+        answers.push(field.default !== undefined ? String(field.default) : 'https://example.com');
+      } else if (field.type === 'number') {
+        answers.push(field.default !== undefined ? String(field.default) : '10000');
+      } else if (field.type === 'boolean') {
+        answers.push((field.default as boolean) ?? false);
+      } else if (field.type === 'select') {
+        answers.push(field.choices?.[0]?.value ?? 'POST');
+      }
+    }
+
+    const ctx = makeCtx(answers);
+    ctx.config.users = [{ name: 'Test', slug: 'test' }];
+
+    await exportersStep.run(ctx);
+
+    expect(ctx.config.global_exporters).toBeDefined();
+    expect(ctx.config.global_exporters!.length).toBe(1);
+    expect(ctx.config.global_exporters![0].type).toBe('webhook');
   });
 });
 


### PR DESCRIPTION
## Summary

- **Eufy Smart Scale P2 / P2 Pro (T9148 / T9149)** — new dedicated adapter with the AES-128-CBC C0/C1/C2/C3 handshake these models require. Weight + impedance over GATT FFF2 after auth; passive weight reading from the 19-byte advertisement without connecting. Ported from [bdr99/eufylife-ble-client](https://github.com/bdr99/eufylife-ble-client). Reported and tested in #98 by @mart1058 and @dbrb2.
- **GATT enumeration retry** for the BlueZ `ServicesResolved=true` race that occasionally hid FFF2 on first discovery. Up to 3 retries with 500 ms backoff before surfacing "Characteristic not found".
- **Wizard + orchestrator guard** for empty exporter configs. If the setup wizard checkbox is submitted with nothing ticked, it now asks an explicit `Continue without exporters?` confirmation and re-prompts on decline. The orchestrator short-circuits `dispatchExports([])` with a clear warning instead of the misleading `All exports failed` + exit code 1. This was reported by @dbrb2 on #98.

Adapter count now **24**; docs and the landing-page logo easter egg updated accordingly.

## Test plan

- [x] `npm run lint` clean
- [x] `npx prettier --check "src/**/*.ts" "tests/**/*.ts"` clean
- [x] `npm test` — 1188 tests passing across 61 files
- [x] CI on dev: typecheck-and-test (20), typecheck-and-test (22), typecheck-and-test (24), python-check
- [x] On-device: @dbrb2 / @mart1058 to confirm Eufy P2 Pro works end-to-end on ESP32 proxy and native BlueZ after the GATT retry fix
- [x] HA Add-on builds with new version `1.9.0`

## Fixes

Closes #98 (Eufy P2 Pro adapter, wizard empty-exporter guard).