### PR TITLE
Added Support for Eufy T9120 (A1)

### DIFF
--- a/src/scales/one-byone.ts
+++ b/src/scales/one-byone.ts
@@ -10,10 +10,10 @@ import { uuid16, buildPayload, xorChecksum, type ScaleBodyComp } from './body-co
 
 // ─── OneByoneAdapter (Eufy C1/P1, Health Scale) ─────────────────────────────
 
-const ONEBYONE_NAMES = ['t9146', 't9147', 'health scale'];
+const ONEBYONE_NAMES = ['t9146', 't9147', 't9120', 'health scale'];
 
 /**
- * Adapter for Eufy C1/P1 and "Health Scale" branded 1byone devices.
+ * Adapter for Eufy C1/P1/A1 and "Health Scale" branded 1byone devices.
  *
  * Protocol: service 0xFFF0, notify 0xFFF4, write 0xFFF1.
  * Unlock via clock-sync frame: [0xF1, yearHi, yearLo, month, day, hour, min, sec].

--- a/src/scales/standard-gatt.ts
+++ b/src/scales/standard-gatt.ts
@@ -36,6 +36,7 @@ const EXCLUDED = [
   'electronic scale',
   '1byone scale',
   'health scale',
+  't9120',
   't9146',
   't9147',
   'ae bs-06',

--- a/tests/scales/one-byone.test.ts
+++ b/tests/scales/one-byone.test.ts
@@ -15,7 +15,7 @@ describe('OneByoneAdapter', () => {
   }
 
   describe('matches()', () => {
-    it.each(['t9146', 't9147', 'health scale'])('matches "%s"', (name) => {
+    it.each(['t9146', 't9147', 't9120', 'health scale'])('matches "%s"', (name) => {
       const adapter = makeAdapter();
       expect(adapter.matches(mockPeripheral(name))).toBe(true);
     });


### PR DESCRIPTION
## Summary

Added support for T9120 which is identical to T9146

## Changes

Added support for T9120 which is identical to T9146

## Test Plan

<!-- How did you verify this works? -->

- [x] Tests pass (`npm test`)
- [x] Lint clean (`npm run lint`)
- [x] TypeScript compiles (`npx tsc --noEmit`)
- [x] Tested manually (describe below)

## Notes

N/A
