### PR TITLE
ci: add Node 26 to CI matrix (monitoring)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22, 24]
+        node-version: [22, 24, 26]
 
     steps:
       - uses: actions/checkout@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ Both ESLint and Prettier are enforced in CI.
 ble-scale-sync/
 ├── .github/
 │   └── workflows/
-│       ├── ci.yml                   # CI: lint, format, typecheck, tests (Node 22/24), python-check
+│       ├── ci.yml                   # CI: lint, format, typecheck, tests (Node 22/24/26), python-check
 │       ├── docker.yml               # Docker: multi-arch build + GHCR push on release
 │       ├── docker-cleanup.yml       # Prune old GHCR image tags
 │       ├── docs.yml                 # VitePress docs deploy to Cloudflare Pages


### PR DESCRIPTION
## Summary

Track Node 26 compatibility on a dedicated PR so CI runs are visible without polluting `dev`.

Node 26.1.0 shipped on the Current release line on 2026-05-06 and becomes LTS in October 2026. Adding it to the test matrix surfaces ABI / native-module issues against @stoprocent/noble, aedes, and other native modules before the LTS cut.

The same matrix change briefly ran on dev (run 25739693422, since reverted) and passed for Node 22 + 24 + 26 in 2m9s, so the initial signal is green. This PR keeps the matrix expansion isolated so we can decide separately whether to fold it into dev permanently.

## Test plan

- [ ] Watch CI matrix on this PR; expect three green jobs (Node 22, 24, 26)
- [ ] If Node 26 stays green across a few weeks, merge into dev. Otherwise close