### PR TITLE
fix(docker): add missing setup-strava command to entrypoint (#188)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -47,6 +47,9 @@ case "$CMD" in
       exec python3 garmin-scripts/setup_garmin.py "$@"
     fi
     ;;
+  setup-strava)
+    exec node dist/exporters/strava-setup.js
+    ;;
   help|--help|-h)
     echo "BLE Scale Sync - Docker Commands"
     echo ""
@@ -61,6 +64,7 @@ case "$CMD" in
     echo "  setup-garmin                  Garmin auth (env vars: GARMIN_EMAIL, GARMIN_PASSWORD)"
     echo "  setup-garmin --user <name>    Garmin auth for a specific user from config.yaml"
     echo "  setup-garmin --all-users      Garmin auth for all users from config.yaml"
+    echo "  setup-strava                  Strava OAuth (interactive browser authorization)"
     echo "  help                          Show this help message"
     echo ""
     echo "Any other command is executed directly (e.g. 'sh' for a debug shell)."


### PR DESCRIPTION
## Summary

Fixes #188. `docker run ... ble-scale-sync:latest setup-strava` failed with:

```
./docker-entrypoint.sh: 69: exec: setup-strava: not found
```

`docs/exporters.md` documents the `setup-strava` Docker command and `package.json` defines a matching script, but `docker-entrypoint.sh` never had a case for it — unlike `setup-garmin`. The argument fell through to the catch-all `*) exec "$@"` branch and was executed as a missing binary.

## Changes

- Add a `setup-strava)` case running the compiled `dist/exporters/strava-setup.js` (the equivalent of `npm run setup-strava`).
- List `setup-strava` in the `help` command output.

## Verification

- Confirmed `dist/exporters/strava-setup.js` exists and is a self-executing script (`main().catch(...)`).
- `sh -n docker-entrypoint.sh` passes.

> [!NOTE]
> Hotfix branched directly off `main` (not `dev`) since `dev` currently holds unrelated WIP. Squash-merging with this conventional `fix:` title will trigger release-please to open a `chore(main): release` PR with a patch bump (1.10.2 → 1.10.3).