### PR TITLE
Hotfix v1.12.1: fix RSSI freshness regression (#167)

### DIFF
--- a/src/ble/handler-node-ble.ts
+++ b/src/ble/handler-node-ble.ts
@@ -282,16 +282,20 @@ async function startDiscoverySafe(
  * Tracks whether a BlueZ peer is still actively advertising.
  *
  * Two signals decide freshness:
- *  - the current `RSSI` value from `org.bluez.Device1` (Readonly+Optional int16
- *    per the BlueZ docs, verified via context7). Missing or the sentinel 127
- *    ("unavailable" per mgmt-protocol Device Found) means the peer has gone
- *    dark.
+ *  - the explicit `127` sentinel on `org.bluez.Device1.RSSI` (mgmt-protocol
+ *    Device Found "unavailable") means the peer has gone dark.
  *  - the time since the last `RSSI` `PropertiesChanged` signal. BlueZ
  *    refreshes this on every received advertisement, so absence of an update
- *    within `RSSI_FRESHNESS_MS` means no new packets have arrived even though
- *    the cached value may still be present.
+ *    within `RSSI_FRESHNESS_MS` means no new packets have arrived.
  *
- * Either failing signal points at the dying-peer scenario @fromport
+ * `RSSI` is documented Readonly+Optional on `org.bluez.Device1` (BlueZ docs,
+ * verified via context7). BlueZ legitimately omits the prop after
+ * `StopDiscovery`, so absence is NOT a freshness signal (#167 regression).
+ * The `lastRssiUpdateTs = Date.now()` init at construction is load-bearing:
+ * trackers are only created after `waitDevice` resolved, which only fires on
+ * a fresh advertisement.
+ *
+ * The 127 sentinel and time window cover the dying-peer scenario @fromport
  * reproduced for #143 / #140, where `device.connect()` would stall inside
  * GATT discovery against a peer whose link layer is shutting down.
  */
@@ -311,20 +315,22 @@ export function startPeerFreshnessTracker(device: Device): PeerFreshnessTracker 
   try {
     helper.on('PropertiesChanged', onPropsChanged);
   } catch {
-    // Subscription unavailable: fall back to prop-only freshness check.
+    // Subscription unavailable: tracker reports fresh until the init
+    // timestamp ages past RSSI_FRESHNESS_MS, then stale.
   }
   return {
     isFresh: async () => {
+      let rssi: unknown;
       try {
-        const rssi: unknown = await helper.prop('RSSI');
-        if (rssi === undefined || rssi === null) return false;
-        if (typeof rssi === 'number' && rssi === RSSI_UNAVAILABLE) return false;
-        if (Date.now() - lastRssiUpdateTs > RSSI_FRESHNESS_MS) return false;
-        return true;
+        rssi = await helper.prop('RSSI');
       } catch {
-        // Property absent (BlueZ dropped it) or D-Bus error: treat as stale.
-        return false;
+        // RSSI is Optional on org.bluez.Device1 and BlueZ may not expose it
+        // after StopDiscovery or on some controllers (#167). PropertiesChanged
+        // remains the authoritative freshness signal via lastRssiUpdateTs.
+        rssi = undefined;
       }
+      if (typeof rssi === 'number' && rssi === RSSI_UNAVAILABLE) return false;
+      return Date.now() - lastRssiUpdateTs <= RSSI_FRESHNESS_MS;
     },
     stop: () => {
       if (stopped) return;

--- a/tests/ble/connect-recovery-rssi-skip.test.ts
+++ b/tests/ble/connect-recovery-rssi-skip.test.ts
@@ -152,4 +152,26 @@ describe('connectWithRecovery: RSSI freshness skip (#143 integration)', () => {
     expect(initialDevice.connect).toHaveBeenCalledTimes(1);
     expect(result).toBe(initialDevice);
   });
+
+  it('connects directly when RSSI prop is undefined but tracker is freshly created (#167 regression guard)', async () => {
+    // Reproduces the fromport ES-26M fixture: BlueZ drops the Optional RSSI
+    // prop after the upstream StopDiscovery, but the peer is alive. The
+    // freshness tracker is constructed after waitDevice resolved, so
+    // lastRssiUpdateTs is fresh; isFresh() must trust the time window over
+    // the absent prop. No re-discovery, connect goes through on first attempt.
+    const initialDevice = makeDevice(() => undefined);
+    const reDiscoveredDevice = makeDevice(() => -55);
+    const btAdapter = makeAdapter(reDiscoveredDevice);
+
+    const result = await _internals.connectWithRecovery({
+      btAdapter: btAdapter as never,
+      mac: 'FF:04:00:14:AC:0F',
+      initialDevice: initialDevice as never,
+      maxRetries: 0,
+    });
+
+    expect(btAdapter.waitDevice).not.toHaveBeenCalled();
+    expect(initialDevice.connect).toHaveBeenCalledTimes(1);
+    expect(result).toBe(initialDevice);
+  });
 });

--- a/tests/ble/rssi-freshness.test.ts
+++ b/tests/ble/rssi-freshness.test.ts
@@ -41,14 +41,16 @@ describe('isPeerFresh()', () => {
     await expect(isPeerFresh(device)).resolves.toBe(true);
   });
 
-  it('returns false when RSSI is undefined (BlueZ dropped the property)', async () => {
+  it('returns true when RSSI is undefined and tracker is fresh (#167 regression guard)', async () => {
+    // BlueZ may drop the Optional RSSI prop after StopDiscovery. Absence is
+    // not a freshness signal; PropertiesChanged + fresh-init timestamp are.
     const { device } = makeDevice(() => undefined);
-    await expect(isPeerFresh(device)).resolves.toBe(false);
+    await expect(isPeerFresh(device)).resolves.toBe(true);
   });
 
-  it('returns false when RSSI is null', async () => {
+  it('returns true when RSSI is null and tracker is fresh', async () => {
     const { device } = makeDevice(() => null);
-    await expect(isPeerFresh(device)).resolves.toBe(false);
+    await expect(isPeerFresh(device)).resolves.toBe(true);
   });
 
   it('returns false when RSSI is the BlueZ sentinel 127 (unavailable)', async () => {
@@ -56,16 +58,16 @@ describe('isPeerFresh()', () => {
     await expect(isPeerFresh(device)).resolves.toBe(false);
   });
 
-  it('returns false when prop call throws (D-Bus error or property absent)', async () => {
+  it('returns true when prop call throws and tracker is fresh', async () => {
     const { device } = makeDevice(() => {
       throw new Error('Property not found');
     });
-    await expect(isPeerFresh(device)).resolves.toBe(false);
+    await expect(isPeerFresh(device)).resolves.toBe(true);
   });
 
-  it('returns false when prop rejects asynchronously', async () => {
+  it('returns true when prop rejects asynchronously and tracker is fresh', async () => {
     const { device } = makeDevice(() => Promise.reject(new Error('D-Bus error')));
-    await expect(isPeerFresh(device)).resolves.toBe(false);
+    await expect(isPeerFresh(device)).resolves.toBe(true);
   });
 
   it('subscribes to PropertiesChanged and tears down on stop', async () => {
@@ -134,6 +136,26 @@ describe('startPeerFreshnessTracker()', () => {
     });
     const tracker = startPeerFreshnessTracker(device);
     await expect(tracker.isFresh()).resolves.toBe(true);
+    tracker.stop();
+  });
+
+  it('returns false when RSSI is undefined and lastRssiUpdateTs is stale', async () => {
+    // Fresh init protects new trackers, but a long-lived tracker that never
+    // saw another advert in 5+ s must still report stale.
+    const { device } = makeDevice(() => undefined);
+    const tracker = startPeerFreshnessTracker(device);
+    vi.advanceTimersByTime(RSSI_FRESHNESS_MS + 1000);
+    await expect(tracker.isFresh()).resolves.toBe(false);
+    tracker.stop();
+  });
+
+  it('returns false when prop throws and lastRssiUpdateTs is stale', async () => {
+    const { device } = makeDevice(() => {
+      throw new Error('D-Bus error');
+    });
+    const tracker = startPeerFreshnessTracker(device);
+    vi.advanceTimersByTime(RSSI_FRESHNESS_MS + 1000);
+    await expect(tracker.isFresh()).resolves.toBe(false);
     tracker.stop();
   });
 });


### PR DESCRIPTION
## Summary

Hotfix release on top of v1.12.0. Cherry-picks the single fix landed on `dev` after the v1.12.0 cut.

- **#167** (`396837f`) RSSI freshness check no longer treats absent `org.bluez.Device1.RSSI` prop as stale. The #143 dying-peer guard shipped in v1.12.0 rejected every connect attempt to peers whose RSSI prop BlueZ dropped after `StopDiscovery` (deterministically reproduced on Renpho ES-26M static random addresses by @fromport and ES-26BB-B by @boildead, both downgraded to v1.10.2 as a workaround). `isFresh()` now relies only on the 127 mgmt-protocol "unavailable" sentinel and the 5 s `PropertiesChanged` window; the fresh-init `lastRssiUpdateTs = Date.now()` at tracker construction covers the just-after-StopDiscovery case.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx eslint .`
- [x] `npx prettier --check .`
- [x] `npm test` (1382 passed, +3 new cases vs v1.12.0)
- [x] Verified BlueZ Device1.RSSI Readonly+Optional semantics via context7

## Release

release-please will pick up the `fix(ble):` commit and generate the v1.12.1 patch bump PR automatically.