### PR TITLE
fix(node-ble): add timeout to device.gatt() and waitForRawReading

### DIFF
--- a/src/ble/handler-node-ble.ts
+++ b/src/ble/handler-node-ble.ts
@@ -17,6 +17,7 @@ import {
   DISCOVERY_POLL_MS,
   POST_DISCOVERY_QUIESCE_MS,
   GATT_DISCOVERY_TIMEOUT_MS,
+  RAW_READING_TIMEOUT_MS,
   CHAR_DISCOVERY_MAX_RETRIES,
   CHAR_DISCOVERY_RETRY_DELAY_MS,
 } from './types.js';
@@ -541,7 +542,11 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
     // the first enumeration can be missing chars the scale actually exposes.
     // Retry the enumeration a few times with a short backoff when we detect
     // that the adapter's required chars are not yet present.
-    const gatt = await device.gatt();
+    const gatt = await withTimeout(
+      device.gatt(),
+      GATT_DISCOVERY_TIMEOUT_MS,
+      'GATT server acquisition timed out',
+    );
     let charMap = await withTimeout(
       buildCharMap(gatt),
       GATT_DISCOVERY_TIMEOUT_MS,
@@ -567,14 +572,18 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
         'GATT service discovery timed out',
       );
     }
-    const raw = await waitForRawReading(
-      charMap,
-      wrapDevice(device),
-      matchedAdapter,
-      profile,
-      deviceMac.replace(/[:-]/g, '').toUpperCase(),
-      weightUnit,
-      onLiveData,
+    const raw = await withTimeout(
+      waitForRawReading(
+        charMap,
+        wrapDevice(device),
+        matchedAdapter,
+        profile,
+        deviceMac.replace(/[:-]/g, '').toUpperCase(),
+        weightUnit,
+        onLiveData,
+      ),
+      RAW_READING_TIMEOUT_MS,
+      'Timed out waiting for a complete scale reading',
     );
 
     try {

--- a/src/ble/types.ts
+++ b/src/ble/types.ts
@@ -16,6 +16,9 @@ export const DISCOVERY_POLL_MS = 2_000;
 /** Timeout for GATT service/characteristic enumeration after connecting. */
 export const GATT_DISCOVERY_TIMEOUT_MS = 30_000;
 
+/** Timeout for the full reading phase (subscribe → first complete reading). */
+export const RAW_READING_TIMEOUT_MS = 120_000;
+
 /**
  * Max attempts to enumerate GATT characteristics. BlueZ can signal
  * `ServicesResolved=true` before all characteristic interfaces are exported


### PR DESCRIPTION
device.gatt() at handler-node-ble.ts:544 had no timeout wrapper. If the D-Bus call blocks (e.g. connecting to a scale that is shutting down), the process hangs indefinitely at 'Discovering services...' with no recovery.

The existing withTimeout on buildCharMap (line 545) only covered characteristic enumeration, not GATT server acquisition itself.

Similarly, waitForRawReading had no top-level timeout, so an incomplete charMap or a silent notification failure could block forever.

Fix:
- Wrap device.gatt() in withTimeout(GATT_DISCOVERY_TIMEOUT_MS) (30s)
- Wrap waitForRawReading in withTimeout(RAW_READING_TIMEOUT_MS) (120s)
- Add RAW_READING_TIMEOUT_MS constant to types.ts

Ref: #140

## Summary

Adds timeout wrappers to two unprotected `await` calls in the node-ble handler, as discussed in #140.

`device.gatt()` had no timeout — if the D-Bus call blocks (e.g. connecting to a scale mid-shutdown), the process hangs at "Discovering services..." with no recovery. `waitForRawReading()` also had no top-level timeout, so an incomplete charMap or silent notification failure could block forever.


## Changes

- Wrap `device.gatt()` in `withTimeout(GATT_DISCOVERY_TIMEOUT_MS)` (30s)
- Wrap `waitForRawReading()` in `withTimeout(RAW_READING_TIMEOUT_MS)` (120s)
- Add `RAW_READING_TIMEOUT_MS = 120_000` constant to `types.ts`



## Test Plan

- [x] TypeScript compiles (`npx tsc --noEmit` — no errors in changed files)
- [x] Prettier clean (`npx prettier --write` — no changes)
- [x] Tested manually: service running in continuous mode on Debian/Asahi (M2 Mac Mini) with Renpho ES-26M for 12+ hours. Timeout does not interfere with normal measurement flow.

## Notes


This is the defensive safety net discussed in #140. It won't catch synchronous D-Bus stalls (where the event loop itself is blocked), but covers the asynchronous variants. The primary trigger for #140 (connecting to a dying device after short scan_cooldown) is a separate fix.

Ref: #140