### PR TITLE
Release v1.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- **ESPHome proxy**: the handler now logs a one-time Phase 1 capability summary on connect, listing which configured scale adapters are broadcast-capable (produce readings on this transport) and which are GATT-only (will time out until Phase 2 / [#116](https://github.com/KristianP26/ble-scale-sync/issues/116) ships). Users who were only seeing the generic `Timed out waiting for any recognized scale broadcast via ESPHome proxy` line now immediately see whether their scale brand is in the broadcast-capable set, instead of having to reproduce the failure twice to catch the per-MAC warn. Surfaces the Yunmai / Beurer / Mi Scale 2 / etc. mismatch reported in [#133](https://github.com/KristianP26/ble-scale-sync/issues/133)
+
 ## [1.10.1] - 2026-04-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.10.2] - 2026-04-24
+
+### Fixed
+- **Renpho ES-26M**: the 18-byte `0x12` scale-info frame (where byte[1] is the packet length and bytes [2-7] carry the device MAC) was being misread as "byte[2] is the protocol type", yielding `proto=0xFF` and causing every subsequent handshake command to be rejected by the scale. No `0x10` weight frames were ever returned. The QN-Scale adapter now detects the long-frame format (`data.length >= 18 && data[1] === length`) and falls through to the ES-30M code path with `weightScaleFactor=10`, so the existing heuristic auto-corrects the weight divisor. The unconditional skip of `R1=R2=0` stable frames in ES-30M mode is also lifted: the ES-26M never reports impedance when the user is wearing socks, and those frames are the only stable reading available in that scenario. Contributed by [@fromport](https://github.com/fromport) ([#128](https://github.com/KristianP26/ble-scale-sync/pull/128))
+
 ### Changed
-- **ESPHome proxy**: the handler now logs a one-time Phase 1 capability summary on connect, listing which configured scale adapters are broadcast-capable (produce readings on this transport) and which are GATT-only (will time out until Phase 2 / [#116](https://github.com/KristianP26/ble-scale-sync/issues/116) ships). Users who were only seeing the generic `Timed out waiting for any recognized scale broadcast via ESPHome proxy` line now immediately see whether their scale brand is in the broadcast-capable set, instead of having to reproduce the failure twice to catch the per-MAC warn. Surfaces the Yunmai / Beurer / Mi Scale 2 / etc. mismatch reported in [#133](https://github.com/KristianP26/ble-scale-sync/issues/133)
+- **ESPHome proxy**: the handler now logs a one-time Phase 1 capability summary on connect, listing which configured scale adapters are broadcast-capable (produce readings on this transport) and which are GATT-only (will time out until Phase 2 / [#116](https://github.com/KristianP26/ble-scale-sync/issues/116) ships). Users who were only seeing the generic `Timed out waiting for any recognized scale broadcast via ESPHome proxy` line now immediately see whether their scale brand is in the broadcast-capable set, instead of having to reproduce the failure twice to catch the per-MAC warn. Surfaces the Yunmai / Beurer / Mi Scale 2 / etc. mismatch reported by [@geniusliang](https://github.com/geniusliang) in [#133](https://github.com/KristianP26/ble-scale-sync/issues/133)
+
+### Docs
+- **CONTRIBUTING.md**: project structure tree refreshed to match the current layout (HA add-on, ESPHome proxy handler, updated scale/test files)
+- **README**: contributors migrated to a GitHub-style table with inline avatars, [@fromport](https://github.com/fromport) added for the ES-26M contribution
+
+### Thanks
+- [@fromport](https://github.com/fromport) for diagnosing and fixing the ES-26M handshake end to end, including the heuristic weight-divisor path
+- [@geniusliang](https://github.com/geniusliang) for the detailed ESPHome proxy repro that led to the capability-summary UX improvement
 
 ## [1.10.1] - 2026-04-22
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,124 +83,166 @@ Both ESLint and Prettier are enforced in CI.
 ble-scale-sync/
 ├── .github/
 │   └── workflows/
-│       ├── ci.yml                  # CI: lint, format, typecheck, tests (Node 20/22)
-│       └── docker.yml              # Docker: multi-arch build + GHCR push on release
+│       ├── ci.yml                   # CI: lint, format, typecheck, tests (Node 20/22/24), python-check
+│       ├── docker.yml               # Docker: multi-arch build + GHCR push on release
+│       ├── docker-cleanup.yml       # Prune old GHCR image tags
+│       ├── docs.yml                 # VitePress docs deploy to Cloudflare Pages
+│       └── worker.yml               # Deploy stats Cloudflare Worker
 ├── src/
-│   ├── index.ts                    # Entry point (single/multi-user flow, SIGHUP reload, heartbeat)
-│   ├── orchestrator.ts             # Exported orchestration logic (healthchecks, export dispatch)
+│   ├── index.ts                     # Entry point (single/multi-user flow, SIGHUP reload, heartbeat)
+│   ├── orchestrator.ts              # Export dispatch, healthchecks, partial/total failure handling
+│   ├── diagnose.ts                  # npm run diagnose (BLE troubleshooting tool)
+│   ├── scan.ts                      # BLE device scanner utility (npm run scan)
+│   ├── logger.ts                    # createLogger, setLogLevel (structured logging)
+│   ├── update-check.ts              # Optional anonymous version check + stats ping
+│   ├── validate-env.ts              # .env validation & typed config loader (legacy path)
 │   ├── config/
-│   │   ├── schema.ts               # Zod schemas (AppConfig, UserConfig, etc.) + WeightUnit
-│   │   ├── load.ts                 # Unified config loader (YAML + .env fallback)
-│   │   ├── resolve.ts              # Config → runtime types (UserProfile, exporters, etc.)
-│   │   ├── validate-cli.ts         # CLI entry point for npm run validate
-│   │   ├── slugify.ts              # Slug generation + uniqueness validation
-│   │   ├── user-matching.ts        # Weight-based multi-user matching (4-tier)
-│   │   └── write.ts                # Atomic YAML write + debounced weight updates
+│   │   ├── schema.ts                # Zod schemas (AppConfig, UserConfig) + WeightUnit
+│   │   ├── load.ts                  # Unified config loader (YAML + .env fallback)
+│   │   ├── resolve.ts               # Config → runtime types (UserProfile, exporters)
+│   │   ├── validate-cli.ts          # CLI entry for npm run validate
+│   │   ├── slugify.ts               # Slug generation + uniqueness validation
+│   │   ├── user-matching.ts         # Weight-based multi-user matching (4-tier)
+│   │   └── write.ts                 # Atomic YAML write + debounced weight updates
 │   ├── ble/
-│   │   ├── index.ts                # OS detection + dynamic import barrel (scanAndRead, scanAndReadRaw)
-│   │   ├── types.ts                # ScanOptions, ScanResult, constants, utilities
-│   │   ├── shared.ts               # BleChar/BleDevice abstractions, waitForRawReading(), waitForReading()
-│   │   ├── handler-node-ble.ts     # Linux: node-ble (BlueZ D-Bus)
-│   │   ├── handler-noble.ts        # macOS default: @stoprocent/noble
-│   │   └── handler-noble-legacy.ts # Windows default: @abandonware/noble
+│   │   ├── index.ts                 # OS detection + handler barrel (scanAndRead, scanAndReadRaw)
+│   │   ├── types.ts                 # ScanOptions, ScanResult, constants, utilities
+│   │   ├── shared.ts                # BleChar/BleDevice abstractions, waitForReading()
+│   │   ├── async-queue.ts           # Async notification queue for GATT handlers
+│   │   ├── loopback.ts              # In-process loopback handler (tests)
+│   │   ├── handler-node-ble.ts      # Linux native: node-ble (BlueZ D-Bus)
+│   │   ├── handler-noble.ts         # macOS native: @stoprocent/noble
+│   │   ├── handler-noble-legacy.ts  # Windows native: @abandonware/noble
+│   │   ├── handler-mqtt-proxy.ts    # ESP32 proxy over MQTT
+│   │   ├── handler-esphome-proxy.ts # ESPHome BT proxy over Native API (phase 1, broadcast)
+│   │   ├── embedded-broker.ts       # Embedded aedes MQTT broker for ESP32 proxy
+│   │   └── mqtt-proxy-bootstrap.ts  # First-run scan + adapter pin for ESP32 proxy
 │   ├── exporters/
-│   │   ├── index.ts                # Exporter factory — createExporters()
-│   │   ├── registry.ts             # Self-describing exporter registry (schemas + factories)
-│   │   ├── config.ts               # Exporter env validation + config parsing
-│   │   ├── garmin.ts               # Garmin Connect exporter (Python subprocess)
-│   │   ├── mqtt.ts                 # MQTT exporter + Home Assistant auto-discovery
-│   │   ├── webhook.ts              # Webhook exporter (generic HTTP)
-│   │   ├── influxdb.ts             # InfluxDB v2 exporter (line protocol)
-│   │   └── ntfy.ts                 # Ntfy push notification exporter
+│   │   ├── index.ts                 # Exporter factory — createExporters()
+│   │   ├── registry.ts              # Self-describing exporter registry (schemas + factories)
+│   │   ├── config.ts                # Exporter env validation + config parsing
+│   │   ├── garmin.ts                # Garmin Connect (Python subprocess)
+│   │   ├── strava.ts                # Strava OAuth2 (per-user only)
+│   │   ├── strava-setup.ts          # One-time Strava OAuth (npm run setup-strava)
+│   │   ├── mqtt.ts                  # MQTT + Home Assistant auto-discovery
+│   │   ├── webhook.ts               # Generic HTTP webhook
+│   │   ├── influxdb.ts              # InfluxDB v2 (line protocol)
+│   │   ├── ntfy.ts                  # Ntfy push notifications
+│   │   └── file.ts                  # Local file exporter (CSV / JSONL)
 │   ├── wizard/
-│   │   ├── index.ts                # Entry point for npm run setup
-│   │   ├── types.ts                # WizardStep, WizardContext, PromptProvider, BackNavigation
-│   │   ├── runner.ts               # Step sequencer (sequential + edit mode)
-│   │   ├── non-interactive.ts      # Non-interactive validation + slug enrichment
-│   │   ├── platform.ts             # OS/Docker/Python detection
-│   │   ├── prompt-provider.ts      # Real + mock prompt providers (DI)
-│   │   ├── ui.ts                   # Banner, icons, section boxes, chalk helpers
+│   │   ├── index.ts                 # Entry for npm run setup
+│   │   ├── types.ts                 # WizardStep, WizardContext, PromptProvider
+│   │   ├── runner.ts                # Step sequencer (sequential + edit mode)
+│   │   ├── non-interactive.ts       # Non-interactive validation + slug enrichment
+│   │   ├── platform.ts              # OS/Docker/Python detection
+│   │   ├── prompt-provider.ts       # Real + mock prompt providers (DI)
+│   │   ├── ui.ts                    # Banner, icons, section boxes, chalk helpers
 │   │   └── steps/
-│   │       ├── index.ts            # Step registry (WIZARD_STEPS)
-│   │       ├── welcome.ts          # Banner + edit mode detection
-│   │       ├── ble.ts              # BLE scale discovery / manual MAC entry
-│   │       ├── users.ts            # User profile setup (name, slug, height, etc.)
-│   │       ├── exporters.ts        # Unified exporter selection (schema-driven prompts)
-│   │       ├── garmin-auth.ts      # Garmin Connect authentication
-│   │       ├── runtime.ts          # Runtime settings (continuous, cooldown, etc.)
-│   │       ├── validate.ts         # Exporter connectivity tests
-│   │       └── summary.ts          # Config review + YAML save
+│   │       ├── index.ts             # Step registry (WIZARD_STEPS)
+│   │       ├── welcome.ts           # Banner + edit mode detection
+│   │       ├── ble.ts               # BLE scale discovery / manual MAC entry
+│   │       ├── users.ts             # User profile setup
+│   │       ├── exporters.ts         # Schema-driven exporter selection
+│   │       ├── garmin-auth.ts       # Garmin Connect authentication
+│   │       ├── runtime.ts           # Runtime settings (continuous, cooldown)
+│   │       ├── validate.ts          # Exporter connectivity tests
+│   │       └── summary.ts           # Config review + YAML save
 │   ├── utils/
-│   │   ├── retry.ts                # Shared retry utility (withRetry) used by all exporters
-│   │   └── error.ts                # Shared error utility (errMsg) for unknown→string conversion
-│   ├── validate-env.ts             # .env validation & typed config loader (legacy)
-│   ├── scan.ts                     # BLE device scanner utility
+│   │   ├── retry.ts                 # Shared retry utility (withRetry)
+│   │   └── error.ts                 # errMsg (unknown → string)
 │   ├── interfaces/
-│   │   ├── scale-adapter.ts        # ScaleAdapter interface & shared types
-│   │   ├── exporter.ts             # Exporter interface & ExportResult type
-│   │   └── exporter-schema.ts      # ExporterSchema interface for self-describing exporters
+│   │   ├── scale-adapter.ts         # ScaleAdapter interface & shared types
+│   │   ├── exporter.ts              # Exporter interface & ExportResult
+│   │   └── exporter-schema.ts       # ExporterSchema for self-describing exporters
 │   └── scales/
-│       ├── index.ts                # Adapter registry (all adapters)
-│       ├── body-comp-helpers.ts    # Shared body-comp utilities
-│       ├── qn-scale.ts             # QN-Scale / Renpho / Senssun / Sencor
-│       ├── renpho.ts               # Renpho ES-WBE28
-│       ├── renpho-es26bb.ts        # Renpho ES-26BB-B
-│       ├── mi-scale-2.ts           # Xiaomi Mi Scale 2
-│       ├── yunmai.ts               # Yunmai Signal / Mini / SE
-│       ├── beurer-sanitas.ts       # Beurer BF700/710/800, Sanitas SBF70/75
-│       ├── sanitas-sbf72.ts        # Sanitas SBF72/73, Beurer BF915
-│       ├── soehnle.ts              # Soehnle Shape / Style
-│       ├── medisana-bs44x.ts       # Medisana BS430/440/444
-│       ├── trisa.ts                # Trisa Body Analyze
-│       ├── es-cs20m.ts             # ES-CS20M
-│       ├── exingtech-y1.ts         # Exingtech Y1 (vscale)
-│       ├── excelvan-cf369.ts       # Excelvan CF369
-│       ├── hesley.ts               # Hesley (YunChen)
-│       ├── inlife.ts               # Inlife (fatscale)
-│       ├── digoo.ts                # Digoo DG-SO38H (Mengii)
-│       ├── senssun.ts              # Senssun Fat
-│       ├── one-byone.ts            # 1byone / Eufy C1 / Eufy P1
-│       ├── active-era.ts           # Active Era BF-06
-│       ├── mgb.ts                  # MGB (Swan / Icomon / YG)
-│       ├── hoffen.ts               # Hoffen BS-8107
-│       └── standard-gatt.ts        # Generic BCS/WSS catch-all
+│       ├── index.ts                 # Adapter registry (order matters — generic last)
+│       ├── body-comp-helpers.ts     # Shared body-comp utilities
+│       ├── qn-scale.ts              # QN / Renpho (incl. ES-26M, ES-30M) / Senssun / Sencor
+│       ├── renpho.ts                # Renpho ES-WBE28
+│       ├── renpho-es26bb.ts         # Renpho ES-26BB-B
+│       ├── mi-scale-2.ts            # Xiaomi Mi Scale 2
+│       ├── yunmai.ts                # Yunmai Signal / Mini / SE
+│       ├── eufy-p2.ts               # Eufy P2 / P2 Pro (T9148/T9149, AES-128 handshake)
+│       ├── beurer-sanitas.ts        # Beurer BF700/710/800, Sanitas SBF70/75
+│       ├── sanitas-sbf72.ts         # Sanitas SBF72/73, Beurer BF915
+│       ├── soehnle.ts               # Soehnle Shape / Style
+│       ├── medisana-bs44x.ts        # Medisana BS430/440/444
+│       ├── trisa.ts                 # Trisa Body Analyze
+│       ├── es-cs20m.ts              # ES-CS20M
+│       ├── exingtech-y1.ts          # Exingtech Y1 (vscale)
+│       ├── excelvan-cf369.ts        # Excelvan CF369
+│       ├── hesley.ts                # Hesley (YunChen)
+│       ├── inlife.ts                # Inlife (fatscale)
+│       ├── digoo.ts                 # Digoo DG-SO38H (Mengii)
+│       ├── senssun.ts               # Senssun Fat
+│       ├── one-byone.ts             # 1byone / Eufy C1 / Eufy P1
+│       ├── active-era.ts            # Active Era BF-06
+│       ├── mgb.ts                   # MGB (Swan / Icomon / YG)
+│       ├── hoffen.ts                # Hoffen BS-8107
+│       └── standard-gatt.ts         # Generic BCS/WSS catch-all
 ├── tests/
-│   ├── body-comp-helpers.test.ts   # Body-comp helper unit tests
-│   ├── validate-env.test.ts        # .env validation unit tests
-│   ├── orchestrator.test.ts        # Healthcheck + export dispatch tests
-│   ├── multi-user-flow.test.ts     # Multi-user integration tests
-│   ├── logger.test.ts              # Logger utility tests
+│   ├── body-comp-helpers.test.ts    # Body-comp math
+│   ├── validate-env.test.ts         # .env validation
+│   ├── orchestrator.test.ts         # Healthchecks + export dispatch
+│   ├── multi-user-flow.test.ts      # Multi-user integration
+│   ├── logger.test.ts               # Logger utility
+│   ├── update-check.test.ts         # Update check + stats ping
 │   ├── helpers/
-│   │   └── scale-test-utils.ts     # Shared test utilities (mock peripheral, etc.)
-│   ├── wizard/                     # Wizard tests (runner, users, exporters, non-interactive, platform)
-│   ├── config/                     # Config tests (schema, slugify, load, resolve, write, matching)
-│   ├── ble/                        # BLE tests (shared logic, utilities, abort signal)
-│   ├── utils/                      # Utility tests (retry, error)
-│   ├── scales/                     # One test file per adapter (23 files)
-│   └── exporters/                  # Exporter tests (config, garmin, mqtt, webhook, influxdb, ntfy, context)
+│   │   └── scale-test-utils.ts      # Mock peripheral + shared helpers
+│   ├── wizard/                      # Runner, users, exporters, non-interactive, platform
+│   ├── config/                      # Schema, slugify, load, resolve, write, matching
+│   ├── ble/                         # Shared logic, utilities, handlers, abort signal
+│   ├── utils/                       # Retry, error
+│   ├── scales/                      # One file per adapter (23 files)
+│   └── exporters/                   # config, garmin, mqtt (+multi-user), webhook, influxdb,
+│                                    # ntfy, strava, file, context, healthcheck, registry, index
+├── ble-scale-sync-addon/            # Home Assistant Supervisor Add-on
+│   ├── Dockerfile                   # Thin layer on GHCR image + jq/curl/run.sh
+│   ├── build.yaml                   # Multi-arch build config
+│   ├── config.yaml                  # Add-on manifest (options schema, HA services, perms)
+│   ├── run.sh                       # /data/options.json → config.yaml → app start
+│   ├── merge_last_weights.py        # Persist last_known_weight across restarts
+│   ├── DOCS.md                      # Add-on user docs (shown in HA UI)
+│   ├── CHANGELOG.md                 # Add-on version history
+│   ├── icon.png, logo.png
+│   └── translations/
+├── firmware/                        # ESP32 BLE proxy firmware (MicroPython)
+│   ├── main.py, boot.py, ble_bridge.py
+│   ├── board_*.py                   # Per-board pin/display setup (Atom Echo, S3, Guition)
+│   ├── ui.py, beep.py, panel_init_*.py
+│   ├── flash.sh                     # Board flashing helper
+│   ├── requirements.txt, config.json.example
+│   └── tools/
+├── worker/                          # Cloudflare Worker for stats.blescalesync.dev
+│   ├── src/, wrangler.toml, package.json, tsconfig.json
 ├── garmin-scripts/
-│   ├── garmin_upload.py            # Garmin uploader (JSON stdin → JSON stdout)
-│   └── setup_garmin.py             # One-time Garmin auth setup
-├── docs/
-│   ├── exporters.md                # Exporter configuration reference
-│   ├── multi-user.md               # Multi-user weight matching guide
-│   ├── body-composition.md         # Body composition metrics & formulas
-│   └── troubleshooting.md          # Common issues & solutions
-├── config.yaml.example             # Annotated config template (copy to config.yaml)
-├── CONTRIBUTING.md                 # This file
-├── CHANGELOG.md                    # Version history (Keep a Changelog format)
-├── .env.example                    # Legacy .env template (config.yaml preferred)
-├── .prettierrc                     # Prettier config
-├── eslint.config.js                # ESLint flat config
-├── tsconfig.json                   # TypeScript config (src)
-├── tsconfig.eslint.json            # TypeScript config (src + tests, for ESLint)
-├── Dockerfile                      # Multi-arch Docker image (node:20-slim + BlueZ + Python)
-├── docker-entrypoint.sh            # Docker entrypoint (start/setup/scan/validate/help)
-├── docker-compose.example.yml      # Example Compose file (host network + BLE)
-├── .dockerignore
-├── .gitignore
-├── package.json
-├── requirements.txt
+│   ├── garmin_upload.py             # Garmin uploader (JSON stdin → JSON stdout)
+│   └── setup_garmin.py              # One-time Garmin auth setup
+├── docs/                            # VitePress site → blescalesync.dev
+│   ├── index.md, exporters.md, multi-user.md, body-composition.md
+│   ├── troubleshooting.md, changelog.md, alternatives.md, faq.md
+│   ├── guide/
+│   │   ├── getting-started.md, configuration.md, supported-scales.md
+│   │   ├── home-assistant-addon.md, esp32-proxy.md, esphome-proxy.md
+│   │   └── auto-update.md
+│   └── public/, images/
+├── drivers/                         # Bundled vendor BLE drivers / helper binaries
+├── repository.yaml                  # HA add-on repository manifest (one-click install)
+├── config.yaml.example              # Annotated config template
+├── docker-compose.example.yml       # Example Compose (native BLE)
+├── docker-compose.mqtt-proxy.yml    # Example Compose (ESP32 MQTT proxy)
+├── Dockerfile                       # Multi-arch image (node:20-slim + BlueZ + Python)
+├── docker-entrypoint.sh             # Docker entrypoint (start/setup/scan/validate/help)
+├── CONTRIBUTING.md                  # This file
+├── CHANGELOG.md                     # Version history (Keep a Changelog format)
+├── CODE_OF_CONDUCT.md
+├── SECURITY.md
+├── PORTING.md                       # Notes for porting adapters from openScale
+├── .env.example                     # Legacy .env template (config.yaml preferred)
+├── .prettierrc, eslint.config.js
+├── tsconfig.json, tsconfig.eslint.json
+├── .nvmrc, .gitattributes, .dockerignore, .gitignore
+├── package.json, package-lock.json, requirements.txt
 ├── LICENSE
 └── README.md
 ```

--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ Requires Node.js v20.19+ and a BLE adapter. See the **[full install guide](https
 
 ## Contributors
 
-<a href="https://github.com/KristianP26"><img src="https://avatars.githubusercontent.com/u/28766334?v=4" width="50" height="50" alt="KristianP26" style="border-radius:50%"></a>
-<a href="https://github.com/APIUM"><img src="https://avatars.githubusercontent.com/u/9067013?v=4" width="50" height="50" alt="APIUM" style="border-radius:50%"></a>
-<a href="https://github.com/marcelorodrigo"><img src="https://avatars.githubusercontent.com/u/443962?v=4" width="50" height="50" alt="marcelorodrigo" style="border-radius:50%"></a>
-<a href="https://github.com/fromport"><img src="https://avatars.githubusercontent.com/u/5751308?v=4" width="50" height="50" alt="fromport" style="border-radius:50%"></a>
+<a href="https://github.com/KristianP26"><img src="https://avatars.githubusercontent.com/u/28766334?v=4" width="50" height="50" alt="KristianP26" style="border-radius:50%;margin-right:8px"></a>
+<a href="https://github.com/APIUM"><img src="https://avatars.githubusercontent.com/u/9067013?v=4" width="50" height="50" alt="APIUM" style="border-radius:50%;margin-right:8px"></a>
+<a href="https://github.com/marcelorodrigo"><img src="https://avatars.githubusercontent.com/u/443962?v=4" width="50" height="50" alt="marcelorodrigo" style="border-radius:50%;margin-right:8px"></a>
+<a href="https://github.com/fromport"><img src="https://avatars.githubusercontent.com/u/5751308?v=4" width="50" height="50" alt="fromport" style="border-radius:50%;margin-right:8px"></a>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -102,10 +102,7 @@ Requires Node.js v20.19+ and a BLE adapter. See the **[full install guide](https
 
 ## Contributors
 
-<a href="https://github.com/KristianP26"><img src="https://avatars.githubusercontent.com/u/28766334?v=4" width="50" height="50" alt="KristianP26" style="border-radius:50%;margin-right:8px"></a>
-<a href="https://github.com/APIUM"><img src="https://avatars.githubusercontent.com/u/9067013?v=4" width="50" height="50" alt="APIUM" style="border-radius:50%;margin-right:8px"></a>
-<a href="https://github.com/marcelorodrigo"><img src="https://avatars.githubusercontent.com/u/443962?v=4" width="50" height="50" alt="marcelorodrigo" style="border-radius:50%;margin-right:8px"></a>
-<a href="https://github.com/fromport"><img src="https://avatars.githubusercontent.com/u/5751308?v=4" width="50" height="50" alt="fromport" style="border-radius:50%;margin-right:8px"></a>
+<p><a href="https://github.com/KristianP26"><img src="https://avatars.githubusercontent.com/u/28766334?v=4" width="50" height="50" alt="KristianP26" style="border-radius:50%;margin-right:8px"></a><a href="https://github.com/APIUM"><img src="https://avatars.githubusercontent.com/u/9067013?v=4" width="50" height="50" alt="APIUM" style="border-radius:50%;margin-right:8px"></a><a href="https://github.com/marcelorodrigo"><img src="https://avatars.githubusercontent.com/u/443962?v=4" width="50" height="50" alt="marcelorodrigo" style="border-radius:50%;margin-right:8px"></a><a href="https://github.com/fromport"><img src="https://avatars.githubusercontent.com/u/5751308?v=4" width="50" height="50" alt="fromport" style="border-radius:50%;margin-right:8px"></a></p>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Requires Node.js v20.19+ and a BLE adapter. See the **[full install guide](https
 <a href="https://github.com/KristianP26"><img src="https://avatars.githubusercontent.com/u/28766334?v=4" width="50" height="50" alt="KristianP26" style="border-radius:50%"></a>
 <a href="https://github.com/APIUM"><img src="https://avatars.githubusercontent.com/u/9067013?v=4" width="50" height="50" alt="APIUM" style="border-radius:50%"></a>
 <a href="https://github.com/marcelorodrigo"><img src="https://avatars.githubusercontent.com/u/443962?v=4" width="50" height="50" alt="marcelorodrigo" style="border-radius:50%"></a>
+<a href="https://github.com/fromport"><img src="https://avatars.githubusercontent.com/u/5751308?v=4" width="50" height="50" alt="fromport" style="border-radius:50%"></a>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,12 @@ Requires Node.js v20.19+ and a BLE adapter. See the **[full install guide](https
 
 ## Contributors
 
-<p><a href="https://github.com/KristianP26"><img src="https://avatars.githubusercontent.com/u/28766334?v=4" width="50" height="50" alt="KristianP26" style="border-radius:50%;margin-right:8px"></a><a href="https://github.com/APIUM"><img src="https://avatars.githubusercontent.com/u/9067013?v=4" width="50" height="50" alt="APIUM" style="border-radius:50%;margin-right:8px"></a><a href="https://github.com/marcelorodrigo"><img src="https://avatars.githubusercontent.com/u/443962?v=4" width="50" height="50" alt="marcelorodrigo" style="border-radius:50%;margin-right:8px"></a><a href="https://github.com/fromport"><img src="https://avatars.githubusercontent.com/u/5751308?v=4" width="50" height="50" alt="fromport" style="border-radius:50%;margin-right:8px"></a></p>
+<table><tr>
+<td align="center"><a href="https://github.com/KristianP26"><img src="https://avatars.githubusercontent.com/u/28766334?v=4" width="60" height="60" alt="KristianP26"><br><sub>KristianP26</sub></a></td>
+<td align="center"><a href="https://github.com/APIUM"><img src="https://avatars.githubusercontent.com/u/9067013?v=4" width="60" height="60" alt="APIUM"><br><sub>APIUM</sub></a></td>
+<td align="center"><a href="https://github.com/marcelorodrigo"><img src="https://avatars.githubusercontent.com/u/443962?v=4" width="60" height="60" alt="marcelorodrigo"><br><sub>marcelorodrigo</sub></a></td>
+<td align="center"><a href="https://github.com/fromport"><img src="https://avatars.githubusercontent.com/u/5751308?v=4" width="60" height="60" alt="fromport"><br><sub>fromport</sub></a></td>
+</tr></table>
 
 ## Contributing
 

--- a/ble-scale-sync-addon/config.yaml
+++ b/ble-scale-sync-addon/config.yaml
@@ -1,5 +1,5 @@
 name: BLE Scale Sync
-version: "1.10.1"
+version: "1.10.2"
 slug: ble-scale-sync
 description: Read BLE smart scales and export to Garmin Connect, MQTT (HA auto-discovery), InfluxDB, and more
 url: https://github.com/KristianP26/ble-scale-sync

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,21 @@ All notable changes to this project are documented here. Format based on [Keep a
 
 ## Unreleased {#unreleased}
 
-## v1.10.1 <Badge type="tip" text="latest" /> {#v1-10-1}
+## v1.10.2 <Badge type="tip" text="latest" /> {#v1-10-2}
+
+_2026-04-24_
+
+### Fixed
+- **Renpho ES-26M**: the 18-byte `0x12` scale-info frame (where byte[1] is the packet length and bytes [2-7] carry the device MAC) was being misread as "byte[2] is the protocol type", yielding `proto=0xFF` and causing every subsequent handshake command to be rejected by the scale. No `0x10` weight frames were ever returned. The QN-Scale adapter now detects the long-frame format and falls through to the ES-30M code path with `weightScaleFactor=10`, so the existing heuristic auto-corrects the weight divisor. The unconditional skip of `R1=R2=0` stable frames in ES-30M mode is also lifted: the ES-26M never reports impedance when the user is wearing socks, and those frames are the only stable reading available in that scenario. Contributed by [@fromport](https://github.com/fromport) ([#128](https://github.com/KristianP26/ble-scale-sync/pull/128))
+
+### Changed
+- **ESPHome proxy**: the handler now logs a one-time Phase 1 capability summary on connect, listing which configured adapters are broadcast-capable (produce readings on this transport) and which are GATT-only (will time out until Phase 2 / [#116](https://github.com/KristianP26/ble-scale-sync/issues/116) ships). Users who were only seeing the generic `Timed out waiting for any recognized scale broadcast via ESPHome proxy` line now immediately see whether their scale brand is in the broadcast-capable set, instead of having to reproduce the failure twice to catch the per-MAC warn ([#133](https://github.com/KristianP26/ble-scale-sync/issues/133))
+
+### Docs
+- **CONTRIBUTING.md**: project structure tree refreshed to match the current layout
+- **README**: contributors migrated to a GitHub-style table with inline avatars, [@fromport](https://github.com/fromport) added
+
+## v1.10.1 {#v1-10-1}
 
 _2026-04-22_
 

--- a/docs/guide/esphome-proxy.md
+++ b/docs/guide/esphome-proxy.md
@@ -106,6 +106,7 @@ volumes:
 
 Phase 1 only handles broadcast scales. Behavior depends on the mode:
 
+- **On connect**, the handler logs a one-time capability summary naming every configured adapter: which are broadcast-capable (produce readings on this transport) and which are GATT-only (will not). If your scale brand is in the GATT-only list, that's why nothing gets read, switch handler instead of waiting for a 60 s timeout.
 - **Single-shot (`npm start`)** fails fast with a descriptive error when a GATT-only scale is matched, so misconfigured setups surface immediately.
 - **Continuous (`CONTINUOUS_MODE=true`)** logs a one-time warning per device and keeps running, so a GATT scale passing through range does not crash a multi-scale deployment.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ble-scale-sync",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ble-scale-sync",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@2colors/esphome-native-api": "^1.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ble-scale-sync",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Universal BLE Smart Scale bridge. Captures body composition from Renpho, Xiaomi & 20+ others, syncs to Garmin Connect, Strava, MQTT (Home Assistant), InfluxDB, Webhooks, Ntfy & local files. Headless CLI for Raspberry Pi, Linux, macOS & Windows.",
   "type": "module",
   "main": "src/index.ts",

--- a/src/ble/handler-esphome-proxy.ts
+++ b/src/ble/handler-esphome-proxy.ts
@@ -208,6 +208,39 @@ function gattNotSupportedError(adapterName: string, address: string): Error {
 }
 
 /**
+ * Emit a one-line summary of which configured adapters can actually produce
+ * readings over the Phase 1 (broadcast-only) ESPHome proxy transport, so
+ * users see the constraint on startup instead of waiting for a 60s timeout.
+ * Classifies each adapter by whether it defines parseBroadcast().
+ */
+function logPhase1Capabilities(adapters: ScaleAdapter[]): void {
+  const broadcast: string[] = [];
+  const gattOnly: string[] = [];
+  for (const a of adapters) {
+    if (typeof a.parseBroadcast === 'function') {
+      broadcast.push(a.name);
+    } else if (a.charNotifyUuid) {
+      gattOnly.push(a.name);
+    }
+  }
+  if (broadcast.length === 0 && gattOnly.length === 0) return;
+
+  const parts: string[] = ['ESPHome proxy transport is broadcast-only in Phase 1.'];
+  if (broadcast.length > 0) {
+    parts.push(`Broadcast-capable adapters: ${broadcast.join(', ')}.`);
+  }
+  if (gattOnly.length > 0) {
+    parts.push(
+      `GATT-only adapters will not produce readings on this transport: ${gattOnly.join(', ')}.`,
+    );
+    parts.push(
+      'If your scale matches a GATT-only adapter, switch ble.handler to "native" or "mqtt-proxy". Phase 2 tracking: #116.',
+    );
+  }
+  bleLog.warn(parts.join(' '));
+}
+
+/**
  * Subscribe to BLE advertisements via an ESPHome proxy, match against adapters,
  * and return the first broadcast reading that parses successfully.
  *
@@ -229,6 +262,7 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
   try {
     await waitForConnected(client, hostPort);
     bleLog.info(`ESPHome proxy connected at ${hostPort}`);
+    logPhase1Capabilities(adapters);
 
     return await withTimeout(
       new Promise<RawReading>((resolve, reject) => {
@@ -420,6 +454,7 @@ export class ReadingWatcher {
       ];
 
       await waitForConnected(this.client, hostPort);
+      logPhase1Capabilities(this.adapters);
 
       this.onAdHandler = (ad) => this.handleAd(ad);
       this.client.on('ble', this.onAdHandler);

--- a/src/scales/qn-scale.ts
+++ b/src/scales/qn-scale.ts
@@ -11,7 +11,8 @@ import { uuid16 } from './body-comp-helpers.js';
 import { bleLog } from '../ble/types.js';
 
 /** Format bytes as hex string for debug logging. */
-const hex = (data: number[]): string => data.map((b) => b.toString(16).padStart(2, '0')).join(' ');
+const hex = (data: number[] | Buffer): string =>
+  [...data].map((b) => b.toString(16).padStart(2, '0')).join(' ');
 
 /**
  * Ported from openScale's QNHandler.kt
@@ -47,9 +48,15 @@ const hex = (data: number[]): string => data.map((b) => b.toString(16).padStart(
  *   [7-8]   resistance R1 (BE uint16)
  *   [9-10]  resistance R2 (BE uint16)
  *
- * 0x12 frame (scale info):
+ * 0x12 frame (scale info, classic 11-byte format):
  *   [2]     protocol type (echoed back in all config commands)
  *   [10]    weight scale flag (1 = /100, else /10)
+ *
+ * 0x12 frame (ES-26M long format, 18 bytes):
+ *   [1]     length (== packet length, i.e. 0x12 == 18)
+ *   [2-7]   MAC address (NOT protocol type!)
+ *   Protocol type should be set to 0x00 for this variant.
+ *   Weight scale factor is 10 (ES-30M format with heuristic /100 fallback).
  */
 
 // Type 2 UUIDs (most common variant)
@@ -70,6 +77,14 @@ const SVC_T2 = 'fff0';
 
 /** Seconds from Unix epoch to 2000-01-01 00:00:00 UTC. */
 const SCALE_EPOCH_OFFSET = 946684800;
+
+/**
+ * Grace period (ms) to wait for an impedance frame after the first stable
+ * R1=R2=0 frame on long-frame variants (e.g. ES-26M). If an impedance frame
+ * arrives within this window, it supersedes the weight-only reading. If not,
+ * the weight-only reading is accepted on the next stable frame.
+ */
+const IMPEDANCE_GRACE_MS = 1500;
 
 export class QnScaleAdapter implements ScaleAdapter {
   readonly name = 'QN Scale';
@@ -95,6 +110,22 @@ export class QnScaleAdapter implements ScaleAdapter {
 
   /** Whether the AE00 service is available (newer firmware). */
   private hasAe00 = false;
+
+  /**
+   * Whether the scale sent a long-frame (18-byte) 0x12 variant (e.g. ES-26M).
+   * These scales may never provide impedance, so stable frames with R1=R2=0
+   * must be accepted after a grace period. Classic ES-30M scales always send
+   * an impedance frame after the weight-only stable frame, so skipping
+   * R1=R2=0 is correct there.
+   */
+  private isLongFrameVariant = false;
+
+  /**
+   * Timestamp (Date.now()) of the first stable R1=R2=0 frame seen on a
+   * long-frame variant. After IMPEDANCE_GRACE_MS without an impedance frame,
+   * subsequent R1=R2=0 stable frames are accepted.
+   */
+  private firstStableNoImpedanceAt: number | null = null;
 
   /** Deduplication guards: prevent duplicate state machine responses. */
   private configSent = false;
@@ -146,6 +177,8 @@ export class QnScaleAdapter implements ScaleAdapter {
     this.seenProtocolType = 0x00;
     this.weightScaleFactor = 100;
     this.hasAe00 = false;
+    this.isLongFrameVariant = false;
+    this.firstStableNoImpedanceAt = null;
     this.configSent = false;
     this.timeSyncSent = false;
     this.historyResponseSent = false;
@@ -274,14 +307,30 @@ export class QnScaleAdapter implements ScaleAdapter {
   parseNotification(data: Buffer): ScaleReading | null {
     if (data.length < 3) return null;
 
+    bleLog.debug(`QN RAW (${data.length}B): [${hex(data)}]`);
+
     const opcode = data[0];
 
     // 0x12: scale info, update weight scale factor and capture protocol type
     if (opcode === 0x12 && data.length > 10) {
-      this.weightScaleFactor = data[10] === 1 ? 100 : 10;
-      this.seenProtocolType = data[2];
+      // Renpho ES-26M (and similar newer firmware) sends an 18-byte 0x12
+      // frame where byte[1] == packet length and bytes [2-7] contain the
+      // MAC address. The classic QN format has ~11 bytes with protocol
+      // type at [2] and weight scale flag at [10].
+      if (data.length >= 18 && data[1] === data.length) {
+        // Long frame (ES-26M): MAC at [2-7], use proto=0x00
+        this.isLongFrameVariant = true;
+        this.seenProtocolType = 0x00;
+        this.weightScaleFactor = 10;
+      } else {
+        // Classic short frame
+        this.seenProtocolType = data[2];
+        this.weightScaleFactor = data[10] === 1 ? 100 : 10;
+      }
       bleLog.debug(
-        `QN: scale info, factor=${this.weightScaleFactor}, proto=0x${this.seenProtocolType.toString(16).padStart(2, '0')}`,
+        `QN: scale info (${data.length}B), ` +
+          `factor=${this.weightScaleFactor}, ` +
+          `proto=0x${this.seenProtocolType.toString(16).padStart(2, '0')}`,
       );
       void this.handleScaleInfo();
       return null;
@@ -328,10 +377,26 @@ export class QnScaleAdapter implements ScaleAdapter {
       r1 = data.readUInt16BE(7);
       r2 = data.readUInt16BE(9);
 
-      // ES-30M scales send a weight-only stable frame (R1=R2=0) before the
-      // impedance-bearing one. Skip it so isComplete() doesn't accept an
-      // impedance=0 reading prematurely (which triggers broadcast-mode logic).
-      if (stable && r1 === 0 && r2 === 0) return null;
+      if (stable && r1 === 0 && r2 === 0) {
+        if (!this.isLongFrameVariant) {
+          // Classic ES-30M: always skip — impedance frame follows.
+          return null;
+        }
+        // Long-frame variant (ES-26M): accept after grace period.
+        // The first stable R1=R2=0 frame starts a timer. If no impedance
+        // frame arrives within IMPEDANCE_GRACE_MS, subsequent R1=R2=0
+        // frames are accepted. This prevents losing BIA data if the
+        // scale sends a transient R1=R2=0 before the impedance frame.
+        const now = Date.now();
+        if (this.firstStableNoImpedanceAt === null) {
+          this.firstStableNoImpedanceAt = now;
+          return null;
+        }
+        if (now - this.firstStableNoImpedanceAt < IMPEDANCE_GRACE_MS) {
+          return null;
+        }
+        // Grace period elapsed — accept this weight-only reading.
+      }
     } else {
       // Original: [3-4]=weight, [5]=stable(1), [6-7]=R1, [8-9]=R2
       stable = data[5] === 1;
@@ -357,6 +422,9 @@ export class QnScaleAdapter implements ScaleAdapter {
 
     // R1 (primary BIA resistance) and R2 (secondary)
     const impedance = r1 > 0 ? r1 : r2;
+
+    // Reset the impedance grace timer on successful reading
+    this.firstStableNoImpedanceAt = null;
 
     // Acknowledge stable reading (0x1F) so the scale knows we received it
     if (this.ctx) {

--- a/tests/ble/handler-esphome-proxy.test.ts
+++ b/tests/ble/handler-esphome-proxy.test.ts
@@ -186,6 +186,93 @@ describe('_internals.extractBytes', () => {
   });
 });
 
+describe('Phase 1 capability summary', () => {
+  beforeEach(() => {
+    mockClient = new MockEsphomeClient();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('scanAndReadRaw warns about GATT-only adapters before the broadcast wait starts', async () => {
+    const broadcast = makeBroadcastAdapter();
+    const gattOnly = makeGattOnlyAdapter();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { scanAndReadRaw } = await import('../../src/ble/handler-esphome-proxy.js');
+
+    const promise = scanAndReadRaw({
+      adapters: [broadcast, gattOnly],
+      profile,
+      esphomeProxy: config,
+      bleHandler: 'esphome-proxy',
+    });
+
+    await mockClient.waitForListener('ble');
+
+    const summary = warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((s) => /broadcast-only in Phase 1/.test(s));
+    expect(summary.length).toBe(1);
+    expect(summary[0]).toMatch(/Broadcast-capable adapters: MockBroadcast/);
+    expect(summary[0]).toMatch(/GATT-only adapters .*: MockGattOnly/);
+    expect(summary[0]).toMatch(/Phase 2 tracking: #116/);
+
+    // Unblock the pending promise with a matching advertisement
+    mockClient.pushBle({
+      address: 0x112233445566,
+      name: 'MyScale',
+      rssi: -60,
+      manufacturerDataList: [{ uuid: '0xee57', legacyDataList: [0x01, 0x02], data: '' }],
+    });
+    await promise;
+    warnSpy.mockRestore();
+  });
+
+  it('ReadingWatcher.start warns once with the Phase 1 capability summary', async () => {
+    const broadcast = makeBroadcastAdapter();
+    const gattOnly = makeGattOnlyAdapter();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { ReadingWatcher } = await import('../../src/ble/handler-esphome-proxy.js');
+    const watcher = new ReadingWatcher(config, [broadcast, gattOnly]);
+
+    const startPromise = watcher.start();
+    await mockClient.waitForListener('ble');
+    await startPromise;
+
+    const summary = warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((s) => /broadcast-only in Phase 1/.test(s));
+    expect(summary.length).toBe(1);
+    expect(summary[0]).toMatch(/MockBroadcast/);
+    expect(summary[0]).toMatch(/MockGattOnly/);
+
+    warnSpy.mockRestore();
+    await watcher.stop();
+  });
+
+  it('omits GATT section when every configured adapter is broadcast-capable', async () => {
+    const broadcast = makeBroadcastAdapter();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { ReadingWatcher } = await import('../../src/ble/handler-esphome-proxy.js');
+    const watcher = new ReadingWatcher(config, [broadcast]);
+
+    const startPromise = watcher.start();
+    await mockClient.waitForListener('ble');
+    await startPromise;
+
+    const summary = warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((s) => /broadcast-only in Phase 1/.test(s));
+    expect(summary.length).toBe(1);
+    expect(summary[0]).toMatch(/Broadcast-capable adapters: MockBroadcast/);
+    expect(summary[0]).not.toMatch(/GATT-only adapters/);
+
+    warnSpy.mockRestore();
+    await watcher.stop();
+  });
+});
+
 describe('scanAndReadRaw', () => {
   beforeEach(() => {
     mockClient = new MockEsphomeClient();

--- a/tests/scales/qn-scale.test.ts
+++ b/tests/scales/qn-scale.test.ts
@@ -567,4 +567,150 @@ describe('QnScaleAdapter', () => {
       assertPayloadRanges(payload);
     });
   });
+  // ── Tests to append inside the describe('QnScaleAdapter', () => { block ──
+
+  describe('ES-26M long-frame variant', () => {
+    /** Build an 18-byte 0x12 frame matching the ES-26M format. */
+    function makeLongScaleInfo(): Buffer {
+      // Real captured frame: 12 12 ff 0f ac 14 00 04 ff 0f 07 0a 00 00 05 9f 30 e9
+      return Buffer.from([
+        0x12, 0x12, 0xff, 0x0f, 0xac, 0x14, 0x00, 0x04, 0xff, 0x0f, 0x07, 0x0a, 0x00, 0x00, 0x05,
+        0x9f, 0x30, 0xe9,
+      ]);
+    }
+
+    /** Build an ES-30M-format 0x10 weight frame. */
+    function makeWeightFrame(weightRaw: number, state: number, r1: number, r2: number): Buffer {
+      const buf = Buffer.alloc(14);
+      buf[0] = 0x10;
+      buf[1] = 0x0e;
+      buf[2] = 0xff;
+      buf[3] = 0x01;
+      buf[4] = state;
+      buf.writeUInt16BE(weightRaw, 5);
+      buf.writeUInt16BE(r1, 7);
+      buf.writeUInt16BE(r2, 9);
+      return buf;
+    }
+
+    it('18B 0x12 frame sets isLongFrameVariant, proto=0x00, factor=10', () => {
+      const adapter = makeAdapter();
+      const result = adapter.parseNotification(makeLongScaleInfo());
+      expect(result).toBeNull(); // info frames return null
+
+      // Verify factor=10 by parsing a weight frame: rawWeight=9790,
+      // 9790/10=979 >=250 → heuristic tries /100 → 97.90 kg
+      const weightBuf = makeWeightFrame(9790, 0x02, 501, 499);
+      const reading = adapter.parseNotification(weightBuf);
+      expect(reading).not.toBeNull();
+      expect(reading!.weight).toBeCloseTo(97.9);
+      expect(reading!.impedance).toBe(501);
+    });
+
+    it('classic 11B 0x12 frame still reads proto from data[2]', () => {
+      const adapter = makeAdapter();
+      const infoBuf = Buffer.alloc(11);
+      infoBuf[0] = 0x12;
+      infoBuf[2] = 0xab; // protocol type
+      infoBuf[10] = 1; // weightScaleFactor = 100
+
+      adapter.parseNotification(infoBuf);
+
+      // Verify classic behavior: factor=100, weight at [3-4]
+      const dataBuf = Buffer.alloc(10);
+      dataBuf[0] = 0x10;
+      dataBuf.writeUInt16BE(7500, 3); // 75.00 kg
+      dataBuf[5] = 1; // stable
+      dataBuf.writeUInt16BE(500, 6);
+      dataBuf.writeUInt16BE(490, 8);
+
+      const reading = adapter.parseNotification(dataBuf);
+      expect(reading).not.toBeNull();
+      expect(reading!.weight).toBe(75);
+    });
+
+    it('long-frame: barefoot reading with R1>0 returns impedance', () => {
+      const adapter = makeAdapter();
+      adapter.parseNotification(makeLongScaleInfo());
+
+      // Actual captured ES-26M barefoot frame:
+      // 10 0e ff 01 02 26 39 01 f5 01 f3 01 34 9e
+      const buf = Buffer.from([
+        0x10, 0x0e, 0xff, 0x01, 0x02, 0x26, 0x39, 0x01, 0xf5, 0x01, 0xf3, 0x01, 0x34, 0x9e,
+      ]);
+
+      const reading = adapter.parseNotification(buf);
+      expect(reading).not.toBeNull();
+      // 0x2639 = 9785, /10=978.5 >=250, heuristic /100 = 97.85
+      expect(reading!.weight).toBeCloseTo(97.85);
+      expect(reading!.impedance).toBe(501); // R1 = 0x01F5
+    });
+
+    it('long-frame: first stable R1=R2=0 is skipped (grace period)', () => {
+      const adapter = makeAdapter();
+      adapter.parseNotification(makeLongScaleInfo());
+
+      // First stable frame with no impedance — should be skipped
+      const buf = makeWeightFrame(9790, 0x02, 0, 0);
+      expect(adapter.parseNotification(buf)).toBeNull();
+    });
+
+    it('long-frame: R1=R2=0 accepted after grace period (socks path)', () => {
+      const adapter = makeAdapter();
+      adapter.parseNotification(makeLongScaleInfo());
+
+      const buf = makeWeightFrame(9790, 0x02, 0, 0);
+
+      // First stable R1=R2=0 — skipped, starts grace timer
+      expect(adapter.parseNotification(buf)).toBeNull();
+
+      // Simulate grace period elapsed by manipulating internal state.
+      // Access private field for testing — the grace period is 1500ms.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (adapter as any).firstStableNoImpedanceAt = Date.now() - 2000;
+
+      // Now it should be accepted
+      const reading = adapter.parseNotification(buf);
+      expect(reading).not.toBeNull();
+      expect(reading!.weight).toBeCloseTo(97.9);
+      expect(reading!.impedance).toBe(0);
+    });
+
+    it('long-frame: impedance frame within grace period supersedes', () => {
+      const adapter = makeAdapter();
+      adapter.parseNotification(makeLongScaleInfo());
+
+      // First stable R1=R2=0 — skipped
+      const noImpBuf = makeWeightFrame(9790, 0x02, 0, 0);
+      expect(adapter.parseNotification(noImpBuf)).toBeNull();
+
+      // Impedance frame arrives within grace period — accepted immediately
+      const impBuf = makeWeightFrame(9790, 0x02, 501, 499);
+      const reading = adapter.parseNotification(impBuf);
+      expect(reading).not.toBeNull();
+      expect(reading!.weight).toBeCloseTo(97.9);
+      expect(reading!.impedance).toBe(501);
+    });
+
+    it('classic ES-30M: stable R1=R2=0 is still skipped (regression guard)', () => {
+      const adapter = makeAdapter();
+      // Classic 11-byte 0x12 frame → isLongFrameVariant=false
+      const infoBuf = Buffer.alloc(11);
+      infoBuf[0] = 0x12;
+      infoBuf[2] = 0xff;
+      infoBuf[10] = 0; // factor=10
+      adapter.parseNotification(infoBuf);
+
+      // Stable frame with R1=R2=0
+      const buf = makeWeightFrame(600, 0x02, 0, 0);
+      expect(adapter.parseNotification(buf)).toBeNull();
+
+      // Next frame with impedance should be accepted
+      const impBuf = makeWeightFrame(600, 0x02, 509, 507);
+      const reading = adapter.parseNotification(impBuf);
+      expect(reading).not.toBeNull();
+      expect(reading!.weight).toBe(60);
+      expect(reading!.impedance).toBe(509);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- **Renpho ES-26M handshake fix** (contributed by @fromport, #128). Long `0x12` frame format was misread, blocking every weight reading on ES-26M. QN-Scale adapter now detects the 18-byte variant and routes through the ES-30M code path with the heuristic weight divisor.
- **ESPHome proxy Phase 1 capability summary** on connect (#133). Users no longer have to wait 60 s and reproduce the failure twice to realize their scale is GATT-only on Phase 1 of the ESPHome proxy transport.
- Docs: CONTRIBUTING project tree refresh, contributors README table with inline avatars.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npx prettier --check` clean on changed files
- [x] `npm test` 1253/1253 passing (64 files)
- [x] HA Add-on version bumped to 1.10.2 to track the main app release

Full notes: [CHANGELOG.md#1102---2026-04-24](https://github.com/KristianP26/ble-scale-sync/blob/dev/CHANGELOG.md#1102---2026-04-24)
