### PR TITLE
feat(trisa): partial support for ADE BA 1600 (fitvigo)

### DIFF
--- a/docs/guide/supported-scales.md
+++ b/docs/guide/supported-scales.md
@@ -32,7 +32,7 @@ BLE Scale Sync ships **24 protocol adapters** out of the box, covering Xiaomi, R
 | **MGB** (Swan / Icomon / YG) | |
 | **Digoo** DG-SO38H (Mengii) | |
 | **Excelvan** CF369 | |
-| **Trisa** Body Analyze | |
+| **Trisa** Body Analyze / **ADE** BA 1600 (fitvigo) | ADE variant: weight only, body comp encoding TBD |
 | **Hoffen** BS-8107 | |
 | **Hesley** (YunChen) | |
 | **Inlife** (FatScale) | |

--- a/src/ble/shared.ts
+++ b/src/ble/shared.ts
@@ -48,6 +48,7 @@ export function findMissingCharacteristics(
 
   if (adapter.characteristics) {
     for (const binding of adapter.characteristics) {
+      if (binding.optional) continue;
       if (!resolveChar(charMap, binding.uuid)) missing.push(binding.uuid);
     }
     return missing;
@@ -102,9 +103,11 @@ function initializeAdapter(
 
   const start = async (): Promise<void> => {
     if (adapter.onConnected) {
+      const availableChars = new Set<string>(charMap.keys());
       const ctx: ConnectionContext = {
         profile,
         deviceAddress,
+        availableChars,
         write: async (charUuid, data, withResponse = true) => {
           const char = resolveChar(charMap, charUuid);
           if (!char) throw new Error(`Characteristic ${charUuid} not found`);
@@ -175,11 +178,17 @@ async function subscribeAndInit(
       );
     }
 
+    let subscribed = 0;
     for (const binding of notifyBindings) {
+      if (binding.optional && !resolveChar(charMap, binding.uuid)) {
+        bleLog.debug(`Skipping optional notify binding ${binding.uuid} (not present on device)`);
+        continue;
+      }
       const unsub = await subscribeToChar(charMap, binding.uuid, onNotification);
       unsubscribers.push(unsub);
+      subscribed += 1;
     }
-    bleLog.info(`Subscribed to ${notifyBindings.length} notification(s). Step on the scale.`);
+    bleLog.info(`Subscribed to ${subscribed} notification(s). Step on the scale.`);
     await startInit();
   } else {
     // Legacy mode — single notify + write pair

--- a/src/interfaces/scale-adapter.ts
+++ b/src/interfaces/scale-adapter.ts
@@ -42,6 +42,13 @@ export interface CharacteristicBinding {
   uuid: string;
   /** How this characteristic is used. */
   type: 'notify' | 'write' | 'read';
+  /**
+   * Mark the binding as optional. When true, the BLE handler will not fail if
+   * the characteristic is missing, and will skip subscribing/writing to it.
+   * Used by adapters that handle multiple firmware variants where some chars
+   * are present on one variant but not the other (e.g. Trisa + ADE BA 1600).
+   */
+  optional?: boolean;
 }
 
 /**
@@ -62,6 +69,13 @@ export interface ConnectionContext {
    * Uppercase, no separators. Empty string when unavailable (e.g. macOS CoreBluetooth UUID).
    */
   deviceAddress: string;
+  /**
+   * Set of characteristic UUIDs (normalized 32-char hex, lowercase) that were
+   * actually discovered on the connected device. Adapters with `optional`
+   * bindings can use this to detect firmware variants and switch behavior.
+   * Always populated when the adapter declares `characteristics`.
+   */
+  availableChars: ReadonlySet<string>;
 }
 
 export interface ScaleAdapter {

--- a/src/interfaces/scale-adapter.ts
+++ b/src/interfaces/scale-adapter.ts
@@ -44,9 +44,15 @@ export interface CharacteristicBinding {
   type: 'notify' | 'write' | 'read';
   /**
    * Mark the binding as optional. When true, the BLE handler will not fail if
-   * the characteristic is missing, and will skip subscribing/writing to it.
-   * Used by adapters that handle multiple firmware variants where some chars
-   * are present on one variant but not the other (e.g. Trisa + ADE BA 1600).
+   * the characteristic is missing, and will skip auto-subscribing to it when
+   * `type === 'notify'`. Used by adapters that handle multiple firmware
+   * variants where some chars are present on one variant but not the other
+   * (e.g. Trisa + ADE BA 1600).
+   *
+   * NOTE: only `notify` bindings are auto-skipped. For optional `write`/`read`
+   * bindings the adapter's `onConnected` MUST consult `ctx.availableChars`
+   * before issuing the write/read — otherwise the call throws at runtime when
+   * the char is missing.
    */
   optional?: boolean;
 }
@@ -73,7 +79,8 @@ export interface ConnectionContext {
    * Set of characteristic UUIDs (normalized 32-char hex, lowercase) that were
    * actually discovered on the connected device. Adapters with `optional`
    * bindings can use this to detect firmware variants and switch behavior.
-   * Always populated when the adapter declares `characteristics`.
+   * Always populated for adapters with an `onConnected` hook, regardless of
+   * whether `characteristics` is declared.
    */
   availableChars: ReadonlySet<string>;
 }

--- a/src/scales/trisa.ts
+++ b/src/scales/trisa.ts
@@ -98,15 +98,17 @@ export class TrisaAdapter implements ScaleAdapter {
 
     // Both measurement chars are declared `optional` so that variant detection
     // can pick whichever one the firmware exposes. If neither shows up, that
-    // is almost certainly a transient BlueZ ServicesResolved race
-    // (bluez/bluez#1489) — fail fast with a clear message instead of silently
-    // subscribing to no measurement char and stalling on read.
+    // is almost certainly a transient GATT discovery race (BlueZ
+    // ServicesResolved firing before all chars are exported — bluez/bluez#1489
+    // — or the noble equivalent on Windows/macOS). Fail fast with a clear
+    // message instead of silently subscribing to no measurement char and
+    // stalling on read.
     const hasMeasurement =
       ctx.availableChars.has(CHR_MEASUREMENT_TRISA) || ctx.availableChars.has(CHR_MEASUREMENT_ADE);
     if (!hasMeasurement) {
       throw new Error(
         'Trisa: no measurement characteristic discovered (expected 0x8A21 or 0x8A24). ' +
-          'Likely a transient BlueZ discovery race — try again.',
+          'Likely a transient GATT discovery race — try again.',
       );
     }
 
@@ -125,6 +127,13 @@ export class TrisaAdapter implements ScaleAdapter {
     await ctx.write(CHR_DOWNLOAD, [broadcastOp], true);
   }
 
+  /**
+   * Variant precedence: pick `ade` only when 0x8A21 is *absent* and 0x8A24 is
+   * present. Any other combination defaults to `trisa`, which preserves the
+   * original handshake. A hypothetical hybrid firmware exposing both chars
+   * would be driven as Trisa (the safer default — known protocol, known
+   * challenge response).
+   */
   private detectVariant(available: ReadonlySet<string>): Variant {
     const hasTrisa = available.has(CHR_MEASUREMENT_TRISA);
     const hasAde = available.has(CHR_MEASUREMENT_ADE);

--- a/src/scales/trisa.ts
+++ b/src/scales/trisa.ts
@@ -8,30 +8,60 @@ import type {
   BodyComposition,
 } from '../interfaces/scale-adapter.js';
 import { uuid16, buildPayload, type ScaleBodyComp } from './body-comp-helpers.js';
+import { bleLog } from '../ble/types.js';
 
-const CHR_MEASUREMENT = uuid16(0x8a21);
+// Original Trisa firmware exposes 0x8A21 (notify) for measurement.
+const CHR_MEASUREMENT_TRISA = uuid16(0x8a21);
+// ADE BA 1600 / fitvigo firmware does NOT expose 0x8A21 — measurement frames
+// arrive on 0x8A24 (indicate) instead. Frame layout (weight portion) is
+// compatible with the Trisa decoder; body composition encoding still TBD.
+const CHR_MEASUREMENT_ADE = uuid16(0x8a24);
+// On ADE the scale also pushes another payload on 0x8A22 (indicate) shortly
+// after the weight frame. Encoding is not yet decoded — we subscribe to it
+// purely so future captures with debug logging can collect the bytes.
+const CHR_BODYCOMP_ADE = uuid16(0x8a22);
+// 0x8A82 is the upload channel on both variants. Trisa sends password (0xA0)
+// + challenge (0xA1); ADE only sends challenge (0xA1) without a preceding
+// password frame.
 const CHR_UPLOAD = uuid16(0x8a82);
+// 0x8A81 is the host -> scale write channel on both variants.
 const CHR_DOWNLOAD = uuid16(0x8a81);
 
-/** openScale opcodes for the Trisa challenge-response protocol. */
+// openScale opcodes for the Trisa challenge-response protocol.
 const OP_PASSWORD = 0xa0;
 const OP_CHALLENGE = 0xa1;
+// Time-sync command — opcode 0x02 followed by 4-byte LE seconds-since-2010.
+// Identical on Trisa and ADE.
+const OP_TIME_SYNC = 0x02;
+// Final "pairing complete" / broadcast-id opcode. Trisa uses 0x21, ADE 0x22.
+const OP_BROADCAST_TRISA = 0x21;
+const OP_BROADCAST_ADE = 0x22;
+// Challenge response opcode. Trisa echoes 0xA1; ADE uses 0x20 (the response
+// payload encoding is also different — see handleUploadChannel).
+const OP_RESPONSE_TRISA = 0xa1;
+
+const EPOCH_2010 = 1262304000;
+
+type Variant = 'trisa' | 'ade';
 
 /**
- * Adapter for Trisa body-composition scales (names starting with "01257B" or "11257B").
+ * Adapter for the Trisa body-composition scale family.
  *
- * Protocol details (from openScale TrisaBodyAnalyzeHandler):
- *   - Service 0x7802
- *   - 0x8A21 (notify) — measurement data
- *   - 0x8A82 (notify) — upload channel: scale sends password + challenge
- *   - 0x8A81 (write)  — download channel: host sends challenge response
- *   - Scale sends password (opcode 0xA0) on 0x8A82, then challenge (0xA1).
- *     Host replies with XOR(challenge, password) on 0x8A81.
- *   - Measurement frames on 0x8A21 use base-10 float encoding.
+ * Two firmware variants are supported:
+ *   - Trisa (default): exposes 0x8A21 (notify) for measurement, full
+ *     password + challenge handshake on 0x8A82.
+ *   - ADE BA 1600 / fitvigo: 0x8A21 is missing; measurement arrives on 0x8A24
+ *     (indicate). Different challenge-response and different
+ *     "pairing complete" opcode (0x22 instead of 0x21). Body-composition
+ *     decoding is not yet implemented — only weight is reported.
+ *
+ * Variant detection happens in `onConnected()` via `ctx.availableChars`:
+ * if 0x8A21 is missing but 0x8A24 is present → ADE.
  */
 export class TrisaAdapter implements ScaleAdapter {
   readonly name = 'Trisa';
-  readonly charNotifyUuid = CHR_MEASUREMENT;
+  // Legacy single-char fallback (only used when `characteristics` is ignored).
+  readonly charNotifyUuid = CHR_MEASUREMENT_TRISA;
   readonly charWriteUuid = CHR_DOWNLOAD;
 
   readonly normalizesWeight = true;
@@ -39,12 +69,21 @@ export class TrisaAdapter implements ScaleAdapter {
   readonly unlockIntervalMs = 0;
 
   readonly characteristics: CharacteristicBinding[] = [
-    { uuid: CHR_MEASUREMENT, type: 'notify' },
+    // Trisa-only measurement char.
+    { uuid: CHR_MEASUREMENT_TRISA, type: 'notify', optional: true },
+    // ADE-only measurement char.
+    { uuid: CHR_MEASUREMENT_ADE, type: 'notify', optional: true },
+    // ADE-only body-composition push (encoding TBD — captured via debug log).
+    { uuid: CHR_BODYCOMP_ADE, type: 'notify', optional: true },
+    // Shared upload channel (password + challenge).
     { uuid: CHR_UPLOAD, type: 'notify' },
+    // Shared write channel.
     { uuid: CHR_DOWNLOAD, type: 'write' },
   ];
 
-  /** Stored password from opcode 0xA0, used to solve the challenge. */
+  /** Detected firmware variant. Set in onConnected(). */
+  private variant: Variant = 'trisa';
+  /** Stored password from opcode 0xA0 (Trisa). ADE does not send this. */
   private password: Buffer | null = null;
   /** Reference to write function, saved from onConnected context. */
   private writeFn: ConnectionContext['write'] | null = null;
@@ -56,32 +95,52 @@ export class TrisaAdapter implements ScaleAdapter {
 
   async onConnected(ctx: ConnectionContext): Promise<void> {
     this.writeFn = ctx.write;
+    this.variant = this.detectVariant(ctx.availableChars);
+    bleLog.debug(`Trisa adapter: variant=${this.variant}`);
 
-    // Time sync — seconds since 2010-01-01 00:00:00 UTC
-    const EPOCH_2010 = 1262304000;
+    // Time sync (same opcode on both variants).
     const now = Math.floor(Date.now() / 1000) - EPOCH_2010;
     const tsCmd = Buffer.alloc(5);
-    tsCmd[0] = 0x02;
+    tsCmd[0] = OP_TIME_SYNC;
     tsCmd.writeUInt32LE(now, 1);
     await ctx.write(CHR_DOWNLOAD, [...tsCmd], true);
 
-    // Broadcast ID — signals pairing complete
-    await ctx.write(CHR_DOWNLOAD, [0x21], true);
+    // Broadcast / pairing-complete opcode differs between variants.
+    const broadcastOp = this.variant === 'ade' ? OP_BROADCAST_ADE : OP_BROADCAST_TRISA;
+    await ctx.write(CHR_DOWNLOAD, [broadcastOp], true);
+  }
+
+  private detectVariant(available: ReadonlySet<string>): Variant {
+    const hasTrisa = available.has(CHR_MEASUREMENT_TRISA);
+    const hasAde = available.has(CHR_MEASUREMENT_ADE);
+    if (!hasTrisa && hasAde) return 'ade';
+    return 'trisa';
   }
 
   /**
    * Dispatch notifications from different characteristics.
    *
-   * - 0x8A82: password (0xA0) and challenge (0xA1) frames
-   * - 0x8A21: measurement data
+   * Trisa:
+   *   - 0x8A82: password (0xA0) and challenge (0xA1) frames
+   *   - 0x8A21: measurement data
+   * ADE BA 1600:
+   *   - 0x8A82: challenge (0xA1) — no password frame; response algo unknown
+   *   - 0x8A24: measurement data (Trisa-compatible weight encoding)
+   *   - 0x8A22: body-composition push (encoding TBD)
    */
   parseCharNotification(charUuid: string, data: Buffer): ScaleReading | null {
     if (charUuid === CHR_UPLOAD) {
       this.handleUploadChannel(data);
       return null;
     }
-    if (charUuid === CHR_MEASUREMENT) {
+    if (charUuid === CHR_MEASUREMENT_TRISA || charUuid === CHR_MEASUREMENT_ADE) {
       return this.parseMeasurement(data);
+    }
+    if (charUuid === CHR_BODYCOMP_ADE) {
+      // Capture for future analysis — encoding not yet decoded so we can't
+      // turn this into impedance/fat/water/etc.
+      bleLog.debug(`ADE body-comp frame on 0x8A22 (TBD encoding): ${data.toString('hex')}`);
+      return null;
     }
     return null;
   }
@@ -104,17 +163,34 @@ export class TrisaAdapter implements ScaleAdapter {
 
   /**
    * Handle password and challenge frames from the upload channel (0x8A82).
+   *
+   * On Trisa: scale sends 0xA0 (password), then 0xA1 (challenge); host responds
+   * with [0xA1, XOR(challenge, password)].
+   *
+   * On ADE BA 1600: scale sends 0xA1 (challenge) directly without a password
+   * frame. The phone responds with 5 bytes starting with opcode 0x20 — the
+   * exact algorithm is not yet known. We don't write anything here on ADE,
+   * relying on the time-sync + broadcast handshake in onConnected() to
+   * progress the scale to the measurement state. If the scale stalls on ADE,
+   * a fresh capture with multiple weigh-ins will be needed to crack this.
    */
   private handleUploadChannel(data: Buffer): void {
     if (data.length < 2) return;
     const opcode = data[0];
+
+    if (this.variant === 'ade') {
+      // ADE challenge response algorithm is unknown. Logging the raw bytes
+      // helps when comparing against future captures.
+      bleLog.debug(`ADE upload frame (TBD response): ${data.toString('hex')}`);
+      return;
+    }
 
     if (opcode === OP_PASSWORD) {
       this.password = Buffer.from(data.subarray(1));
     } else if (opcode === OP_CHALLENGE && this.password && this.writeFn) {
       const challenge = data.subarray(1);
       const response = Buffer.alloc(challenge.length + 1);
-      response[0] = OP_CHALLENGE;
+      response[0] = OP_RESPONSE_TRISA;
       for (let i = 0; i < challenge.length; i++) {
         response[i + 1] = challenge[i] ^ (this.password[i % this.password.length] ?? 0);
       }
@@ -124,9 +200,9 @@ export class TrisaAdapter implements ScaleAdapter {
   }
 
   /**
-   * Parse a Trisa measurement frame from 0x8A21.
+   * Parse a Trisa measurement frame.
    *
-   * Layout:
+   * Layout (verified for Trisa 0x8A21 and ADE BA 1600 0x8A24, weight only):
    *   [0]      info flags
    *             bit 0: timestamp present (7 bytes at offset 5)
    *             bit 1: resistance1 present (4 bytes base-10 float)
@@ -137,8 +213,14 @@ export class TrisaAdapter implements ScaleAdapter {
    *   then:    optional resistance1 (4 bytes if bit1 set)
    *   then:    optional resistance2 (4 bytes if bit2 set)
    *
-   * Weight = mantissa * 10^exponent
-   * Impedance from resistance2: r2 < 410 ? 3.0 : 0.3 * (r2 - 400)
+   * Weight = mantissa * 10^exponent.
+   * Impedance from resistance2: r2 < 410 ? 3.0 : 0.3 * (r2 - 400).
+   *
+   * NOTE for ADE: the layout past the weight bytes appears to differ slightly
+   * from Trisa (timestamp may be 8 bytes instead of 7), so the impedance
+   * derived from this parser may be incorrect on ADE. Body-comp values arrive
+   * on 0x8A22 in a separate, currently undecoded frame — so for ADE we
+   * effectively only report weight until more captures are available.
    */
   private parseMeasurement(data: Buffer): ScaleReading | null {
     if (data.length < 5) return null;
@@ -161,19 +243,13 @@ export class TrisaAdapter implements ScaleAdapter {
 
     if (weight <= 0 || !Number.isFinite(weight)) return null;
 
-    // Walk through optional fields to find resistance2
+    // Walk through optional fields to find resistance2.
     let offset = 5;
-
-    if (hasTimestamp) {
-      offset += 7;
-    }
-
-    if (hasResistance1) {
-      offset += 4;
-    }
+    if (hasTimestamp) offset += 7;
+    if (hasResistance1) offset += 4;
 
     let impedance = 0;
-    if (hasResistance2 && offset + 4 <= data.length) {
+    if (this.variant === 'trisa' && hasResistance2 && offset + 4 <= data.length) {
       const r2Mantissa = data[offset] | (data[offset + 1] << 8) | (data[offset + 2] << 16);
       const r2Exponent = data.readInt8(offset + 3);
       const r2 = r2Mantissa * Math.pow(10, r2Exponent);

--- a/src/scales/trisa.ts
+++ b/src/scales/trisa.ts
@@ -95,6 +95,21 @@ export class TrisaAdapter implements ScaleAdapter {
 
   async onConnected(ctx: ConnectionContext): Promise<void> {
     this.writeFn = ctx.write;
+
+    // Both measurement chars are declared `optional` so that variant detection
+    // can pick whichever one the firmware exposes. If neither shows up, that
+    // is almost certainly a transient BlueZ ServicesResolved race
+    // (bluez/bluez#1489) — fail fast with a clear message instead of silently
+    // subscribing to no measurement char and stalling on read.
+    const hasMeasurement =
+      ctx.availableChars.has(CHR_MEASUREMENT_TRISA) || ctx.availableChars.has(CHR_MEASUREMENT_ADE);
+    if (!hasMeasurement) {
+      throw new Error(
+        'Trisa: no measurement characteristic discovered (expected 0x8A21 or 0x8A24). ' +
+          'Likely a transient BlueZ discovery race — try again.',
+      );
+    }
+
     this.variant = this.detectVariant(ctx.availableChars);
     bleLog.debug(`Trisa adapter: variant=${this.variant}`);
 
@@ -216,11 +231,10 @@ export class TrisaAdapter implements ScaleAdapter {
    * Weight = mantissa * 10^exponent.
    * Impedance from resistance2: r2 < 410 ? 3.0 : 0.3 * (r2 - 400).
    *
-   * NOTE for ADE: the layout past the weight bytes appears to differ slightly
-   * from Trisa (timestamp may be 8 bytes instead of 7), so the impedance
-   * derived from this parser may be incorrect on ADE. Body-comp values arrive
-   * on 0x8A22 in a separate, currently undecoded frame — so for ADE we
-   * effectively only report weight until more captures are available.
+   * NOTE: only the Trisa branch walks the optional-field table. For ADE the
+   * post-weight layout is unverified (timestamp may be 8 bytes instead of 7)
+   * and body comp arrives on a separate 0x8A22 push, so the parser
+   * short-circuits to weight-only after computing the weight.
    */
   private parseMeasurement(data: Buffer): ScaleReading | null {
     if (data.length < 5) return null;
@@ -243,13 +257,20 @@ export class TrisaAdapter implements ScaleAdapter {
 
     if (weight <= 0 || !Number.isFinite(weight)) return null;
 
+    // ADE BA 1600: only the weight bytes are verified (single capture frame in
+    // #138). The post-weight layout — timestamp width, resistance encoding —
+    // is not confirmed and body-comp values arrive on a separate 0x8A22 push
+    // anyway. Don't walk the offset table; return weight only until more
+    // captures are available.
+    if (this.variant === 'ade') return { weight, impedance: 0 };
+
     // Walk through optional fields to find resistance2.
     let offset = 5;
     if (hasTimestamp) offset += 7;
     if (hasResistance1) offset += 4;
 
     let impedance = 0;
-    if (this.variant === 'trisa' && hasResistance2 && offset + 4 <= data.length) {
+    if (hasResistance2 && offset + 4 <= data.length) {
       const r2Mantissa = data[offset] | (data[offset + 1] << 8) | (data[offset + 2] << 16);
       const r2Exponent = data.readInt8(offset + 3);
       const r2 = r2Mantissa * Math.pow(10, r2Exponent);

--- a/tests/ble/shared.test.ts
+++ b/tests/ble/shared.test.ts
@@ -820,4 +820,32 @@ describe('findMissingCharacteristics()', () => {
       [WRITE_UUID, OTHER_UUID].sort(),
     );
   });
+
+  it('skips optional bindings that are not present (used by Trisa/ADE variant detection)', () => {
+    const { charMap } = createCharMap([
+      [NOTIFY_UUID, createMockChar()],
+      [WRITE_UUID, createMockChar()],
+    ]);
+    const adapter = createLegacyAdapter({
+      characteristics: [
+        { service: SERVICE_UUID, uuid: NOTIFY_UUID, type: 'notify' },
+        { service: SERVICE_UUID, uuid: WRITE_UUID, type: 'write' },
+        // Optional and missing — must NOT show up as missing.
+        { service: SERVICE_UUID, uuid: OTHER_UUID, type: 'notify', optional: true },
+      ],
+    });
+    expect(findMissingCharacteristics(charMap, adapter)).toEqual([]);
+  });
+
+  it('still flags non-optional missing chars when other bindings are optional', () => {
+    const { charMap } = createCharMap([[NOTIFY_UUID, createMockChar()]]);
+    const adapter = createLegacyAdapter({
+      characteristics: [
+        { service: SERVICE_UUID, uuid: NOTIFY_UUID, type: 'notify' },
+        { service: SERVICE_UUID, uuid: WRITE_UUID, type: 'write' }, // required, missing
+        { service: SERVICE_UUID, uuid: OTHER_UUID, type: 'notify', optional: true }, // optional, missing
+      ],
+    });
+    expect(findMissingCharacteristics(charMap, adapter)).toEqual([WRITE_UUID]);
+  });
 });

--- a/tests/scales/trisa.test.ts
+++ b/tests/scales/trisa.test.ts
@@ -139,6 +139,16 @@ describe('TrisaAdapter', () => {
       // Verify challenge-response still works
       expect(writeFn).toHaveBeenCalledOnce();
     });
+
+    it('throws when neither 0x8A21 nor 0x8A24 is discovered (BlueZ race guard)', async () => {
+      const adapter = makeAdapter();
+      // Upload + download present but no measurement char — what a BlueZ
+      // ServicesResolved race could produce.
+      const partial = new Set<string>([uuid16(0x8a82), uuid16(0x8a81)]);
+      const { ctx } = ctxWithChars(partial);
+
+      await expect(adapter.onConnected!(ctx)).rejects.toThrow(/measurement characteristic/i);
+    });
   });
 
   describe('parseNotification()', () => {
@@ -290,6 +300,25 @@ describe('TrisaAdapter', () => {
       const adapter = makeAdapter();
       const buf = Buffer.from('6d652ab21e01caf07af252f11cf0', 'hex');
       expect(adapter.parseCharNotification!(uuid16(0x8a22), buf)).toBeNull();
+    });
+
+    it('returns impedance=0 on ADE measurement even when r2 flag is set', async () => {
+      const adapter = makeAdapter();
+      // Force variant=ade so the parser must skip the resistance walk.
+      const { ctx } = ctxWithChars(ADE_CHARS);
+      await adapter.onConnected!(ctx);
+
+      // Frame would compute impedance=30 on Trisa (r2 = 500.0 → 0.3*(500-400)).
+      // ADE branch must short-circuit to impedance=0 regardless of r2 flag.
+      const flags = 0x04; // r2 only
+      const weightFloat = encodeFloat(8000, -2); // 80.0 kg
+      const r2Float = encodeFloat(5000, -1); // r2 = 500
+      const buf = Buffer.concat([Buffer.from([flags]), weightFloat, r2Float]);
+
+      const reading = adapter.parseCharNotification!(uuid16(0x8a24), buf);
+      expect(reading).not.toBeNull();
+      expect(reading!.weight).toBeCloseTo(80, 1);
+      expect(reading!.impedance).toBe(0);
     });
 
     it('returns null for upload channel notifications', () => {

--- a/tests/scales/trisa.test.ts
+++ b/tests/scales/trisa.test.ts
@@ -17,6 +17,9 @@ function uuid16(code: number): string {
 
 const TRISA_CHARS = new Set<string>([uuid16(0x8a21), uuid16(0x8a82), uuid16(0x8a81)]);
 
+// 0x8A20 is exposed by ADE BA 1600 firmware but the adapter does not bind to
+// it — included here so the test ctx mirrors what the real scale advertises
+// post-discovery.
 const ADE_CHARS = new Set<string>([
   uuid16(0x8a24),
   uuid16(0x8a22),
@@ -140,10 +143,11 @@ describe('TrisaAdapter', () => {
       expect(writeFn).toHaveBeenCalledOnce();
     });
 
-    it('throws when neither 0x8A21 nor 0x8A24 is discovered (BlueZ race guard)', async () => {
+    it('throws when neither 0x8A21 nor 0x8A24 is discovered (GATT race guard)', async () => {
       const adapter = makeAdapter();
-      // Upload + download present but no measurement char — what a BlueZ
-      // ServicesResolved race could produce.
+      // Upload + download present but no measurement char — what a transient
+      // GATT discovery race (BlueZ ServicesResolved firing early or noble
+      // equivalent on Windows/macOS) could produce.
       const partial = new Set<string>([uuid16(0x8a82), uuid16(0x8a81)]);
       const { ctx } = ctxWithChars(partial);
 

--- a/tests/scales/trisa.test.ts
+++ b/tests/scales/trisa.test.ts
@@ -11,6 +11,35 @@ function makeAdapter() {
   return new TrisaAdapter();
 }
 
+function uuid16(code: number): string {
+  return `0000${code.toString(16).padStart(4, '0')}00001000800000805f9b34fb`;
+}
+
+const TRISA_CHARS = new Set<string>([uuid16(0x8a21), uuid16(0x8a82), uuid16(0x8a81)]);
+
+const ADE_CHARS = new Set<string>([
+  uuid16(0x8a24),
+  uuid16(0x8a22),
+  uuid16(0x8a20),
+  uuid16(0x8a82),
+  uuid16(0x8a81),
+]);
+
+function ctxWithChars(
+  available: ReadonlySet<string>,
+  writeFn = vi.fn().mockResolvedValue(undefined),
+): { ctx: ConnectionContext; writeFn: ReturnType<typeof vi.fn> } {
+  const ctx: ConnectionContext = {
+    write: writeFn,
+    read: vi.fn(),
+    subscribe: vi.fn(),
+    profile: defaultProfile(),
+    deviceAddress: '',
+    availableChars: available,
+  };
+  return { ctx, writeFn };
+}
+
 /**
  * Encode weight as base-10 float: 24-bit LE mantissa + int8 exponent.
  * weight = mantissa * 10^exponent
@@ -54,16 +83,9 @@ describe('TrisaAdapter', () => {
   });
 
   describe('onConnected()', () => {
-    it('saves writeFn and sends time sync + broadcast', async () => {
+    it('saves writeFn and sends time sync + broadcast (Trisa variant)', async () => {
       const adapter = makeAdapter();
-      const writeFn = vi.fn().mockResolvedValue(undefined);
-
-      const ctx: ConnectionContext = {
-        write: writeFn,
-        read: vi.fn(),
-        subscribe: vi.fn(),
-        profile: defaultProfile(),
-      };
+      const { ctx, writeFn } = ctxWithChars(TRISA_CHARS);
 
       await adapter.onConnected!(ctx);
 
@@ -82,28 +104,32 @@ describe('TrisaAdapter', () => {
       const tsFromCmd = Buffer.from(data1.slice(1)).readUInt32LE(0);
       expect(Math.abs(tsFromCmd - expectedTs)).toBeLessThan(5);
 
-      // Call 2: broadcast ID
+      // Call 2: broadcast ID — Trisa uses 0x21
       const [charUuid2, data2, withResponse2] = writeFn.mock.calls[1];
       expect(charUuid2).toBe(adapter.charWriteUuid);
       expect(withResponse2).toBe(true);
       expect(data2).toEqual([0x21]);
     });
 
+    it('uses 0x22 broadcast opcode on ADE variant', async () => {
+      const adapter = makeAdapter();
+      const { ctx, writeFn } = ctxWithChars(ADE_CHARS);
+
+      await adapter.onConnected!(ctx);
+
+      expect(writeFn).toHaveBeenCalledTimes(2);
+      const [, data2] = writeFn.mock.calls[1];
+      expect(data2).toEqual([0x22]);
+    });
+
     it('writeFn is available for challenge-response after onConnected', async () => {
       const adapter = makeAdapter();
-      const writeFn = vi.fn().mockResolvedValue(undefined);
-
-      const ctx: ConnectionContext = {
-        write: writeFn,
-        read: vi.fn(),
-        subscribe: vi.fn(),
-        profile: defaultProfile(),
-      };
+      const { ctx, writeFn } = ctxWithChars(TRISA_CHARS);
 
       await adapter.onConnected!(ctx);
       writeFn.mockClear();
 
-      const uploadUuid = adapter.characteristics![1].uuid;
+      const uploadUuid = uuid16(0x8a82);
 
       // Password
       adapter.parseCharNotification!(uploadUuid, Buffer.from([0xa0, 0x11]));
@@ -174,28 +200,35 @@ describe('TrisaAdapter', () => {
   });
 
   describe('characteristics', () => {
-    it('declares three characteristics for multi-char protocol', () => {
+    it('declares Trisa + ADE chars with optional flags for variant detection', () => {
       const adapter = makeAdapter();
-      expect(adapter.characteristics).toHaveLength(3);
-      expect(adapter.characteristics!.map((c) => c.type)).toEqual(['notify', 'notify', 'write']);
+      expect(adapter.characteristics).toHaveLength(5);
+      const meas21 = adapter.characteristics!.find((c) => c.uuid === uuid16(0x8a21));
+      const meas24 = adapter.characteristics!.find((c) => c.uuid === uuid16(0x8a24));
+      const bodyComp22 = adapter.characteristics!.find((c) => c.uuid === uuid16(0x8a22));
+      const upload = adapter.characteristics!.find((c) => c.uuid === uuid16(0x8a82));
+      const download = adapter.characteristics!.find((c) => c.uuid === uuid16(0x8a81));
+
+      // Variant-specific chars must be optional
+      expect(meas21?.optional).toBe(true);
+      expect(meas24?.optional).toBe(true);
+      expect(bodyComp22?.optional).toBe(true);
+      // Shared chars are required
+      expect(upload?.optional).toBeFalsy();
+      expect(download?.optional).toBeFalsy();
+      expect(upload?.type).toBe('notify');
+      expect(download?.type).toBe('write');
     });
   });
 
   describe('challenge-response', () => {
-    it('stores password and responds to challenge with XOR', async () => {
+    it('stores password and responds to challenge with XOR (Trisa variant)', async () => {
       const adapter = makeAdapter();
-      const writeFn = vi.fn().mockResolvedValue(undefined);
-
-      const ctx: ConnectionContext = {
-        write: writeFn,
-        read: vi.fn(),
-        subscribe: vi.fn(),
-        profile: defaultProfile(),
-      };
+      const { ctx, writeFn } = ctxWithChars(TRISA_CHARS);
       await adapter.onConnected!(ctx);
       writeFn.mockClear(); // Clear the time sync + broadcast writes
 
-      const uploadUuid = adapter.characteristics![1].uuid; // 0x8A82
+      const uploadUuid = uuid16(0x8a82);
 
       // Step 1: Scale sends password on upload channel
       const password = Buffer.from([0xa0, 0x11, 0x22, 0x33]);
@@ -208,7 +241,7 @@ describe('TrisaAdapter', () => {
       // Verify response was written
       expect(writeFn).toHaveBeenCalledOnce();
       const [charUuid, data, withResponse] = writeFn.mock.calls[0];
-      expect(charUuid).toBe(adapter.characteristics![2].uuid); // 0x8A81
+      expect(charUuid).toBe(uuid16(0x8a81));
 
       // Response = [0xA1, XOR(challenge, password)]
       expect(data[0]).toBe(0xa1);
@@ -218,25 +251,51 @@ describe('TrisaAdapter', () => {
       expect(withResponse).toBe(true);
     });
 
-    it('dispatches measurement data via parseCharNotification', () => {
+    it('does not respond to challenge on ADE variant (response algo unknown)', async () => {
       const adapter = makeAdapter();
-      const measurementUuid = adapter.characteristics![0].uuid; // 0x8A21
+      const { ctx, writeFn } = ctxWithChars(ADE_CHARS);
+      await adapter.onConnected!(ctx);
+      writeFn.mockClear();
 
+      const uploadUuid = uuid16(0x8a82);
+      // ADE only sends challenge directly, no preceding password
+      adapter.parseCharNotification!(uploadUuid, Buffer.from([0xa1, 0x01, 0x00, 0xb2, 0x2a]));
+
+      expect(writeFn).not.toHaveBeenCalled();
+    });
+
+    it('dispatches Trisa measurement (0x8A21) via parseCharNotification', () => {
+      const adapter = makeAdapter();
       const flags = 0x00;
       const weightFloat = encodeFloat(8000, -2);
       const buf = Buffer.concat([Buffer.from([flags]), weightFloat]);
 
-      const reading = adapter.parseCharNotification!(measurementUuid, buf);
+      const reading = adapter.parseCharNotification!(uuid16(0x8a21), buf);
       expect(reading).not.toBeNull();
       expect(reading!.weight).toBeCloseTo(80, 1);
     });
 
+    it('dispatches ADE measurement (0x8A24) via parseCharNotification', () => {
+      const adapter = makeAdapter();
+      // Real frame from ADE BA 1600 capture (issue #138):
+      // 1f 68 1f 00 fe ... → flags=0x1f, mantissa=0x001f68=8040, exp=-2 → 80.40 kg
+      const buf = Buffer.from('1f681f00fe652ab21e000000006a1500ff011900', 'hex');
+
+      const reading = adapter.parseCharNotification!(uuid16(0x8a24), buf);
+      expect(reading).not.toBeNull();
+      expect(reading!.weight).toBeCloseTo(80.4, 1);
+    });
+
+    it('returns null and only logs for ADE body-comp char (0x8A22)', () => {
+      const adapter = makeAdapter();
+      const buf = Buffer.from('6d652ab21e01caf07af252f11cf0', 'hex');
+      expect(adapter.parseCharNotification!(uuid16(0x8a22), buf)).toBeNull();
+    });
+
     it('returns null for upload channel notifications', () => {
       const adapter = makeAdapter();
-      const uploadUuid = adapter.characteristics![1].uuid;
-
       const data = Buffer.from([0xa0, 0x11, 0x22]);
-      expect(adapter.parseCharNotification!(uploadUuid, data)).toBeNull();
+      expect(adapter.parseCharNotification!(uuid16(0x8a82), data)).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

Adds partial support for the **ADE BA 1600** body-composition scale (sold under the **fitvigo** app), which belongs to the Trisa protocol family but uses a slightly different firmware. After this PR an ADE BA 1600 connects, completes the handshake, and reports **weight** to BLE Scale Sync. Body composition (impedance / fat / water / muscle / bone) is **not yet decoded** for ADE — the adapter logs the relevant frames at debug level so we can analyze them once we have more captures from the reporter.

Closes part of #138.

## What I confirmed from the HCI snoop log in #138

| Aspect | Trisa (existing) | ADE BA 1600 |
|---|---|---|
| Measurement char | 0x8A21 (notify) | **0x8A24** (indicate) |
| Body-comp char | n/a | 0x8A22 (indicate, encoding TBD) |
| Upload (challenge) | 0x8A82 (notify) | 0x8A82 (indicate) |
| Download (write) | 0x8A81 | 0x8A81 |
| Time-sync opcode | 0x02 | 0x02 |
| Pairing-complete opcode | 0x21 | **0x22** |
| Challenge-response | password (0xA0) + XOR with [0xA1] echo | challenge (0xA1) only, response opcode 0x20, algo unknown |
| Weight encoding | flags + 24-bit LE mantissa + int8 exponent | **same** (verified: 80.40 kg from `1f681f00fe...`) |

## Approach

Rather than introduce a separate adapter (both variants advertise the same `01257B*`/`11257B*` name and we cannot disambiguate from advertisement data), the existing Trisa adapter now handles both firmware variants. Variant detection happens in `onConnected()` based on the GATT characteristics that were actually discovered.

To make this clean I added two small affordances to the BLE infrastructure that future multi-variant adapters can reuse:

- `CharacteristicBinding.optional?: boolean` — bindings flagged optional are skipped by `findMissingCharacteristics` and `subscribeAndInit` when missing.
- `ConnectionContext.availableChars: ReadonlySet<string>` — adapters can inspect which chars exist post-discovery to switch behavior.

## Why partial?

The HCI capture attached to #138 ends ~4 seconds after the initial pairing handshake; only **one** measurement frame is captured. From that frame we can confirm the weight encoding (Trisa-compatible), but the body-composition push on 0x8A22 and the challenge-response algorithm on 0x8A82 (response opcode 0x20) cannot be reverse-engineered from a single sample. I have asked the reporter for additional captures so we can finish the decoder in a follow-up PR.

If the time-sync + 0x22 broadcast alone is not enough to unlock measurement on the scale (i.e. the scale stalls waiting for the unknown response), that will be visible in the reporter's debug log — the adapter logs every ADE upload-channel frame at debug level for exactly this reason.

## Test plan

- [x] `npm run build`
- [x] `npm test` — all 64 files / 1259 tests pass (4 new tests for ADE)
- [x] `npm run lint`
- [x] `npm run format:check`
- [ ] Reporter (sttehh) tests an ADE BA 1600 against the new adapter and reports back

## Notes

- Original Trisa scales remain unaffected — the existing 0x8A21 / password+challenge path is preserved and gated on variant detection.
- The optional-binding mechanism is generic and can be reused by future adapters that need to handle multiple firmware variants of the same protocol family.