### PR TITLE
feat(ble): consecutive-failure watchdog for BlueZ stuck-state recovery

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -90,6 +90,10 @@ Step on the scale during the scan so it starts advertising.
 
 On Linux, `sudo systemctl restart bluetooth` fixes roughly 80% of transient GATT issues. If failures persist, flip `ble.noble_driver` between `abandonware` and `stoprocent` in `config.yaml`. The full decision tree lives in [Troubleshooting](/troubleshooting).
 
+### My Raspberry Pi works for a few hours then stops finding the scale until I reboot. How do I fix this?
+
+This is the BlueZ "stuck discovery" state — a known kernel/firmware-level issue on Pi 3 / 4 / Zero 2W with the on-board Broadcom Bluetooth chip. BLE Scale Sync's recovery tiers (D-Bus stop, btmgmt power-cycle, rfkill, `systemctl restart bluetoothd`) clear it on most setups but sometimes don't on Pi Broadcom firmware. Home Assistant has the [same problem](https://github.com/home-assistant/operating-system/issues/4022) and recommends the same fix: an [ESP32](/guide/esp32-proxy) or [ESPHome](/guide/esphome-proxy) Bluetooth proxy that runs the BLE work outside the Pi. If you want to stick with the on-board chip, the built-in [watchdog](/troubleshooting#ble-discovery-stops-working-after-hours-bluez-stuck-state) auto-restarts the container after 10 consecutive scan failures so Docker can recover automatically.
+
 ---
 
 ## Body composition

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -141,6 +141,7 @@ runtime:
   scan_cooldown: 30
   dry_run: false
   debug: false
+  watchdog_max_consecutive_failures: 10
 ```
 
 | Field | Required | Default | Description |
@@ -149,6 +150,7 @@ runtime:
 | `scan_cooldown` | No | `30` | Seconds between scans (5–3600) |
 | `dry_run` | No | `false` | Read scale + compute body comp, skip exports |
 | `debug` | No | `false` | Verbose BLE logging |
+| `watchdog_max_consecutive_failures` | No | `10` | In continuous mode on Linux: exit after this many consecutive scan failures so Docker `restart: unless-stopped` can recover from a stuck BlueZ controller (0 = disabled). See [Troubleshooting](/troubleshooting#ble-discovery-stops-working-after-hours-bluez-stuck-state). |
 
 ### Update Check
 
@@ -187,6 +189,7 @@ These environment variables always override `config.yaml` values, useful for Doc
 | `DRY_RUN` | `runtime.dry_run` |
 | `DEBUG` | `runtime.debug` |
 | `SCAN_COOLDOWN` | `runtime.scan_cooldown` |
+| `BLE_WATCHDOG_MAX_FAILURES` | `runtime.watchdog_max_consecutive_failures` |
 | `SCALE_MAC` | `ble.scale_mac` |
 | `NOBLE_DRIVER` | `ble.noble_driver` |
 | `BLE_ADAPTER` | `ble.adapter` |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -125,23 +125,41 @@ getent group bluetooth | cut -d: -f3
 
 Common values: `112` (Debian/Ubuntu), `108` (Arch).
 
-### BLE discovery stops working after hours (BlueZ zombie state)
+### BLE discovery stops working after hours (BlueZ stuck state)
 
 **Symptoms** (visible with `DEBUG=true`):
 
 - Repeated `startDiscovery failed: Discovery already in progress` and `D-Bus StopDiscovery failed: No discovery started`
 - Or `Discovery started` logs succeed, but the scale is never found even after stepping on it
-- Common on Raspberry Pi Zero 2W / 3 / 4 with the built-in Broadcom adapter
+- Common on Raspberry Pi 3 / 4 / Zero 2W with the on-board Broadcom adapter under continuous-mode load
 
 **Cause.** A [known BlueZ bug](https://github.com/bluez/bluez/issues/807) (also tracked at [bluez/bluer#47](https://github.com/bluez/bluer/issues/47)): after repeated GATT connect/disconnect cycles, BlueZ's `Discovering` property desyncs from the HCI controller. The daemon reports active discovery, but the controller is no longer running LE scan.
 
-**Automatic recovery.** The app already:
+::: warning Hardware/firmware limitation, not just software
+On Pi 3/4 Broadcom on-board chips, this is a kernel/firmware-level issue that even much larger projects have given up on fixing in software — see [home-assistant/operating-system#4022](https://github.com/home-assistant/operating-system/issues/4022) and [home-assistant/core#142656](https://github.com/home-assistant/core/issues/142656), both closed as **Not Planned** with HA recommending a Bluetooth proxy as the workaround. The recovery tiers below clear the wedge on most setups but not all of them.
+:::
+
+**Recommended long-term fix: Bluetooth proxy.** The most reliable way to run BLE Scale Sync on a Pi long-term is to bypass the on-board Bluetooth entirely — run an external [ESP32 BLE proxy](/guide/esp32-proxy) (≈€8 board, communicates over MQTT) or reuse an existing [ESPHome BT proxy](/guide/esphome-proxy). Both eliminate the host BlueZ stack from the BLE path completely.
+
+**Automatic in-process recovery.** The app already:
 
 - Resets its D-Bus client after every GATT operation in continuous mode
 - Runs a preemptive `btmgmt power off/on` cycle after every GATT operation to clear zombie controller state before it accumulates
-- Escalates through 6 recovery tiers when `StartDiscovery` fails (D-Bus StopDiscovery, adapter power-cycle, btmgmt reset, rfkill, bluetoothd restart)
+- Escalates through 6 recovery tiers when `StartDiscovery` fails (D-Bus `StopDiscovery`, adapter power-cycle, btmgmt reset, rfkill block/unblock, `systemctl restart bluetooth`)
 
-**What you should do in Docker.** Make sure `/dev/rfkill` is mapped so Tier 5 recovery is available:
+**Auto-restart watchdog (continuous mode).** When in-process recovery is not enough — typically Pi 3/4 Broadcom firmware lock-up — a watchdog exits the process after `runtime.watchdog_max_consecutive_failures` consecutive scan failures (default `10`, ≈30 min). With Docker `restart: unless-stopped` the container restarts cleanly, the entrypoint resets the BT adapter, and the controller is typically unwedged. The watchdog only arms after the first successful weigh-in in the process lifetime, so it does not restart-loop the container if the scale is offline (vacation) or `scale_mac` is misconfigured.
+
+```yaml
+runtime:
+  watchdog_max_consecutive_failures: 10  # default; 0 = disabled
+```
+
+```bash
+# Or env override
+docker run ... -e BLE_WATCHDOG_MAX_FAILURES=10 ghcr.io/kristianp26/ble-scale-sync:latest
+```
+
+**Docker compose tip.** Make sure `/dev/rfkill` is mapped so Tier 5 recovery is available:
 
 ```yaml
 devices:
@@ -151,7 +169,6 @@ devices:
 **Last-resort escape hatch: switch away from BlueZ.** If BlueZ keeps getting stuck despite the above, bypass it entirely by using the `@stoprocent/noble` driver (HCI socket directly, no D-Bus):
 
 ```yaml
-# config.yaml
 ble:
   noble_driver: stoprocent
 ```

--- a/src/ble/watchdog.ts
+++ b/src/ble/watchdog.ts
@@ -1,0 +1,62 @@
+/**
+ * Circuit-breaker for the continuous-mode poll loop.
+ *
+ * On Linux the BlueZ controller can enter a "zombie discovery" state after a
+ * few GATT cycles (especially on Raspberry Pi 3/4 Broadcom on-board chips):
+ * `Discovering=true` is reported, but no actual scanning happens. The handler
+ * already has multiple recovery tiers (D-Bus stop, btmgmt power-cycle, rfkill,
+ * systemctl restart bluetooth), but on this hardware they sometimes fail to
+ * unwedge the firmware. The deterministic recovery is to exit the process so
+ * Docker `restart: unless-stopped` rebuilds the container — which closes all
+ * D-Bus clients and runs the entrypoint's BT reset, which generally clears
+ * the wedge.
+ *
+ * The watchdog only arms after the first successful scan in the process'
+ * lifetime. This avoids restart loops when the user is on vacation (scale
+ * powered off the whole time → no first success → watchdog stays disarmed).
+ *
+ * See: bluez/bluer#47, home-assistant/operating-system#4022, issue #80.
+ */
+export interface WatchdogTripContext {
+  consecutiveFailures: number;
+}
+
+export class ConsecutiveFailureWatchdog {
+  private consecutiveFailures = 0;
+  private hasSucceededOnce = false;
+
+  constructor(
+    private readonly maxFailures: number,
+    private readonly onTrip: (ctx: WatchdogTripContext) => void,
+  ) {}
+
+  /** Record a successful scan cycle. Resets the failure count and arms the watchdog. */
+  recordSuccess(): void {
+    this.consecutiveFailures = 0;
+    this.hasSucceededOnce = true;
+  }
+
+  /**
+   * Record a failed scan cycle. If the watchdog is enabled (max > 0) and armed
+   * (first success seen), increment the counter and trip when it reaches the
+   * configured max.
+   */
+  recordFailure(): void {
+    if (this.maxFailures <= 0) return;
+    if (!this.hasSucceededOnce) return;
+
+    this.consecutiveFailures++;
+    if (this.consecutiveFailures >= this.maxFailures) {
+      this.onTrip({ consecutiveFailures: this.consecutiveFailures });
+    }
+  }
+
+  /** Inspectable state for tests and logging. */
+  get state(): { consecutiveFailures: number; hasSucceededOnce: boolean; enabled: boolean } {
+    return {
+      consecutiveFailures: this.consecutiveFailures,
+      hasSucceededOnce: this.hasSucceededOnce,
+      enabled: this.maxFailures > 0,
+    };
+  }
+}

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -102,6 +102,7 @@ function applyEnvOverrides(config: AppConfig): AppConfig {
     scan_cooldown: config.runtime?.scan_cooldown ?? 30,
     dry_run: config.runtime?.dry_run ?? false,
     debug: config.runtime?.debug ?? false,
+    watchdog_max_consecutive_failures: config.runtime?.watchdog_max_consecutive_failures ?? 10,
   };
   const ble = { handler: 'auto' as const, ...config.ble };
 
@@ -121,6 +122,12 @@ function applyEnvOverrides(config: AppConfig): AppConfig {
     const num = Number(process.env.SCAN_COOLDOWN);
     if (Number.isFinite(num) && num >= 5 && num <= 3600) {
       runtime.scan_cooldown = num;
+    }
+  }
+  if (process.env.BLE_WATCHDOG_MAX_FAILURES !== undefined) {
+    const num = Number(process.env.BLE_WATCHDOG_MAX_FAILURES);
+    if (Number.isInteger(num) && num >= 0 && num <= 1000) {
+      runtime.watchdog_max_consecutive_failures = num;
     }
   }
 
@@ -324,6 +331,7 @@ export function loadEnvConfig(): AppConfig {
       scan_cooldown: envConfig.scanCooldownSec,
       dry_run: envConfig.dryRun,
       debug: process.env.DEBUG === 'true',
+      watchdog_max_consecutive_failures: 10,
     },
     update_check: true,
   };

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -52,6 +52,7 @@ export interface ResolvedRuntimeConfig {
   dryRun: boolean;
   continuousMode: boolean;
   scanCooldownSec: number;
+  watchdogMaxFailures: number;
   bleHandler: BleHandlerName;
   bleAdapter?: string;
   mqttProxy?: MqttProxyConfig;
@@ -72,6 +73,7 @@ export function resolveRuntimeConfig(config: AppConfig): ResolvedRuntimeConfig {
     dryRun: config.runtime?.dry_run ?? false,
     continuousMode: config.runtime?.continuous_mode ?? false,
     scanCooldownSec: config.runtime?.scan_cooldown ?? 30,
+    watchdogMaxFailures: config.runtime?.watchdog_max_consecutive_failures ?? 10,
     bleHandler: config.ble?.handler ?? 'auto',
     bleAdapter: config.ble?.adapter ?? undefined,
     mqttProxy: config.ble?.mqtt_proxy ?? undefined,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -126,6 +126,12 @@ export const RuntimeSchema = z.object({
   scan_cooldown: z.number().int().min(5).max(3600).default(30),
   dry_run: z.boolean().default(false),
   debug: z.boolean().default(false),
+  /**
+   * Continuous-mode watchdog: exit the process after this many consecutive scan
+   * failures (after at least one successful scan). Docker `restart: unless-stopped`
+   * then performs a clean BlueZ recovery. Set to 0 to disable.
+   */
+  watchdog_max_consecutive_failures: z.number().int().min(0).max(1000).default(10),
 });
 
 export const DockerSchema = z.object({

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
 import { bootstrapMqttProxy } from './ble/mqtt-proxy-bootstrap.js';
 import type { EmbeddedBrokerHandle } from './ble/embedded-broker.js';
 import { abortableSleep } from './ble/types.js';
+import { ConsecutiveFailureWatchdog } from './ble/watchdog.js';
 import { adapters } from './scales/index.js';
 import { createLogger, setLogLevel, LogLevel } from './logger.js';
 import { errMsg } from './utils/error.js';
@@ -54,6 +55,9 @@ if (cliFlags.help) {
   console.log('  DRY_RUN          true/false — override runtime.dry_run');
   console.log('  DEBUG            true/false — override runtime.debug');
   console.log('  SCAN_COOLDOWN    5-3600     — override runtime.scan_cooldown');
+  console.log(
+    '  BLE_WATCHDOG_MAX_FAILURES 0-1000 — override runtime.watchdog_max_consecutive_failures (0 = disabled)',
+  );
   console.log('  SCALE_MAC        MAC/UUID   — override ble.scale_mac');
   console.log('  NOBLE_DRIVER     abandonware/stoprocent — override ble.noble_driver');
   console.log('  BLE_ADAPTER      hci0/hci1/... — override ble.adapter (Linux only)');
@@ -77,6 +81,7 @@ const {
   dryRun,
   continuousMode,
   scanCooldownSec,
+  watchdogMaxFailures,
   bleHandler,
   bleAdapter,
   mqttProxy: initialMqttProxy,
@@ -522,7 +527,27 @@ async function main(): Promise<void> {
     }
     await watcher.stop();
   } else {
-    // Poll-based loop for auto/noble BLE handlers
+    // Poll-based loop for auto/noble BLE handlers.
+    //
+    // The watchdog is BlueZ-specific: on Pi 3/4 Broadcom on-board chips the
+    // controller can enter a stuck state after a few GATT cycles where the
+    // in-handler recovery tiers (D-Bus stop, btmgmt, rfkill, systemctl) don't
+    // unwedge the firmware. After N consecutive failures (post first-success)
+    // we exit so Docker's `restart: unless-stopped` can rebuild the container,
+    // closing all D-Bus clients and re-running the entrypoint's BT reset.
+    const watchdog = new ConsecutiveFailureWatchdog(
+      watchdogMaxFailures,
+      ({ consecutiveFailures }) => {
+        log.warn(
+          `Watchdog triggered: ${consecutiveFailures} consecutive scan failures since last ` +
+            `success. Exiting so the container can restart cleanly. ` +
+            `If this persists on Raspberry Pi 3/4 with the on-board Bluetooth chip, ` +
+            `consider an ESP32/ESPHome BLE proxy — see https://blescalesync.dev/troubleshooting`,
+        );
+        process.exit(1);
+      },
+    );
+
     while (!signal.aborted) {
       try {
         touchHeartbeat();
@@ -543,6 +568,7 @@ async function main(): Promise<void> {
         }
 
         backoffMs = 0; // Reset backoff on success
+        watchdog.recordSuccess();
 
         if (signal.aborted) break;
         const cooldown = appConfig.runtime?.scan_cooldown ?? scanCooldownSec;
@@ -550,6 +576,11 @@ async function main(): Promise<void> {
         await abortableSleep(cooldown * 1000, signal);
       } catch (err) {
         if (signal.aborted) break;
+
+        // Watchdog records the failure and may exit the process if armed and
+        // tripped — order matters: trip before sleeping so we don't waste a
+        // backoff cycle on a controller we already know is wedged.
+        watchdog.recordFailure();
 
         // Exponential backoff: 5s → 10s → 20s → 40s → 60s (cap)
         backoffMs = backoffMs === 0 ? BACKOFF_INITIAL_MS : Math.min(backoffMs * 2, BACKOFF_MAX_MS);

--- a/src/wizard/steps/runtime.ts
+++ b/src/wizard/steps/runtime.ts
@@ -37,7 +37,13 @@ export const runtimeStep: WizardStep = {
       default: false,
     });
 
-    ctx.config.runtime = { continuous_mode, scan_cooldown, dry_run, debug };
+    ctx.config.runtime = {
+      continuous_mode,
+      scan_cooldown,
+      dry_run,
+      debug,
+      watchdog_max_consecutive_failures: 10,
+    };
 
     console.log(
       dim(

--- a/tests/ble/watchdog.test.ts
+++ b/tests/ble/watchdog.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ConsecutiveFailureWatchdog } from '../../src/ble/watchdog.js';
+
+describe('ConsecutiveFailureWatchdog', () => {
+  it('does nothing on failure when maxFailures is 0 (disabled)', () => {
+    const onTrip = vi.fn();
+    const w = new ConsecutiveFailureWatchdog(0, onTrip);
+    w.recordSuccess();
+    for (let i = 0; i < 100; i++) w.recordFailure();
+    expect(onTrip).not.toHaveBeenCalled();
+    expect(w.state.enabled).toBe(false);
+  });
+
+  it('does not trip before first success even if many failures occur', () => {
+    const onTrip = vi.fn();
+    const w = new ConsecutiveFailureWatchdog(3, onTrip);
+    for (let i = 0; i < 50; i++) w.recordFailure();
+    expect(onTrip).not.toHaveBeenCalled();
+    expect(w.state.consecutiveFailures).toBe(0);
+    expect(w.state.hasSucceededOnce).toBe(false);
+  });
+
+  it('trips on the Nth consecutive failure after first success', () => {
+    const onTrip = vi.fn();
+    const w = new ConsecutiveFailureWatchdog(3, onTrip);
+
+    w.recordSuccess();
+    expect(w.state.hasSucceededOnce).toBe(true);
+
+    w.recordFailure();
+    expect(onTrip).not.toHaveBeenCalled();
+    w.recordFailure();
+    expect(onTrip).not.toHaveBeenCalled();
+    w.recordFailure();
+    expect(onTrip).toHaveBeenCalledOnce();
+    expect(onTrip).toHaveBeenCalledWith({ consecutiveFailures: 3 });
+  });
+
+  it('resets the counter on success (cycle of fail/success/fail does not accumulate)', () => {
+    const onTrip = vi.fn();
+    const w = new ConsecutiveFailureWatchdog(3, onTrip);
+
+    w.recordSuccess();
+    w.recordFailure();
+    w.recordFailure();
+    expect(w.state.consecutiveFailures).toBe(2);
+
+    w.recordSuccess();
+    expect(w.state.consecutiveFailures).toBe(0);
+
+    w.recordFailure();
+    w.recordFailure();
+    expect(onTrip).not.toHaveBeenCalled();
+  });
+
+  it('keeps tripping on each failure once threshold is crossed (caller should exit)', () => {
+    // The watchdog itself does not stop tripping — exiting/handling is the
+    // caller's responsibility (in the real loop, onTrip calls process.exit).
+    const onTrip = vi.fn();
+    const w = new ConsecutiveFailureWatchdog(2, onTrip);
+    w.recordSuccess();
+    w.recordFailure();
+    w.recordFailure(); // trips at 2
+    w.recordFailure(); // trips at 3
+    expect(onTrip).toHaveBeenCalledTimes(2);
+    expect(onTrip).toHaveBeenLastCalledWith({ consecutiveFailures: 3 });
+  });
+
+  it('exposes state for inspection', () => {
+    const w = new ConsecutiveFailureWatchdog(5, () => {});
+    expect(w.state).toEqual({
+      consecutiveFailures: 0,
+      hasSucceededOnce: false,
+      enabled: true,
+    });
+    w.recordSuccess();
+    w.recordFailure();
+    expect(w.state).toEqual({
+      consecutiveFailures: 1,
+      hasSucceededOnce: true,
+      enabled: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a circuit-breaker for the continuous-mode poll loop. After N consecutive scan failures (post first-success in the process lifetime) the process exits with code 1, and Docker `restart: unless-stopped` rebuilds the container — closing all D-Bus client state and re-running the entrypoint's BT reset.

This is the deterministic recovery path for the BlueZ "stuck discovery" state that #80 has been chasing for two months. The handler-level recovery tiers (D-Bus stop, btmgmt power-cycle, rfkill, systemctl restart bluetoothd) clear the wedge on most setups, but on Pi 3/4 Broadcom on-board chips they sometimes fail to unwedge the firmware. Home Assistant has come to the same conclusion (HA OS issue #4022, HA Core #142656 both closed as Not Planned, with HA recommending ESPHome BT proxy as the workaround).

## Approach

- **`ConsecutiveFailureWatchdog`** in `src/ble/watchdog.ts` — small testable class with `recordSuccess`/`recordFailure`. The `onTrip` callback is wired to log + `process.exit(1)` in `src/index.ts`.
- **First-success guard.** The watchdog only arms after the first successful scan in the process lifetime. Without it, the container would restart-loop when the user is on vacation (scale off → no first success → no scope to declare "stuck") or has misconfigured `scale_mac`.
- **Poll-based loop only.** Mqtt-proxy and esphome-proxy paths don't talk to host BlueZ and have their own resilience strategies.
- **Default 10 failures** = ~30 min wedge window before container restart (60s capped backoff + 2-min scan timeout per cycle). Configurable via `runtime.watchdog_max_consecutive_failures` (range 0-1000, 0 = disabled) or `BLE_WATCHDOG_MAX_FAILURES` env.

## Diagram

```
Container starts
  │
  ├─ Scan #1: scale found, reading ok ─── watchdog armed
  ├─ Scan #2: ok                    ─── counter reset
  ├─ Scan #3: timeout               ─── failures = 1
  ├─ Scan #4: timeout               ─── failures = 2
  │     ...
  └─ Scan #12: timeout              ─── failures = 10 → exit(1)
                                          ↓
Docker restart: unless-stopped → entrypoint Reset Bluetooth → fresh start
```

## What this is NOT

This is not a fix for the BlueZ wedge itself — that's a kernel/firmware/hardware issue we cannot fully solve in user-space (see #80 discussion linking bluez/bluer#47, home-assistant/operating-system#4022). The watchdog is a deterministic *recovery* — automating the manual `docker restart ble-scale-sync` that affected users were already doing.

For a permanent fix on Pi 3/4 Broadcom hosts, the ESP32/ESPHome BT proxy paths are recommended (already supported, see [docs/guide/esp32-proxy](https://blescalesync.dev/guide/esp32-proxy)).

## Test plan

- [x] `npm run build`
- [x] `npm test` — 65 files / 1267 tests pass (6 new watchdog tests)
- [x] `npm run lint`
- [x] `npm run format:check`
- [ ] Soak test on a Pi 3B+ in continuous mode, verify the container restart loop kicks in once a wedge develops

## Related

- Closes a major piece of #80 (BlueZ stuck-state recovery)
- Follow-up: a docs PR will document the Pi 3/4 limitation in troubleshooting and recommend BT proxy