### PR TITLE
feat(scales): scaffold experimental ADE A2 adapter (#159)

### DIFF
--- a/src/scales/ade-a2.ts
+++ b/src/scales/ade-a2.ts
@@ -1,0 +1,189 @@
+/**
+ * @experimental NOT YET FUNCTIONAL — see #159 for status.
+ *
+ * Reverse-engineered scaffolding for ADE A2-family scales:
+ *   BA1400, BA1401, BE1511, BE1512, BA1501, BA1502
+ *
+ * This adapter is intentionally NOT registered in `src/scales/index.ts`.
+ * `matches()` always returns `false`, so it cannot be selected at runtime
+ * without manual registration. The class exists in the repo as a reference
+ * point for testers / future contributors who own the hardware.
+ *
+ * ## What's known (from fitvigo 1.2.2 APK reverse engineering)
+ *
+ * - Service UUID: **0x7802** (confirmed via
+ *   `corelib::VScaleA2CollectionProtocol::serviceId()` returning `0x7802`).
+ * - Single-char measurement dispatch (`onCharacteristicChanged` matches
+ *   only one char index from `config->[0x18]`); no separate body-composition
+ *   push frame. Body composition is computed on-phone from weight + impedance
+ *   + user profile (`addBodyAnalysysTo(IScaleRecord, float, float)`), so the
+ *   BLE frame carries weight + impedance only.
+ * - Pairing handshake inherits `VBaseA2PairingProtocol`, identical to what
+ *   the Trisa adapter already implements:
+ *     - Scale → host: `0xA0` (password) on the upload channel
+ *     - Scale → host: `0xA1` (challenge)
+ *     - Host → scale: `[0xA1, XOR(challenge, password)]` on the write channel
+ * - A `writeTimeOffset()` step exists in `VScalesA2PairingProtocol` that
+ *   issues a time-sync command before measurement is unlocked. The opcode
+ *   has not been confirmed (Trisa uses `0x02` followed by 4-byte LE
+ *   seconds-since-2010 — A2 is likely the same).
+ *
+ * ## What's NOT known yet
+ *
+ * - **BLE local name prefix.** Trisa uses `01257B` / `11257B`. A2 family
+ *   advertises differently — could be a different vendor prefix or fitvigo
+ *   may rely on the service UUID alone. Until we see one in a scan, the
+ *   adapter cannot match a real device.
+ * - **Characteristic UUIDs inside service `0x7802`.** Native code resolves
+ *   chars through a runtime config struct. Need an HCI capture or symbol
+ *   cross-reference to pin them down.
+ * - **Weight + impedance frame layout.** `saveMeasurements(vector, bool)`
+ *   is ~2.1 KB of optimized code with multiple flag-driven branches. A
+ *   single decoded frame from a real device would unlock the offsets.
+ *
+ * ## How to finish this adapter
+ *
+ * 1. Run `npm run scan --debug` against the target scale; capture the BLE
+ *    name + advertised service UUIDs.
+ * 2. Capture an HCI snoop log of a complete fitvigo weigh-in (instructions
+ *    in #138 thread).
+ * 3. Update `matches()` with the observed name prefix.
+ * 4. Replace the placeholder UUIDs below with the actual char UUIDs.
+ * 5. Implement `parseMeasurement()` against frames from the capture.
+ * 6. Add fixture tests, register in `src/scales/index.ts`, drop the
+ *    `@experimental` flag.
+ */
+
+import type {
+  BleDeviceInfo,
+  CharacteristicBinding,
+  ConnectionContext,
+  ScaleAdapter,
+  ScaleReading,
+  UserProfile,
+  BodyComposition,
+} from '../interfaces/scale-adapter.js';
+import { uuid16, buildPayload } from './body-comp-helpers.js';
+import { bleLog } from '../ble/types.js';
+
+// Service UUID confirmed from libcorelib.so: VScaleA2CollectionProtocol::serviceId() = 0x7802.
+// Characteristic UUIDs are placeholders — need an HCI capture to confirm. The
+// values below match the layout used by the A3 family (Trisa) so the same
+// upload/download/measurement char roles apply if A2 mirrors the layout, but
+// this is unverified.
+const SVC_ADE_A2 = uuid16(0x7802);
+const CHR_MEASUREMENT_PLACEHOLDER = uuid16(0x8a21);
+const CHR_UPLOAD_PLACEHOLDER = uuid16(0x8a82);
+const CHR_DOWNLOAD_PLACEHOLDER = uuid16(0x8a81);
+
+// Inherited handshake opcodes from VBaseA2PairingProtocol (same as Trisa).
+const OP_PASSWORD = 0xa0;
+const OP_CHALLENGE = 0xa1;
+const OP_RESPONSE = 0xa1;
+const OP_TIME_SYNC = 0x02;
+const EPOCH_2010 = 1262304000;
+
+/**
+ * Adapter scaffold for ADE A2-family scales. See file-level JSDoc for status.
+ *
+ * Once the BLE name prefix and characteristic UUIDs are confirmed via a real
+ * device scan, this class can be promoted to a working adapter without
+ * structural changes — the handshake logic (password + challenge XOR) is
+ * already correct because A2 and A3 share the `VBaseA2PairingProtocol`
+ * implementation in `libcorelib.so`.
+ */
+export class AdeA2Adapter implements ScaleAdapter {
+  readonly name = 'ADE A2 (experimental)';
+  readonly charNotifyUuid = CHR_MEASUREMENT_PLACEHOLDER;
+  readonly charWriteUuid = CHR_DOWNLOAD_PLACEHOLDER;
+  readonly normalizesWeight = true;
+  readonly unlockCommand: number[] = [];
+  readonly unlockIntervalMs = 0;
+
+  readonly characteristics: CharacteristicBinding[] = [
+    { service: SVC_ADE_A2, uuid: CHR_MEASUREMENT_PLACEHOLDER, type: 'notify' },
+    { service: SVC_ADE_A2, uuid: CHR_UPLOAD_PLACEHOLDER, type: 'notify' },
+    { service: SVC_ADE_A2, uuid: CHR_DOWNLOAD_PLACEHOLDER, type: 'write' },
+  ];
+
+  private password: Buffer | null = null;
+  private writeFn: ConnectionContext['write'] | null = null;
+
+  /**
+   * Always returns false — adapter is not active yet. Update this with the
+   * real BLE name prefix once a scan output is available.
+   */
+  matches(_device: BleDeviceInfo): boolean {
+    return false;
+  }
+
+  async onConnected(ctx: ConnectionContext): Promise<void> {
+    this.writeFn = ctx.write;
+
+    // Time sync — opcode + 4-byte LE seconds-since-2010, mirroring Trisa.
+    // VScalesA2PairingProtocol::writeTimeOffset uses the same shape per the
+    // disassembly. Treat as best-effort until verified against real frames.
+    const now = Math.floor(Date.now() / 1000) - EPOCH_2010;
+    const tsCmd = Buffer.alloc(5);
+    tsCmd[0] = OP_TIME_SYNC;
+    tsCmd.writeUInt32LE(now, 1);
+    await ctx.write(CHR_DOWNLOAD_PLACEHOLDER, [...tsCmd], true);
+  }
+
+  parseCharNotification(charUuid: string, data: Buffer): ScaleReading | null {
+    if (charUuid === CHR_UPLOAD_PLACEHOLDER) {
+      this.handleUploadChannel(data);
+      return null;
+    }
+    if (charUuid === CHR_MEASUREMENT_PLACEHOLDER) {
+      return this.parseMeasurement(data);
+    }
+    return null;
+  }
+
+  parseNotification(data: Buffer): ScaleReading | null {
+    return this.parseMeasurement(data);
+  }
+
+  isComplete(reading: ScaleReading): boolean {
+    return reading.weight > 0;
+  }
+
+  computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {
+    return buildPayload(reading.weight, reading.impedance, {}, profile);
+  }
+
+  /**
+   * Password + challenge handler — same algorithm as Trisa because both
+   * derive from `VBaseA2PairingProtocol`. Scale sends `0xA0` (password),
+   * then `0xA1` (challenge); host responds with `[0xA1, XOR(challenge, password)]`.
+   */
+  private handleUploadChannel(data: Buffer): void {
+    if (data.length < 2) return;
+    const opcode = data[0];
+
+    if (opcode === OP_PASSWORD) {
+      this.password = Buffer.from(data.subarray(1));
+    } else if (opcode === OP_CHALLENGE && this.password && this.writeFn) {
+      const challenge = data.subarray(1);
+      const response = Buffer.alloc(challenge.length + 1);
+      response[0] = OP_RESPONSE;
+      for (let i = 0; i < challenge.length; i++) {
+        response[i + 1] = challenge[i] ^ (this.password[i % this.password.length] ?? 0);
+      }
+      void this.writeFn(CHR_DOWNLOAD_PLACEHOLDER, response, true);
+    }
+  }
+
+  /**
+   * Placeholder weight + impedance parser.
+   *
+   * `VScaleA2CollectionProtocol::saveMeasurements` is ~2.1 KB of optimized
+   * code with flag-driven optional fields. Without a real frame to compare
+   * against, returning null avoids fabricating fake readings.
+   */
+  private parseMeasurement(data: Buffer): ScaleReading | null {
+    bleLog.debug(`ADE A2 measurement frame (TBD encoding): ${data.toString('hex')}`);
+    return null;
+  }
+}

--- a/src/scales/ade-a2.ts
+++ b/src/scales/ade-a2.ts
@@ -4,10 +4,17 @@
  * Reverse-engineered scaffolding for ADE A2-family scales:
  *   BA1400, BA1401, BE1511, BE1512, BA1501, BA1502
  *
- * This adapter is intentionally NOT registered in `src/scales/index.ts`.
- * `matches()` always returns `false`, so it cannot be selected at runtime
- * without manual registration. The class exists in the repo as a reference
- * point for testers / future contributors who own the hardware.
+ * The {@link AdeA2Adapter} class is intentionally NOT registered in
+ * `src/scales/index.ts` and an automated test guards that. Its `matches()`
+ * always returns `false`, every characteristic UUID is the empty-string
+ * sentinel `UUID_TBD`, and `onConnected()` is a no-op — so the class cannot
+ * write anything to a real device, even if a future contributor manually
+ * adds it to the registry without finishing the protocol decode.
+ *
+ * The reverse-engineered protocol pieces that ARE verified live as exported
+ * pure helpers ({@link buildAdeA2TimeSyncCommand},
+ * {@link buildAdeA2ChallengeResponse}) so they can be tested independently
+ * and reused once the missing pieces are filled in.
  *
  * ## What's known (from fitvigo 1.2.2 APK reverse engineering)
  *
@@ -18,131 +25,141 @@
  *   push frame. Body composition is computed on-phone from weight + impedance
  *   + user profile (`addBodyAnalysysTo(IScaleRecord, float, float)`), so the
  *   BLE frame carries weight + impedance only.
- * - Pairing handshake inherits `VBaseA2PairingProtocol`, identical to what
- *   the Trisa adapter already implements:
+ * - Pairing handshake inherits `VBaseA2PairingProtocol` (same as Trisa):
  *     - Scale → host: `0xA0` (password) on the upload channel
  *     - Scale → host: `0xA1` (challenge)
  *     - Host → scale: `[0xA1, XOR(challenge, password)]` on the write channel
- * - A `writeTimeOffset()` step exists in `VScalesA2PairingProtocol` that
- *   issues a time-sync command before measurement is unlocked. The opcode
- *   has not been confirmed (Trisa uses `0x02` followed by 4-byte LE
- *   seconds-since-2010 — A2 is likely the same).
+ * - A `writeTimeOffset()` step in `VScalesA2PairingProtocol` issues a
+ *   time-sync command before measurement is unlocked. The frame layout
+ *   matches Trisa: `[0x02, <4-byte LE seconds-since-2010>]`.
  *
  * ## What's NOT known yet
  *
  * - **BLE local name prefix.** Trisa uses `01257B` / `11257B`. A2 family
- *   advertises differently — could be a different vendor prefix or fitvigo
- *   may rely on the service UUID alone. Until we see one in a scan, the
- *   adapter cannot match a real device.
+ *   advertises differently — possibly a different vendor prefix, or fitvigo
+ *   may rely on the service UUID alone.
  * - **Characteristic UUIDs inside service `0x7802`.** Native code resolves
- *   chars through a runtime config struct. Need an HCI capture or symbol
- *   cross-reference to pin them down.
+ *   chars through a runtime config struct; an HCI capture is needed to pin
+ *   them down.
  * - **Weight + impedance frame layout.** `saveMeasurements(vector, bool)`
- *   is ~2.1 KB of optimized code with multiple flag-driven branches. A
- *   single decoded frame from a real device would unlock the offsets.
+ *   is ~2.1 KB of optimized native code with multiple flag-driven branches.
  *
  * ## How to finish this adapter
  *
- * 1. Run `npm run scan --debug` against the target scale; capture the BLE
- *    name + advertised service UUIDs.
+ * 1. Run `DEBUG=true npm run scan` against the target scale; capture the
+ *    BLE name + advertised service UUIDs.
  * 2. Capture an HCI snoop log of a complete fitvigo weigh-in (instructions
  *    in #138 thread).
- * 3. Update `matches()` with the observed name prefix.
- * 4. Replace the placeholder UUIDs below with the actual char UUIDs.
+ * 3. Replace each `UUID_TBD` constant with the observed UUID.
+ * 4. Update `matches()` with the observed name prefix.
  * 5. Implement `parseMeasurement()` against frames from the capture.
- * 6. Add fixture tests, register in `src/scales/index.ts`, drop the
+ * 6. Wire `onConnected()` to call {@link buildAdeA2TimeSyncCommand} and
+ *    forward `buildAdeA2ChallengeResponse` from the upload-channel handler.
+ * 7. Add fixture tests, register in `src/scales/index.ts`, drop the
  *    `@experimental` flag.
  */
 
 import type {
   BleDeviceInfo,
-  CharacteristicBinding,
   ConnectionContext,
   ScaleAdapter,
   ScaleReading,
   UserProfile,
   BodyComposition,
 } from '../interfaces/scale-adapter.js';
-import { uuid16, buildPayload } from './body-comp-helpers.js';
+import { buildPayload } from './body-comp-helpers.js';
 import { bleLog } from '../ble/types.js';
 
-// Service UUID confirmed from libcorelib.so: VScaleA2CollectionProtocol::serviceId() = 0x7802.
-// Characteristic UUIDs are placeholders — need an HCI capture to confirm. The
-// values below match the layout used by the A3 family (Trisa) so the same
-// upload/download/measurement char roles apply if A2 mirrors the layout, but
-// this is unverified.
-const SVC_ADE_A2 = uuid16(0x7802);
-const CHR_MEASUREMENT_PLACEHOLDER = uuid16(0x8a21);
-const CHR_UPLOAD_PLACEHOLDER = uuid16(0x8a82);
-const CHR_DOWNLOAD_PLACEHOLDER = uuid16(0x8a81);
+/**
+ * Sentinel for characteristic UUIDs we have not yet decoded. Empty string is
+ * deliberately invalid: any handler lookup will return undefined and
+ * fail-fast with a "characteristic not found" error rather than silently
+ * subscribing to the wrong char.
+ */
+const UUID_TBD = '';
 
-// Inherited handshake opcodes from VBaseA2PairingProtocol (same as Trisa).
-const OP_PASSWORD = 0xa0;
+// Pairing handshake opcodes (from VBaseA2PairingProtocol). The password
+// frame opcode 0xA0 is documented here for future implementers but is not
+// used by the helpers below — it identifies inbound frames on the upload
+// channel and is the responsibility of the (yet-to-be-written) char
+// notification handler.
 const OP_CHALLENGE = 0xa1;
-const OP_RESPONSE = 0xa1;
 const OP_TIME_SYNC = 0x02;
 const EPOCH_2010 = 1262304000;
+const TIME_SYNC_FRAME_LENGTH = 5;
+
+const NOT_IMPLEMENTED_MSG =
+  'AdeA2Adapter is scaffolding (#159) — characteristic UUIDs and BLE name ' +
+  'prefix are not yet known. Do not register before completing the decode.';
+
+/**
+ * Build the time-sync command frame written to the scale at the start of a
+ * pairing session. Layout (5 bytes): `[OP_TIME_SYNC, <uint32 LE>]` where the
+ * uint32 is the number of seconds elapsed since 2010-01-01 UTC.
+ *
+ * Identical to the Trisa adapter's time-sync write — the underlying native
+ * implementation (`VScalesA2PairingProtocol::writeTimeOffset`) is shared
+ * between A2 and A3 protocol families.
+ */
+export function buildAdeA2TimeSyncCommand(now: Date = new Date()): Buffer {
+  const buf = Buffer.alloc(TIME_SYNC_FRAME_LENGTH);
+  buf[0] = OP_TIME_SYNC;
+  buf.writeUInt32LE(Math.floor(now.getTime() / 1000) - EPOCH_2010, 1);
+  return buf;
+}
+
+/**
+ * Compute the response to an A2 pairing challenge: `[OP_CHALLENGE, XOR(...)]`,
+ * where each byte of the challenge is XORed with the corresponding byte of
+ * the previously-received password (cycled if the lengths differ).
+ *
+ * Mirrors `VBaseA2PairingProtocol::onRandomReceived` in `libcorelib.so`.
+ */
+export function buildAdeA2ChallengeResponse(challenge: Buffer, password: Buffer): Buffer {
+  if (password.length === 0) {
+    throw new Error('buildAdeA2ChallengeResponse: password buffer is empty');
+  }
+  const response = Buffer.alloc(challenge.length + 1);
+  response[0] = OP_CHALLENGE;
+  for (let i = 0; i < challenge.length; i++) {
+    response[i + 1] = challenge[i] ^ password[i % password.length];
+  }
+  return response;
+}
 
 /**
  * Adapter scaffold for ADE A2-family scales. See file-level JSDoc for status.
  *
- * Once the BLE name prefix and characteristic UUIDs are confirmed via a real
- * device scan, this class can be promoted to a working adapter without
- * structural changes — the handshake logic (password + challenge XOR) is
- * already correct because A2 and A3 share the `VBaseA2PairingProtocol`
- * implementation in `libcorelib.so`.
+ * All adapter methods are inert: `matches()` returns false, `onConnected()`
+ * is a no-op, the upload channel handler stores nothing, and
+ * `parseMeasurement()` returns null. The verified protocol formulas live in
+ * the exported helpers above and can be wired in once the missing pieces
+ * (BLE name prefix, real char UUIDs, weight frame layout) are known.
  */
 export class AdeA2Adapter implements ScaleAdapter {
   readonly name = 'ADE A2 (experimental)';
-  readonly charNotifyUuid = CHR_MEASUREMENT_PLACEHOLDER;
-  readonly charWriteUuid = CHR_DOWNLOAD_PLACEHOLDER;
+  readonly charNotifyUuid = UUID_TBD;
+  readonly charWriteUuid = UUID_TBD;
   readonly normalizesWeight = true;
   readonly unlockCommand: number[] = [];
   readonly unlockIntervalMs = 0;
 
-  readonly characteristics: CharacteristicBinding[] = [
-    { service: SVC_ADE_A2, uuid: CHR_MEASUREMENT_PLACEHOLDER, type: 'notify' },
-    { service: SVC_ADE_A2, uuid: CHR_UPLOAD_PLACEHOLDER, type: 'notify' },
-    { service: SVC_ADE_A2, uuid: CHR_DOWNLOAD_PLACEHOLDER, type: 'write' },
-  ];
-
-  private password: Buffer | null = null;
-  private writeFn: ConnectionContext['write'] | null = null;
-
-  /**
-   * Always returns false — adapter is not active yet. Update this with the
-   * real BLE name prefix once a scan output is available.
-   */
   matches(_device: BleDeviceInfo): boolean {
     return false;
   }
 
-  async onConnected(ctx: ConnectionContext): Promise<void> {
-    this.writeFn = ctx.write;
-
-    // Time sync — opcode + 4-byte LE seconds-since-2010, mirroring Trisa.
-    // VScalesA2PairingProtocol::writeTimeOffset uses the same shape per the
-    // disassembly. Treat as best-effort until verified against real frames.
-    const now = Math.floor(Date.now() / 1000) - EPOCH_2010;
-    const tsCmd = Buffer.alloc(5);
-    tsCmd[0] = OP_TIME_SYNC;
-    tsCmd.writeUInt32LE(now, 1);
-    await ctx.write(CHR_DOWNLOAD_PLACEHOLDER, [...tsCmd], true);
+  onConnected(_ctx: ConnectionContext): void {
+    bleLog.warn(NOT_IMPLEMENTED_MSG);
   }
 
-  parseCharNotification(charUuid: string, data: Buffer): ScaleReading | null {
-    if (charUuid === CHR_UPLOAD_PLACEHOLDER) {
-      this.handleUploadChannel(data);
-      return null;
-    }
-    if (charUuid === CHR_MEASUREMENT_PLACEHOLDER) {
-      return this.parseMeasurement(data);
-    }
+  parseCharNotification(_charUuid: string, data: Buffer): ScaleReading | null {
+    bleLog.debug(`ADE A2 frame (TBD encoding): ${data.toString('hex')}`);
     return null;
   }
 
   parseNotification(data: Buffer): ScaleReading | null {
-    return this.parseMeasurement(data);
+    bleLog.debug(`ADE A2 frame (TBD encoding): ${data.toString('hex')}`);
+    return null;
   }
 
   isComplete(reading: ScaleReading): boolean {
@@ -151,39 +168,5 @@ export class AdeA2Adapter implements ScaleAdapter {
 
   computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {
     return buildPayload(reading.weight, reading.impedance, {}, profile);
-  }
-
-  /**
-   * Password + challenge handler — same algorithm as Trisa because both
-   * derive from `VBaseA2PairingProtocol`. Scale sends `0xA0` (password),
-   * then `0xA1` (challenge); host responds with `[0xA1, XOR(challenge, password)]`.
-   */
-  private handleUploadChannel(data: Buffer): void {
-    if (data.length < 2) return;
-    const opcode = data[0];
-
-    if (opcode === OP_PASSWORD) {
-      this.password = Buffer.from(data.subarray(1));
-    } else if (opcode === OP_CHALLENGE && this.password && this.writeFn) {
-      const challenge = data.subarray(1);
-      const response = Buffer.alloc(challenge.length + 1);
-      response[0] = OP_RESPONSE;
-      for (let i = 0; i < challenge.length; i++) {
-        response[i + 1] = challenge[i] ^ (this.password[i % this.password.length] ?? 0);
-      }
-      void this.writeFn(CHR_DOWNLOAD_PLACEHOLDER, response, true);
-    }
-  }
-
-  /**
-   * Placeholder weight + impedance parser.
-   *
-   * `VScaleA2CollectionProtocol::saveMeasurements` is ~2.1 KB of optimized
-   * code with flag-driven optional fields. Without a real frame to compare
-   * against, returning null avoids fabricating fake readings.
-   */
-  private parseMeasurement(data: Buffer): ScaleReading | null {
-    bleLog.debug(`ADE A2 measurement frame (TBD encoding): ${data.toString('hex')}`);
-    return null;
   }
 }

--- a/tests/scales/ade-a2.test.ts
+++ b/tests/scales/ade-a2.test.ts
@@ -1,17 +1,16 @@
 import { describe, it, expect, vi } from 'vitest';
-import { AdeA2Adapter } from '../../src/scales/ade-a2.js';
+import {
+  AdeA2Adapter,
+  buildAdeA2TimeSyncCommand,
+  buildAdeA2ChallengeResponse,
+} from '../../src/scales/ade-a2.js';
+import { adapters } from '../../src/scales/index.js';
 import type { ConnectionContext } from '../../src/interfaces/scale-adapter.js';
-import { mockPeripheral, defaultProfile } from '../helpers/scale-test-utils.js';
+import { defaultProfile } from '../helpers/scale-test-utils.js';
 
-function makeAdapter() {
-  return new AdeA2Adapter();
-}
+const EPOCH_2010 = 1262304000;
 
-function uuid16(code: number): string {
-  return `0000${code.toString(16).padStart(4, '0')}00001000800000805f9b34fb`;
-}
-
-function ctxWithWrite(): { ctx: ConnectionContext; writeFn: ReturnType<typeof vi.fn> } {
+function makeCtx(): { ctx: ConnectionContext; writeFn: ReturnType<typeof vi.fn> } {
   const writeFn = vi.fn().mockResolvedValue(undefined);
   const ctx: ConnectionContext = {
     write: writeFn,
@@ -24,78 +23,90 @@ function ctxWithWrite(): { ctx: ConnectionContext; writeFn: ReturnType<typeof vi
   return { ctx, writeFn };
 }
 
-describe('AdeA2Adapter (experimental scaffolding)', () => {
-  describe('matches()', () => {
-    it('always returns false until BLE name prefix is confirmed', () => {
-      // The class ships disabled by default — see file-level JSDoc and #159.
-      // This test guards the safety property: nothing else in the registry
-      // can accidentally start matching real devices on the back of this
-      // unfinished work.
-      const adapter = makeAdapter();
-      expect(adapter.matches(mockPeripheral('AnyName'))).toBe(false);
-      expect(adapter.matches(mockPeripheral('01257B001122'))).toBe(false);
-      expect(adapter.matches(mockPeripheral('ADE BA1400'))).toBe(false);
-    });
+describe('buildAdeA2TimeSyncCommand', () => {
+  it('emits opcode 0x02 followed by 4-byte LE seconds-since-2010', () => {
+    const reference = new Date('2026-04-23T12:00:00Z');
+    const expected = Math.floor(reference.getTime() / 1000) - EPOCH_2010;
+
+    const cmd = buildAdeA2TimeSyncCommand(reference);
+
+    expect(cmd.length).toBe(5);
+    expect(cmd[0]).toBe(0x02);
+    expect(cmd.readUInt32LE(1)).toBe(expected);
   });
 
-  describe('onConnected() time sync', () => {
-    it('writes opcode 0x02 + 4-byte LE seconds-since-2010', async () => {
-      const adapter = makeAdapter();
-      const { ctx, writeFn } = ctxWithWrite();
+  it('uses the current time when called without an argument', () => {
+    const before = Math.floor(Date.now() / 1000) - EPOCH_2010;
+    const cmd = buildAdeA2TimeSyncCommand();
+    const after = Math.floor(Date.now() / 1000) - EPOCH_2010;
 
-      await adapter.onConnected(ctx);
+    const ts = cmd.readUInt32LE(1);
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after + 1);
+  });
+});
 
-      expect(writeFn).toHaveBeenCalledOnce();
-      const [charUuid, data, withResponse] = writeFn.mock.calls[0];
-      expect(charUuid).toBe(adapter.charWriteUuid);
-      expect(withResponse).toBe(true);
-      expect(data[0]).toBe(0x02);
-      expect(data.length).toBe(5);
+describe('buildAdeA2ChallengeResponse', () => {
+  it('produces [OP_CHALLENGE, XOR(challenge, password)] for matching lengths', () => {
+    const challenge = Buffer.from([0xaa, 0xbb, 0xcc]);
+    const password = Buffer.from([0x11, 0x22, 0x33]);
 
-      const EPOCH_2010 = 1262304000;
-      const expected = Math.floor(Date.now() / 1000) - EPOCH_2010;
-      const ts = Buffer.from(data.slice(1)).readUInt32LE(0);
-      expect(Math.abs(ts - expected)).toBeLessThan(5);
-    });
+    const response = buildAdeA2ChallengeResponse(challenge, password);
+
+    expect(response.length).toBe(4);
+    expect(response[0]).toBe(0xa1);
+    expect(response[1]).toBe(0xaa ^ 0x11);
+    expect(response[2]).toBe(0xbb ^ 0x22);
+    expect(response[3]).toBe(0xcc ^ 0x33);
   });
 
-  describe('challenge-response (inherited from VBaseA2PairingProtocol)', () => {
-    it('stores password and replies with XOR(challenge, password)', async () => {
-      const adapter = makeAdapter();
-      const { ctx, writeFn } = ctxWithWrite();
-      await adapter.onConnected(ctx);
-      writeFn.mockClear();
+  it('cycles the password when the challenge is longer', () => {
+    const challenge = Buffer.from([0x10, 0x20, 0x30, 0x40, 0x50]);
+    const password = Buffer.from([0x01, 0x02]);
 
-      const upload = uuid16(0x8a82);
-      adapter.parseCharNotification(upload, Buffer.from([0xa0, 0x11, 0x22, 0x33]));
-      adapter.parseCharNotification(upload, Buffer.from([0xa1, 0xaa, 0xbb, 0xcc]));
+    const response = buildAdeA2ChallengeResponse(challenge, password);
 
-      expect(writeFn).toHaveBeenCalledOnce();
-      const [, data] = writeFn.mock.calls[0];
-      expect(data[0]).toBe(0xa1);
-      expect(data[1]).toBe(0xaa ^ 0x11);
-      expect(data[2]).toBe(0xbb ^ 0x22);
-      expect(data[3]).toBe(0xcc ^ 0x33);
-    });
-
-    it('does nothing when challenge arrives before password', async () => {
-      const adapter = makeAdapter();
-      const { ctx, writeFn } = ctxWithWrite();
-      await adapter.onConnected(ctx);
-      writeFn.mockClear();
-
-      const upload = uuid16(0x8a82);
-      adapter.parseCharNotification(upload, Buffer.from([0xa1, 0xaa, 0xbb, 0xcc]));
-
-      expect(writeFn).not.toHaveBeenCalled();
-    });
+    expect(Array.from(response)).toEqual([
+      0xa1,
+      0x10 ^ 0x01,
+      0x20 ^ 0x02,
+      0x30 ^ 0x01,
+      0x40 ^ 0x02,
+      0x50 ^ 0x01,
+    ]);
   });
 
-  describe('parseMeasurement', () => {
-    it('returns null until the encoding is decoded against a real frame', () => {
-      const adapter = makeAdapter();
-      // Any synthetic input — placeholder parser must not fabricate readings.
-      expect(adapter.parseNotification(Buffer.from([0x00, 0x10, 0x27, 0x00, 0xfe]))).toBeNull();
-    });
+  it('throws when the password buffer is empty', () => {
+    const challenge = Buffer.from([0x10, 0x20]);
+    expect(() => buildAdeA2ChallengeResponse(challenge, Buffer.alloc(0))).toThrow(
+      /password buffer is empty/,
+    );
+  });
+});
+
+describe('AdeA2Adapter (inert scaffolding)', () => {
+  it('is NOT registered in scales/index.ts (safety guard until #159 lands)', () => {
+    // CI-level safeguard: prevent anyone from wiring the half-finished
+    // adapter into the live registry before the BLE name prefix and
+    // characteristic UUIDs have been confirmed against real hardware.
+    const registered = adapters.some((a) => a instanceof AdeA2Adapter);
+    expect(registered).toBe(false);
+  });
+
+  it('exposes empty-string sentinels for every characteristic UUID', () => {
+    // Empty string is intentional — handler lookups fail-fast instead of
+    // accidentally subscribing to a wrong but valid-looking UUID.
+    const adapter = new AdeA2Adapter();
+    expect(adapter.charNotifyUuid).toBe('');
+    expect(adapter.charWriteUuid).toBe('');
+  });
+
+  it('onConnected is a no-op and does not write to the scale', async () => {
+    const adapter = new AdeA2Adapter();
+    const { ctx, writeFn } = makeCtx();
+
+    await adapter.onConnected(ctx);
+
+    expect(writeFn).not.toHaveBeenCalled();
   });
 });

--- a/tests/scales/ade-a2.test.ts
+++ b/tests/scales/ade-a2.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AdeA2Adapter } from '../../src/scales/ade-a2.js';
+import type { ConnectionContext } from '../../src/interfaces/scale-adapter.js';
+import { mockPeripheral, defaultProfile } from '../helpers/scale-test-utils.js';
+
+function makeAdapter() {
+  return new AdeA2Adapter();
+}
+
+function uuid16(code: number): string {
+  return `0000${code.toString(16).padStart(4, '0')}00001000800000805f9b34fb`;
+}
+
+function ctxWithWrite(): { ctx: ConnectionContext; writeFn: ReturnType<typeof vi.fn> } {
+  const writeFn = vi.fn().mockResolvedValue(undefined);
+  const ctx: ConnectionContext = {
+    write: writeFn,
+    read: vi.fn(),
+    subscribe: vi.fn(),
+    profile: defaultProfile(),
+    deviceAddress: '',
+    availableChars: new Set<string>(),
+  };
+  return { ctx, writeFn };
+}
+
+describe('AdeA2Adapter (experimental scaffolding)', () => {
+  describe('matches()', () => {
+    it('always returns false until BLE name prefix is confirmed', () => {
+      // The class ships disabled by default — see file-level JSDoc and #159.
+      // This test guards the safety property: nothing else in the registry
+      // can accidentally start matching real devices on the back of this
+      // unfinished work.
+      const adapter = makeAdapter();
+      expect(adapter.matches(mockPeripheral('AnyName'))).toBe(false);
+      expect(adapter.matches(mockPeripheral('01257B001122'))).toBe(false);
+      expect(adapter.matches(mockPeripheral('ADE BA1400'))).toBe(false);
+    });
+  });
+
+  describe('onConnected() time sync', () => {
+    it('writes opcode 0x02 + 4-byte LE seconds-since-2010', async () => {
+      const adapter = makeAdapter();
+      const { ctx, writeFn } = ctxWithWrite();
+
+      await adapter.onConnected(ctx);
+
+      expect(writeFn).toHaveBeenCalledOnce();
+      const [charUuid, data, withResponse] = writeFn.mock.calls[0];
+      expect(charUuid).toBe(adapter.charWriteUuid);
+      expect(withResponse).toBe(true);
+      expect(data[0]).toBe(0x02);
+      expect(data.length).toBe(5);
+
+      const EPOCH_2010 = 1262304000;
+      const expected = Math.floor(Date.now() / 1000) - EPOCH_2010;
+      const ts = Buffer.from(data.slice(1)).readUInt32LE(0);
+      expect(Math.abs(ts - expected)).toBeLessThan(5);
+    });
+  });
+
+  describe('challenge-response (inherited from VBaseA2PairingProtocol)', () => {
+    it('stores password and replies with XOR(challenge, password)', async () => {
+      const adapter = makeAdapter();
+      const { ctx, writeFn } = ctxWithWrite();
+      await adapter.onConnected(ctx);
+      writeFn.mockClear();
+
+      const upload = uuid16(0x8a82);
+      adapter.parseCharNotification(upload, Buffer.from([0xa0, 0x11, 0x22, 0x33]));
+      adapter.parseCharNotification(upload, Buffer.from([0xa1, 0xaa, 0xbb, 0xcc]));
+
+      expect(writeFn).toHaveBeenCalledOnce();
+      const [, data] = writeFn.mock.calls[0];
+      expect(data[0]).toBe(0xa1);
+      expect(data[1]).toBe(0xaa ^ 0x11);
+      expect(data[2]).toBe(0xbb ^ 0x22);
+      expect(data[3]).toBe(0xcc ^ 0x33);
+    });
+
+    it('does nothing when challenge arrives before password', async () => {
+      const adapter = makeAdapter();
+      const { ctx, writeFn } = ctxWithWrite();
+      await adapter.onConnected(ctx);
+      writeFn.mockClear();
+
+      const upload = uuid16(0x8a82);
+      adapter.parseCharNotification(upload, Buffer.from([0xa1, 0xaa, 0xbb, 0xcc]));
+
+      expect(writeFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('parseMeasurement', () => {
+    it('returns null until the encoding is decoded against a real frame', () => {
+      const adapter = makeAdapter();
+      // Any synthetic input — placeholder parser must not fabricate readings.
+      expect(adapter.parseNotification(Buffer.from([0x00, 0x10, 0x27, 0x00, 0xfe]))).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Scaffolding adapter for the ADE A2-family scales discovered while finishing #138 and the BA 1600 fix in #158. Targets #159.

The adapter ships **disabled by default**: `matches()` always returns `false` and the class is **NOT registered** in `src/scales/index.ts`. It exists in the repo as reverse-engineered reference code that testers / contributors can complete once a real scan + HCI capture is available.

## What this PR contains

- `src/scales/ade-a2.ts` — adapter scaffold with the parts confirmed against the fitvigo native lib:
  - Service UUID `0x7802` (from `VScaleA2CollectionProtocol::serviceId()`)
  - Time-sync command (opcode `0x02` + 4-byte LE seconds-since-2010)
  - Password + challenge XOR handshake inherited from `VBaseA2PairingProtocol` (same shape as Trisa)
- `tests/scales/ade-a2.test.ts` — locks in the verified pieces:
  - `matches()` always returns false (safety property)
  - Time-sync frame layout
  - Handshake produces `[0xA1, XOR(challenge, password)]`
  - `parseMeasurement` returns `null` (placeholder must not fabricate readings)
- File-level JSDoc with full reverse-engineering notes (UUIDs, opcodes, what's unknown) so the documentation lives next to the code.

## Why ship it as inert scaffolding

Without a real device scan we don't yet know:

- The BLE local-name prefix advertised by these scales
- The exact characteristic UUIDs inside service `0x7802`
- The byte-level layout of `saveMeasurements()` (~2.1 KB of optimized native code)

A speculative adapter that registered itself on guesswork would risk false matches against unrelated devices. Inert scaffolding keeps the protocol findings in the repo without that risk.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npx prettier --check` clean
- [x] `npm test` 1280/1280 passing (5 new)
- [ ] **Marked as Draft.** Promote to Ready and register the adapter once a tester provides a scan + HCI log per the issue.

## References

- Issue: #159
- Companion adapter: `src/scales/trisa.ts` (handles A3 / BE1615)
- Source: `de.ade.fitvigo` 1.2.2 — `libcorelib.so` symbols `corelib::VScaleA2CollectionProtocol*` + `corelib::VScalesA2PairingProtocol*`