### PR TITLE
feat(trisa): implement ADE BA 1600 challenge response (#138)

### DIFF
--- a/src/scales/trisa.ts
+++ b/src/scales/trisa.ts
@@ -39,6 +39,7 @@ const OP_BROADCAST_ADE = 0x22;
 // Challenge response opcode. Trisa echoes 0xA1; ADE uses 0x20 (the response
 // payload encoding is also different; see handleUploadChannel).
 const OP_RESPONSE_TRISA = 0xa1;
+const OP_RESPONSE_ADE = 0x20;
 
 const EPOCH_2010 = 1262304000;
 
@@ -161,9 +162,13 @@ export class TrisaAdapter implements ScaleAdapter {
       return this.parseMeasurement(data);
     }
     if (charUuid === CHR_BODYCOMP_ADE) {
-      // Capture for future analysis. Encoding not yet decoded so we can't
-      // turn this into impedance/fat/water/etc.
-      bleLog.debug(`ADE body-comp frame on 0x8A22 (TBD encoding): ${data.toString('hex')}`);
+      // fitvigo's BE1615 protocol stubs out addBodyAnalysis (empty native
+      // function), so even the official app does not decode this frame from
+      // BLE; it derives body composition on-phone from weight + user
+      // profile. We follow the same approach via Deurenberg in computeMetrics.
+      // Logging the raw bytes still helps if a later firmware variant
+      // surfaces an actual encoding here.
+      bleLog.debug(`ADE body-comp frame on 0x8A22 (ignored, see comment): ${data.toString('hex')}`);
       return null;
     }
     return null;
@@ -188,24 +193,31 @@ export class TrisaAdapter implements ScaleAdapter {
   /**
    * Handle password and challenge frames from the upload channel (0x8A82).
    *
-   * On Trisa: scale sends 0xA0 (password), then 0xA1 (challenge); host responds
-   * with [0xA1, XOR(challenge, password)].
+   * Trisa flow: scale sends 0xA0 (password), then 0xA1 (challenge); host
+   * responds with [0xA1, XOR(challenge, password)].
    *
-   * On ADE BA 1600: scale sends 0xA1 (challenge) directly without a password
-   * frame. The phone responds with 5 bytes starting with opcode 0x20; the
-   * exact algorithm is not yet known. We don't write anything here on ADE,
-   * relying on the time-sync + broadcast handshake in onConnected() to
-   * progress the scale to the measurement state. If the scale stalls on ADE,
-   * a fresh capture with multiple weigh-ins will be needed to crack this.
+   * ADE BA 1600 flow: scale sends 0xA1 (challenge) directly without a
+   * password frame. fitvigo's native protocol (`corelib::VBaseA2PairingProtocol`
+   * + `ProtocolUtils::sendVerificationCode`) computes the response as
+   * `[0x20, LE32(savedPassword XOR challengeInt)]`, where `challengeInt` is
+   * the four bytes after the opcode read as little-endian uint32. Because
+   * BE1615 never receives a 0xA0 frame, `savedPassword` stays at its default
+   * zero, so the response collapses to `[0x20]` followed by an echo of the
+   * same four bytes.
    */
   private handleUploadChannel(data: Buffer): void {
     if (data.length < 2) return;
     const opcode = data[0];
 
     if (this.variant === 'ade') {
-      // ADE challenge response algorithm is unknown. Logging the raw bytes
-      // helps when comparing against future captures.
-      bleLog.debug(`ADE upload frame (TBD response): ${data.toString('hex')}`);
+      if (opcode === OP_CHALLENGE && data.length >= 5 && this.writeFn) {
+        // Echo the four bytes that follow the opcode (XOR with savedPassword=0).
+        const response = Buffer.from([OP_RESPONSE_ADE, data[1], data[2], data[3], data[4]]);
+        void this.writeFn(CHR_DOWNLOAD, response, true);
+        bleLog.debug(`ADE challenge ack sent: ${response.toString('hex')}`);
+      } else {
+        bleLog.debug(`ADE upload frame (unhandled opcode): ${data.toString('hex')}`);
+      }
       return;
     }
 
@@ -218,7 +230,7 @@ export class TrisaAdapter implements ScaleAdapter {
       for (let i = 0; i < challenge.length; i++) {
         response[i + 1] = challenge[i] ^ (this.password[i % this.password.length] ?? 0);
       }
-      // Fire-and-forget write: no need to await in notification handler
+      // Fire-and-forget write; no need to await in notification handler
       void this.writeFn(CHR_DOWNLOAD, response, true);
     }
   }

--- a/tests/scales/trisa.test.ts
+++ b/tests/scales/trisa.test.ts
@@ -95,7 +95,7 @@ describe('TrisaAdapter', () => {
       // Should have 2 writes: time sync + broadcast
       expect(writeFn).toHaveBeenCalledTimes(2);
 
-      // Call 1: time sync — opcode 0x02 + 4-byte LE timestamp
+      // Call 1: time sync, opcode 0x02 + 4-byte LE timestamp
       const [charUuid1, data1, withResponse1] = writeFn.mock.calls[0];
       expect(charUuid1).toBe(adapter.charWriteUuid); // CHR_DOWNLOAD
       expect(withResponse1).toBe(true);
@@ -265,15 +265,48 @@ describe('TrisaAdapter', () => {
       expect(withResponse).toBe(true);
     });
 
-    it('does not respond to challenge on ADE variant (response algo unknown)', async () => {
+    it('echoes challenge bytes with opcode 0x20 on ADE variant', async () => {
+      // fitvigo's BE1615 protocol replies with [0x20, LE32(savedPassword XOR
+      // challengeInt)]. Because no 0xA0 password frame ever arrives on ADE,
+      // savedPassword stays at zero and the response is just an echo of the
+      // four challenge bytes with the opcode swapped from 0xA1 to 0x20.
       const adapter = makeAdapter();
       const { ctx, writeFn } = ctxWithChars(ADE_CHARS);
       await adapter.onConnected!(ctx);
       writeFn.mockClear();
 
       const uploadUuid = uuid16(0x8a82);
-      // ADE only sends challenge directly, no preceding password
-      adapter.parseCharNotification!(uploadUuid, Buffer.from([0xa1, 0x01, 0x00, 0xb2, 0x2a]));
+      // Reproduces the challenge captured in #138 (sttehh).
+      adapter.parseCharNotification!(uploadUuid, Buffer.from([0xa1, 0x01, 0x00, 0xb8, 0x99]));
+
+      expect(writeFn).toHaveBeenCalledOnce();
+      const [charUuid, data, withResponse] = writeFn.mock.calls[0];
+      expect(charUuid).toBe(uuid16(0x8a81));
+      expect(Array.from(data as Buffer)).toEqual([0x20, 0x01, 0x00, 0xb8, 0x99]);
+      expect(withResponse).toBe(true);
+    });
+
+    it('ignores ADE upload frames that are not 0xA1 challenges', async () => {
+      const adapter = makeAdapter();
+      const { ctx, writeFn } = ctxWithChars(ADE_CHARS);
+      await adapter.onConnected!(ctx);
+      writeFn.mockClear();
+
+      const uploadUuid = uuid16(0x8a82);
+      adapter.parseCharNotification!(uploadUuid, Buffer.from([0xa0, 0x11, 0x22, 0x33, 0x44]));
+
+      expect(writeFn).not.toHaveBeenCalled();
+    });
+
+    it('ignores truncated ADE challenge frames', async () => {
+      const adapter = makeAdapter();
+      const { ctx, writeFn } = ctxWithChars(ADE_CHARS);
+      await adapter.onConnected!(ctx);
+      writeFn.mockClear();
+
+      const uploadUuid = uuid16(0x8a82);
+      // Only opcode + 3 bytes; algorithm needs 4.
+      adapter.parseCharNotification!(uploadUuid, Buffer.from([0xa1, 0x01, 0x02, 0x03]));
 
       expect(writeFn).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary

Decoded the ADE BA 1600 challenge-response algorithm by reverse-engineering the fitvigo Android app, then ported it into the existing Trisa adapter so the scale finishes pairing instead of disconnecting after the first 0xA1 frame on 0x8A82.

Closes the protocol gap that #153 (v1.11.0) left as TBD. Targets #138.

## Algorithm (recovered from `libcorelib.so`)

The fitvigo native lib uses `corelib::VBaseA2PairingProtocol` for the upload-channel state machine, with `VScaleBE1615PairingProtocol` as the BA 1600 / ZCCO BE1615 specialization. Disassembly of `onRandomReceived` + `ProtocolUtils::sendVerificationCode` shows:

```
challengeInt = LE32(data[1..4])
responseInt  = savedPassword XOR challengeInt
response     = [0x20, byte0, byte1, byte2, byte3]   // LE32(responseInt)
```

`savedPassword` is the int parsed from the 0xA0 frame in `onPasswordReceived`. BE1615 never receives a 0xA0 frame, so `savedPassword` stays at its zero default and the response collapses to an echo of the four challenge bytes with the opcode swapped from `0xA1` to `0x20`.

Reproduced sttehh's HCI capture in `trisa.test.ts`: challenge `a1 01 00 b8 99 ...` produces response `20 01 00 b8 99`, written to 0x8A81 with response.

## Body composition

Intentionally NOT decoded from 0x8A22. The BE1615 protocol's `addBodyAnalysis` is an empty native stub (`size 0x1`, just `ret`), meaning fitvigo itself does not parse a body-comp frame off BLE. The official app derives composition on-phone from weight + user profile, so we take the same approach via Deurenberg in `computeMetrics` (existing `buildPayload` pipeline). Output should match what fitvigo would produce given the same user profile.

The 0x8A22 subscription is kept so future firmware variants that surface a real encoding here are still captured in the debug log.

## Test plan

- [x] Reproduce sttehh's challenge fixture; verify echo response `20 01 00 b8 99` on 0x8A81
- [x] Verify ignored frames (non-0xA1, truncated) do not write
- [x] Existing Trisa challenge-response (XOR with 0xA0 password) unchanged
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npx prettier --check` clean
- [x] `npm test` 1277/1277 passing
- [ ] Field test by @sttehh against the BA 1600 hardware

## Notes on the analysis

- Decompile target: fitvigo 1.2.2 (apkpure, package `de.ade.fitvigo`, app discontinued in 2023)
- Tooling: jadx 1.5.5 for Java, GNU binutils 2.46 (`objdump -d`) for the native lib
- Algorithm is reimplemented from understanding rather than copied; the repo stays GPL-clean