### PR TITLE
fix(ble): characteristic-aware adapter matching for 0xFFF0 collision (#177)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,13 @@ See **[CONTRIBUTING.md](CONTRIBUTING.md)** for development setup, project struct
 ## License
 
 GPL-3.0. See [LICENSE](LICENSE) for details.
+
+## Star History
+
+<a href="https://www.star-history.com/?repos=KristianP26%2Fble-scale-sync&type=date&legend=bottom-right">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=KristianP26/ble-scale-sync&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=KristianP26/ble-scale-sync&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=KristianP26/ble-scale-sync&type=date&legend=top-left" />
+ </picture>
+</a>

--- a/src/ble/handler-node-ble/scan.ts
+++ b/src/ble/handler-node-ble/scan.ts
@@ -174,24 +174,45 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
       });
       bleLog.info('Connected. Discovering services...');
 
-      // Match adapter using device name + GATT service UUIDs (post-connect)
+      // Resolve the adapter post-discovery using characteristics as well as
+      // service UUIDs, so devices that share a generic vendor service (e.g.
+      // 0xFFF0: 1byone/Eufy vs Inlife) are disambiguated instead of falling to
+      // the first service-only match. BlueZ can export characteristics late
+      // ([bluez/bluez#1489]), so retry the enumeration within the existing
+      // discovery budget until an adapter is recognized. #177
       const gatt = await device.gatt();
       const serviceUuids = await gatt.services();
       bleLog.debug(`Services: [${serviceUuids.join(', ')}]`);
 
