### PR TITLE
Release v1.10.1: ESPHome proxy warn fix + runtime.debug wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.10.1] - 2026-04-22
+
+### Fixed
+- **ESPHome proxy**: the `ReadingWatcher` silently dropped advertisements from dual-mode scale adapters (`parseBroadcast` defined **and** `charNotifyUuid` set) when the broadcast frame was not weight-bearing. Reported by [@deadhurricane](https://github.com/deadhurricane) on an Elis 1 / ES-30M, which matches by name as a QN-Scale but only beacons its MAC in manufacturer data and carries weight over GATT. The handler now warns once per MAC that the scale needs a GATT connection (Phase 2), pointing the user at the native BLE handler or the ESP32 MQTT proxy as workarounds instead of leaving them staring at a silent log ([#116](https://github.com/KristianP26/ble-scale-sync/issues/116), [#75](https://github.com/KristianP26/ble-scale-sync/issues/75))
+- **Logger**: `runtime.debug: true` in `config.yaml` did not switch the log level to DEBUG, only the `DEBUG=true` env var did. The app now honors the config value on startup, so HA Add-on users (who pass `debug` as an option, not an env var) and anyone driving the runtime from `config.yaml` get the verbose BLE logs they expect
+
 ## [1.10.0] - 2026-04-22
 
 ### Added

--- a/ble-scale-sync-addon/config.yaml
+++ b/ble-scale-sync-addon/config.yaml
@@ -1,5 +1,5 @@
 name: BLE Scale Sync
-version: "1.10.0"
+version: "1.10.1"
 slug: ble-scale-sync
 description: Read BLE smart scales and export to Garmin Connect, MQTT (HA auto-discovery), InfluxDB, and more
 url: https://github.com/KristianP26/ble-scale-sync

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,9 +9,19 @@ All notable changes to this project are documented here. Format based on [Keep a
 
 ## Unreleased {#unreleased}
 
-## v1.10.0 <Badge type="tip" text="latest" /> {#v1-10-0}
+## v1.10.1 <Badge type="tip" text="latest" /> {#v1-10-1}
 
 _2026-04-22_
+
+### Fixed
+- **ESPHome proxy**: the `ReadingWatcher` silently dropped advertisements from dual-mode scale adapters (`parseBroadcast` defined **and** `charNotifyUuid` set) when the broadcast frame was not weight-bearing. Reported on an Elis 1 / ES-30M, which matches by name as a QN-Scale but only beacons its MAC in manufacturer data and carries weight over GATT. The handler now warns once per MAC that the scale needs a GATT connection (Phase 2), pointing at the native BLE handler or the ESP32 MQTT proxy as workarounds ([#116](https://github.com/KristianP26/ble-scale-sync/issues/116), [#75](https://github.com/KristianP26/ble-scale-sync/issues/75))
+- **Logger**: `runtime.debug: true` in `config.yaml` did not switch the log level to DEBUG, only the `DEBUG=true` env var did. The app now honors the config value on startup, so HA Add-on users and anyone driving the runtime from `config.yaml` get the verbose BLE logs they expect
+
+## v1.10.0 {#v1-10-0}
+
+_2026-04-22_
+
+_Note: released the same day as v1.10.1 above._
 
 ### Added
 - **Embedded MQTT broker for the ESP32 proxy**: zero-config setup, no Mosquitto required. When `ble.mqtt_proxy.broker_url` is omitted, BLE Scale Sync now starts an embedded [aedes](https://github.com/moscajs/aedes) broker on `0.0.0.0:1883` by default; the internal client connects over loopback, and the ESP32 firmware just points at the host machine's LAN IP. Port and bind interface are configurable via `embedded_broker_port` and `embedded_broker_bind`, and optional username/password are enforced when set. Existing `broker_url` setups are untouched ([#54](https://github.com/KristianP26/ble-scale-sync/issues/54))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ble-scale-sync",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ble-scale-sync",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@2colors/esphome-native-api": "^1.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ble-scale-sync",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Universal BLE Smart Scale bridge. Captures body composition from Renpho, Xiaomi & 20+ others, syncs to Garmin Connect, Strava, MQTT (Home Assistant), InfluxDB, Webhooks, Ntfy & local files. Headless CLI for Raspberry Pi, Linux, macOS & Windows.",
   "type": "module",
   "main": "src/index.ts",

--- a/src/ble/handler-esphome-proxy.ts
+++ b/src/ble/handler-esphome-proxy.ts
@@ -475,25 +475,33 @@ export class ReadingWatcher {
       }
     }
 
-    // GATT-only adapter matched; Phase 1 cannot service it. Log once and skip.
-    if (adapter.charNotifyUuid && !adapter.parseBroadcast) {
-      if (this.gattWarnedFor.has(address)) {
-        // Refresh recency so the entry survives LRU eviction.
-        this.gattWarnedFor.delete(address);
-        this.gattWarnedFor.set(address, true);
-        return;
-      }
-      if (this.gattWarnedFor.size >= GATT_WARN_LRU_MAX) {
-        const oldest = this.gattWarnedFor.keys().next().value;
-        if (oldest !== undefined) this.gattWarnedFor.delete(oldest);
-      }
-      this.gattWarnedFor.set(address, true);
-      bleLog.warn(
-        `${adapter.name} at ${address} requires GATT, which the ESPHome proxy transport ` +
-          `does not yet support (Phase 1 is broadcast-only). Measurements from this scale ` +
-          `are skipped.`,
-      );
+    // Adapter matched but no usable broadcast frame came out. If the adapter
+    // supports GATT, Phase 1 cannot read this scale (firmware is either pure
+    // GATT or the broadcast format is not weight-bearing, e.g. QN Elis 1 /
+    // ES-30M which broadcasts only a MAC beacon). Warn once per address so
+    // the user knows they are hitting the Phase 2 gap instead of a silent drop.
+    if (adapter.charNotifyUuid) {
+      this.warnGattNotSupported(adapter.name, address);
     }
+  }
+
+  private warnGattNotSupported(adapterName: string, address: string): void {
+    if (this.gattWarnedFor.has(address)) {
+      // Refresh recency so the entry survives LRU eviction.
+      this.gattWarnedFor.delete(address);
+      this.gattWarnedFor.set(address, true);
+      return;
+    }
+    if (this.gattWarnedFor.size >= GATT_WARN_LRU_MAX) {
+      const oldest = this.gattWarnedFor.keys().next().value;
+      if (oldest !== undefined) this.gattWarnedFor.delete(oldest);
+    }
+    this.gattWarnedFor.set(address, true);
+    bleLog.warn(
+      `${adapterName} at ${address} needs a GATT connection for weight data, which the ` +
+        `ESPHome proxy transport does not yet support (Phase 1 is broadcast-only). ` +
+        `Use the native BLE handler or the ESP32 MQTT proxy for this scale until Phase 2 lands.`,
+    );
   }
 
   private pruneDedup(now: number): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { bootstrapMqttProxy } from './ble/mqtt-proxy-bootstrap.js';
 import type { EmbeddedBrokerHandle } from './ble/embedded-broker.js';
 import { abortableSleep } from './ble/types.js';
 import { adapters } from './scales/index.js';
-import { createLogger } from './logger.js';
+import { createLogger, setLogLevel, LogLevel } from './logger.js';
 import { errMsg } from './utils/error.js';
 import { createExporterFromEntry } from './exporters/registry.js';
 import { runHealthchecks, dispatchExports } from './orchestrator.js';
@@ -68,6 +68,8 @@ const loaded = loadAppConfig(cliFlags.config as string | undefined);
 let appConfig = loaded.config;
 const configSource = loaded.source;
 const configPath = loaded.configPath;
+
+if (appConfig.runtime?.debug) setLogLevel(LogLevel.DEBUG);
 
 const {
   scaleMac: SCALE_MAC,

--- a/tests/ble/handler-esphome-proxy.test.ts
+++ b/tests/ble/handler-esphome-proxy.test.ts
@@ -110,6 +110,29 @@ function makeGattOnlyAdapter(): ScaleAdapter {
   } as unknown as ScaleAdapter;
 }
 
+/**
+ * Dual-mode adapter: parseBroadcast is defined but returns null for this frame
+ * (e.g. QN Elis 1 / ES-30M beacon). charNotifyUuid is set, so the handler
+ * should emit the Phase 2 GATT warning instead of silently dropping.
+ */
+function makeDualModeAdapter(): ScaleAdapter {
+  return {
+    name: 'MockDualMode',
+    matches: vi.fn((info: BleDeviceInfo) => info.localName === 'DualMode-scale'),
+    parseBroadcast: vi.fn((): ScaleReading | null => null) as ScaleAdapter['parseBroadcast'],
+    isComplete: (r: ScaleReading): boolean => r.weight > 0,
+    computeMetrics: (r: ScaleReading): BodyComposition => ({
+      weight: r.weight,
+      impedance: r.impedance,
+    }),
+    parseNotification: () => null,
+    charNotifyUuid: '0000fff1-0000-1000-8000-00805f9b34fb',
+    charWriteUuid: '0000fff2-0000-1000-8000-00805f9b34fb',
+    unlockCommand: [],
+    unlockIntervalMs: 0,
+  } as unknown as ScaleAdapter;
+}
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('_internals.formatMacAddress', () => {
@@ -375,6 +398,39 @@ describe('ReadingWatcher', () => {
     const reading = await watcher.nextReading();
     expect(reading.adapter.name).toBe('MockBroadcast');
     expect(reading.reading.weight).toBe(75.5);
+    await watcher.stop();
+  });
+
+  it('warns once per address when a dual-mode adapter matches but the broadcast frame is not weight-bearing (e.g. Elis 1 MAC beacon)', async () => {
+    const adapter = makeDualModeAdapter();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { ReadingWatcher } = await import('../../src/ble/handler-esphome-proxy.js');
+    const watcher = new ReadingWatcher(config, [adapter]);
+
+    const startPromise = watcher.start();
+    await mockClient.waitForListener('ble');
+    await startPromise;
+
+    // Push two ads from the same scale. Second should not re-warn (LRU-deduped).
+    const ad = {
+      address: 0xff04002255_0f,
+      name: 'DualMode-scale',
+      rssi: -60,
+      manufacturerDataList: [
+        { uuid: '0xffff', legacyDataList: [0x0c, 0xcb, 0x01, 0x00], data: '' },
+      ],
+    };
+    mockClient.pushBle(ad);
+    mockClient.pushBle(ad);
+
+    const gattWarn = warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((s) => /Phase 1 is broadcast-only/i.test(s));
+    expect(gattWarn.length).toBe(1);
+    expect(gattWarn[0]).toMatch(/MockDualMode/);
+    expect(gattWarn[0]).toMatch(/GATT/);
+
+    warnSpy.mockRestore();
     await watcher.stop();
   });
 


### PR DESCRIPTION
## Summary

Patch release on top of v1.10.0. Two fixes driven by @deadhurricane's Phase 1 test report on #116.

### ESPHome proxy: warn instead of silently dropping dual-mode scales

The `ReadingWatcher` only emitted the Phase 1 GATT warning when a matched adapter had `charNotifyUuid` set **and** no `parseBroadcast`. The QN-Scale adapter has both (its `parseBroadcast` returns null for non-AABB firmware), so an Elis 1 / ES-30M matched by name, produced no broadcast reading, and was dropped without a single info/warn line.

The handler now warns once per MAC (LRU-deduped) whenever a matched adapter has a GATT path and produced no usable broadcast, pointing the user at the native BLE handler or the ESP32 MQTT proxy until Phase 2 lands. Covers every dual-mode adapter, not just QN. See #75 for the Elis 1 GATT handshake Phase 2 will need to port to the ESPHome Native API.

### Logger: honor `runtime.debug: true` from config

Setting `debug: true` under `runtime:` in `config.yaml` did not raise the log level — only `DEBUG=true` as an env var did. HA Add-on users who passed `debug` as an option saw no verbose BLE logs. `index.ts` now calls `setLogLevel(DEBUG)` when `appConfig.runtime?.debug` is truthy, at startup, alongside the existing env-var path.

## Changes

- `src/ble/handler-esphome-proxy.ts` — `warnGattNotSupported()` helper, called from `handleAd` whenever a matched adapter has `charNotifyUuid` and no broadcast reading surfaced. Existing LRU dedup map reused (`GATT_WARN_LRU_MAX = 256`).
- `src/index.ts` — `setLogLevel(LogLevel.DEBUG)` on `appConfig.runtime?.debug`.
- `tests/ble/handler-esphome-proxy.test.ts` — new `makeDualModeAdapter()` helper and regression test ensuring the Phase 2 warning fires once per address for dual-mode adapters that produce no broadcast reading.
- Release bookkeeping: `package.json`, `package-lock.json`, `ble-scale-sync-addon/config.yaml`, `CHANGELOG.md`, `docs/changelog.md`.

## Test plan

- [x] `npm test` — 1243 passed (64 files), including the new dual-mode warning regression test
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [ ] Manual: run v1.10.1 with an Elis 1 behind an ESPHome BT proxy — expect `QN Scale at FF:04:... needs a GATT connection ...` warning once per address in continuous mode
- [ ] Manual: run with `runtime.debug: true` in `config.yaml` and no `DEBUG` env var — expect `[BLE:debug]` lines in the output