-      const info: BleDeviceInfo = {
-        localName: name,
-        serviceUuids: serviceUuids.map(normalizeUuid),
-      };
-      const found = adapters.find((a) => a.matches(info));
-      if (!found) {
+      let resolved: ScaleAdapter | undefined;
+      let matchCharMap = await withTimeout(
+        buildCharMap(gatt),
+        GATT_DISCOVERY_TIMEOUT_MS,
+        'GATT service discovery timed out',
+      );
+      for (let attempt = 1; attempt <= CHAR_DISCOVERY_MAX_RETRIES; attempt++) {
+        const info: BleDeviceInfo = {
+          localName: name,
+          serviceUuids: serviceUuids.map(normalizeUuid),
+          characteristicUuids: [...matchCharMap.keys()],
+        };
+        resolved = adapters.find((a) => a.matches(info));
+        if (resolved || attempt === CHAR_DISCOVERY_MAX_RETRIES) break;
+        await sleep(CHAR_DISCOVERY_RETRY_DELAY_MS);
+        matchCharMap = await withTimeout(
+          buildCharMap(gatt),
+          GATT_DISCOVERY_TIMEOUT_MS,
+          'GATT service discovery timed out',
+        );
+      }
+      if (!resolved) {
         throw new Error(
           `Device found (${name}) but no adapter recognized it. ` +
             `Services: [${serviceUuids.join(', ')}]. ` +
             `Adapters: ${adapters.map((a) => a.name).join(', ')}`,
         );
       }
-      matchedAdapter = found;
+      matchedAdapter = resolved;
       bleLog.info(`Matched adapter: ${matchedAdapter.name}`);
     } else {
       // Auto-discovery: poll discovered devices, match by name, connect, verify

--- a/src/interfaces/scale-adapter.ts
+++ b/src/interfaces/scale-adapter.ts
@@ -8,6 +8,13 @@ export interface BleDeviceInfo {
   manufacturerData?: { id: number; data: Buffer };
   /** Service data entries from the BLE advertisement (if present). */
   serviceData?: Array<{ uuid: string; data: Buffer }>;
+  /**
+   * GATT characteristic UUIDs (full 128-bit lowercase form), populated only
+   * post-discovery. Lets adapters that share a vendor service (e.g. 0xFFF0:
+   * 1byone vs Inlife) disambiguate by their own characteristics. Absent on
+   * pre-connect / broadcast match paths.
+   */
+  characteristicUuids?: string[];
 }
 
 export interface ScaleReading {

--- a/src/scales/inlife.ts
+++ b/src/scales/inlife.ts
@@ -42,7 +42,17 @@ export class InlifeScaleAdapter implements ScaleAdapter {
     const name = (device.localName || '').toLowerCase();
     if (KNOWN_NAMES.includes(name)) return true;
 
-    // Also match by advertised service UUID
+    const chars = device.characteristicUuids;
+    if (chars && chars.length > 0) {
+      // Post-discovery: 0xFFF0 is a generic vendor service shared with the
+      // 1byone/Eufy family, so require Inlife's own write characteristic
+      // 0xFFF2 rather than the bare service UUID. Prevents the #177 collision
+      // where a nameless T9146 (0xFFF1 + 0xFFF4, no 0xFFF2) fell to Inlife.
+      return chars.includes(CHR_WRITE);
+    }
+
+    // Pre-connect (no characteristics yet): keep the legacy advertised-service
+    // fallback so true Inlife scales still match before a GATT connection.
     const uuids = (device.serviceUuids || []).map((u) => u.toLowerCase());
     return uuids.some((u) => u === 'fff0' || u === SVC_UUID);
   }

--- a/src/scales/one-byone.ts
+++ b/src/scales/one-byone.ts
@@ -31,7 +31,12 @@ export class OneByoneAdapter implements ScaleAdapter {
 
   matches(device: BleDeviceInfo): boolean {
     const name = (device.localName || '').toLowerCase();
-    return ONEBYONE_NAMES.some((n) => name.includes(n));
+    if (ONEBYONE_NAMES.some((n) => name.includes(n))) return true;
+    // Post-discovery disambiguation of the shared 0xFFF0 vendor service: the
+    // 1byone/Eufy notify characteristic 0xFFF4 is unique to this family (Inlife
+    // never exposes it), so it identifies the device when the broadcast name is
+    // absent at connect time (e.g. BlueZ by-MAC). #177
+    return (device.characteristicUuids ?? []).includes(uuid16(0xfff4));
   }
 
   /**

--- a/tests/helpers/scale-test-utils.ts
+++ b/tests/helpers/scale-test-utils.ts
@@ -9,11 +9,13 @@ export function mockPeripheral(
   name: string,
   uuids: string[] = [],
   manufacturerData?: Buffer,
+  charUuids?: string[],
 ): BleDeviceInfo {
   return {
     localName: name,
     serviceUuids: uuids,
     manufacturerData,
+    ...(charUuids ? { characteristicUuids: charUuids } : {}),
   };
 }
 

--- a/tests/scales/adapter-resolution.test.ts
+++ b/tests/scales/adapter-resolution.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { adapters } from '../../src/scales/index.js';
+import { uuid16 } from '../../src/scales/body-comp-helpers.js';
+import type { BleDeviceInfo } from '../../src/interfaces/scale-adapter.js';
+
+// Regression for #177: a Eufy/1byone T9146 advertises name "eufy T9146" and the
+// generic 0xFFF0 vendor service. Before the fix, Inlife (earlier in the adapter
+// array) shadowed the 1byone adapter via its bare 0xFFF0 fallback. Once
+// characteristics are known post-discovery, Inlife must yield so the device
+// resolves to "1byone (Eufy)".
+describe('adapter resolution (#177 0xFFF0 collision)', () => {
+  it('resolves a T9146 (name + 0xFFF1/0xFFF4 chars) to "1byone (Eufy)"', () => {
+    const info: BleDeviceInfo = {
+      localName: 'eufy T9146',
+      serviceUuids: [uuid16(0xfff0)],
+      characteristicUuids: [uuid16(0xfff1), uuid16(0xfff4)],
+    };
+    const matched = adapters.find((a) => a.matches(info));
+    expect(matched?.name).toBe('1byone (Eufy)');
+  });
+
+  it('does not regress a real Inlife device (known name) -> "Inlife"', () => {
+    const info: BleDeviceInfo = {
+      localName: '000fatscale01',
+      serviceUuids: [uuid16(0xfff0)],
+      characteristicUuids: [uuid16(0xfff1), uuid16(0xfff2)],
+    };
+    const matched = adapters.find((a) => a.matches(info));
+    expect(matched?.name).toBe('Inlife');
+  });
+});

--- a/tests/scales/inlife.test.ts
+++ b/tests/scales/inlife.test.ts
@@ -6,6 +6,7 @@ import {
   defaultProfile,
   assertPayloadRanges,
 } from '../helpers/scale-test-utils.js';
+import { uuid16 } from '../../src/scales/body-comp-helpers.js';
 
 function makeAdapter() {
   return new InlifeScaleAdapter();
@@ -34,6 +35,25 @@ describe('InlifeScaleAdapter', () => {
     it('does not match unrelated name without service UUID', () => {
       const adapter = makeAdapter();
       expect(adapter.matches(mockPeripheral('Random Scale'))).toBe(false);
+    });
+
+    it('matches post-discovery by its own 0xFFF2 characteristic (#177)', () => {
+      const adapter = makeAdapter();
+      const info = mockPeripheral('', [uuid16(0xfff0)], undefined, [
+        uuid16(0xfff1),
+        uuid16(0xfff2),
+      ]);
+      expect(adapter.matches(info)).toBe(true);
+    });
+
+    it('does not match a 1byone/T9146 device once characteristics are known (#177)', () => {
+      const adapter = makeAdapter();
+      // T9146 exposes 0xFFF1 + 0xFFF4 but never Inlife's write char 0xFFF2.
+      const info = mockPeripheral('', [uuid16(0xfff0)], undefined, [
+        uuid16(0xfff1),
+        uuid16(0xfff4),
+      ]);
+      expect(adapter.matches(info)).toBe(false);
     });
   });
 

--- a/tests/scales/one-byone.test.ts
+++ b/tests/scales/one-byone.test.ts
@@ -6,6 +6,7 @@ import {
   defaultProfile,
   assertPayloadRanges,
 } from '../helpers/scale-test-utils.js';
+import { uuid16 } from '../../src/scales/body-comp-helpers.js';
 
 // ─── OneByoneAdapter ─────────────────────────────────────────────────────────
 
@@ -40,6 +41,20 @@ describe('OneByoneAdapter', () => {
     it('does not match unrelated name', () => {
       const adapter = makeAdapter();
       expect(adapter.matches(mockPeripheral('Random Scale'))).toBe(false);
+    });
+
+    it('matches post-discovery by 0xFFF4 characteristic when name absent (#177)', () => {
+      const adapter = makeAdapter();
+      const info = mockPeripheral('', [uuid16(0xfff0)], undefined, [
+        uuid16(0xfff1),
+        uuid16(0xfff4),
+      ]);
+      expect(adapter.matches(info)).toBe(true);
+    });
+
+    it('does not match nameless device with only 0xFFF0 service and no chars (#177)', () => {
+      const adapter = makeAdapter();
+      expect(adapter.matches(mockPeripheral('', [uuid16(0xfff0)]))).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #177: Eufy/1byone T9146 (and the T9147/T9120 family) was mismatched as the `Inlife` adapter at runtime and looped on a missing `0xFFF2` characteristic.

Root cause: `0xFFF0` is a generic vendor service shared by Inlife and 1byone/Eufy. `InlifeScaleAdapter` (index 49) precedes `OneByoneAdapter` (index 51) and its bare `0xFFF0` service fallback shadowed OneByone's name match. Confirmed by reporter `npm run diagnose`: T9146 exposes `0xFFF1` + `0xFFF4`, never `0xFFF2`.

## Changes

- `BleDeviceInfo.characteristicUuids?: string[]` (populated post-discovery only).
- `OneByoneAdapter.matches()`: name OR characteristic `0xFFF4`.
- `InlifeScaleAdapter.matches()`: known name OR (characteristics known then require `0xFFF2`); legacy bare `0xFFF0` service fallback kept only when characteristics are unknown (no regression on non-threaded paths).
- node-ble target-MAC path resolves the adapter after building the characteristic map, retried within the existing discovery budget for BlueZ late-characteristic export.
- `mockPeripheral` gains an optional `charUuids` arg; new resolution regression test plus char cases in one-byone / inlife suites.
- README: Star History section.

## Out of scope / deferred

noble and noble-legacy parity. The guarded Inlife fallback keeps those paths at current behaviour (no new regression); macOS/Windows by-MAC T9146 stays as-is until a follow-up.

## Test Plan

- [x] `npm test` (1436 passed)
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npx prettier --check` on touched files

Issue stays open pending reporter retest after release.