### PR TITLE
fix: force-exit on hung shutdown so the watchdog actually restarts the container (#194)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -168,6 +168,14 @@ On Pi 3/4 Broadcom on-board chips, this is a kernel/firmware-level issue that ev
 
 **Auto-restart watchdog (continuous mode).** When in-process recovery is not enough (typically Pi 3/4 Broadcom firmware lock-up), a watchdog exits the process after `runtime.watchdog_max_consecutive_failures` consecutive scan failures (default `10`, ≈30 min). With Docker `restart: unless-stopped` the container restarts cleanly, the entrypoint resets the BT adapter, and the controller is typically unwedged. The watchdog only arms after the first successful weigh-in in the process lifetime, so it does not restart-loop the container if the scale is offline (vacation) or `scale_mac` is misconfigured.
 
+::: warning The watchdog recovers by **exiting the process** — set a restart policy
+The recovery is the process _exiting_ so the supervisor starts it again. You **must** run with `restart: unless-stopped` (Compose) or `--restart unless-stopped` (`docker run`). Without a restart policy the container just stops.
+
+A Docker/Compose `restart:` policy fires only on process **exit** — it does **not** act on the `HEALTHCHECK` going `unhealthy`. If you see the container stuck `Up (unhealthy)` but never restarting, plain Docker is working as designed: only Swarm, Kubernetes, or an [autoheal](https://github.com/willfarrell/docker-autoheal) sidecar restarts on health status. With a restart policy and the hard-exit floor below, the process always exits, so the policy always fires.
+:::
+
+To bound the rare case where a wedged D-Bus/BlueZ handle pins the event loop open and graceful shutdown cannot drain (the process logs `Stopped.` but never exits, so the restart policy never fires), the app force-exits 5s after any abort-driven shutdown. Override with `BLE_HARD_EXIT_GRACE_MS` (1000–60000 ms) if your cleanup legitimately needs longer.
+
 ```yaml
 runtime:
   watchdog_max_consecutive_failures: 10 # default; 0 = disabled

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { writeFileSync } from 'node:fs';
 import { setDisplayUsers } from './ble/handler-mqtt-proxy/index.js';
 import { bootstrapMqttProxy } from './ble/mqtt-proxy-bootstrap.js';
 import { notifyReady, startHeartbeat, stopHeartbeat } from './runtime/systemd-watchdog.js';
+import { armHardExit } from './runtime/hard-exit.js';
 import { adapters } from './scales/index.js';
 import { assertRegistryIntegrity } from './scales/registry-check.js';
 import { createLogger, setLogLevel, LogLevel } from './logger.js';
@@ -51,6 +52,9 @@ if (cliFlags.help) {
   console.log(
     '  BLE_WATCHDOG_MAX_FAILURES 0-1000  override runtime.watchdog_max_consecutive_failures (0 = disabled)',
   );
+  console.log(
+    '  BLE_HARD_EXIT_GRACE_MS 1000-60000  force-exit floor for hung shutdown (default 5000)',
+  );
   console.log('  SCALE_MAC        MAC/UUID    override ble.scale_mac');
   console.log('  NOBLE_DRIVER     abandonware/stoprocent  override ble.noble_driver');
   console.log('  BLE_ADAPTER      hci0/hci1/...  override ble.adapter (Linux only)');
@@ -69,7 +73,26 @@ if (initialConfig.runtime?.debug) setLogLevel(LogLevel.DEBUG);
 
 // ─── Abort / signal handling ────────────────────────────────────────────────
 
+// Force-exit floor: if abort-driven cleanup cannot drain the event loop
+// within this window (e.g. a wedged D-Bus/BlueZ handle pins it open), the
+// process is force-exited so Docker `restart: unless-stopped` / systemd can
+// recover. Default 5s — below Docker's 10s SIGKILL grace and well below a
+// typical systemd WatchdogSec. Override via BLE_HARD_EXIT_GRACE_MS (ms).
+const HARD_EXIT_GRACE_MS = ((): number => {
+  const raw = process.env.BLE_HARD_EXIT_GRACE_MS;
+  if (raw === undefined) return 5_000;
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= 1_000 && n <= 60_000 ? n : 5_000;
+})();
+
 const ac = new AbortController();
+
+// Register the hard-exit safety net before anything can abort `ac`. Armed
+// once on the first abort (watchdog trip, SIGTERM, or any internal abort);
+// idempotent, unref'd, so a clean drain still exits naturally first (#194).
+ac.signal.addEventListener('abort', () => armHardExit({ timeoutMs: HARD_EXIT_GRACE_MS, log }), {
+  once: true,
+});
 const ctx = createAppContext({
   config: initialConfig,
   resolved: initialResolved,

--- a/src/runtime/hard-exit.ts
+++ b/src/runtime/hard-exit.ts
@@ -1,0 +1,72 @@
+import type { Logger } from '../logger.js';
+
+/**
+ * Hard-exit safety net for shutdown (#194).
+ *
+ * Graceful shutdown aborts the {@link AbortController} and relies on the Node
+ * event loop draining so the process exits naturally (and Docker
+ * `restart: unless-stopped` / systemd restarts it). But the scenario that most
+ * often triggers the continuous-mode watchdog is a *wedged* BlueZ controller,
+ * and node-ble / dbus-next keeps an open D-Bus socket that pins the event loop
+ * open. The loop logs `Stopped.` but the process never exits: the container
+ * stays running with a stale heartbeat (HEALTHCHECK → "unhealthy") and is
+ * never restarted, because plain Docker only restarts on process *exit*, not
+ * on an unhealthy status.
+ *
+ * `armHardExit` bounds every abort-driven shutdown: once the grace window
+ * elapses, the process is force-exited so the supervisor can recover. The
+ * timer is `unref()`d, so a clean drain still exits naturally well before it
+ * fires — this is only the floor, not the normal path.
+ */
+
+let armed = false;
+let timer: ReturnType<typeof setTimeout> | null = null;
+
+export interface ArmHardExitOptions {
+  /** Grace window before force-exit, in milliseconds. */
+  timeoutMs: number;
+  log: Logger;
+  /** Injectable for tests. Defaults to `process.exit`. */
+  exit?: (code: number) => never;
+}
+
+/**
+ * Arm the hard-exit timer. Idempotent: only the first call arms it, so
+ * multiple abort paths (watchdog trip, then a SIGTERM) do not stack timers.
+ */
+export function armHardExit({ timeoutMs, log, exit }: ArmHardExitOptions): void {
+  if (armed) return;
+  armed = true;
+
+  const doExit = exit ?? ((code: number) => process.exit(code));
+
+  timer = setTimeout(() => {
+    // Preserve an explicitly-set exit code (the watchdog sets 1 before
+    // aborting). When unset — e.g. a plain SIGTERM whose graceful cleanup
+    // then hung — fall back to 1 deliberately: a shutdown that could not
+    // drain within the grace window is itself a failure worth a non-zero
+    // code, and a `docker stop`-ped container is not restarted regardless.
+    const code = typeof process.exitCode === 'number' ? process.exitCode : 1;
+    log.warn(
+      `Shutdown did not complete within ${timeoutMs / 1000}s ` +
+        `(event loop still pinned, likely a wedged D-Bus/BlueZ handle). ` +
+        `Force-exiting with code ${code} so the supervisor can restart cleanly.`,
+    );
+    doExit(code);
+  }, timeoutMs);
+
+  // The timer must not itself keep the process alive: if cleanup drains the
+  // loop first, Node exits naturally before this fires (the desired outcome).
+  timer.unref();
+}
+
+/**
+ * Cancel a pending hard-exit timer and disarm so it can be re-armed. Lets a
+ * shutdown path that has fully drained opt out of the force-exit floor, and
+ * resets module state between tests.
+ */
+export function cancelHardExit(): void {
+  if (timer) clearTimeout(timer);
+  timer = null;
+  armed = false;
+}

--- a/tests/runtime/hard-exit.test.ts
+++ b/tests/runtime/hard-exit.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { armHardExit, cancelHardExit } from '../../src/runtime/hard-exit.js';
+import type { Logger } from '../../src/logger.js';
+
+function createMockLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+describe('armHardExit', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Disarm any state leaked from a previous test (module is reused).
+    cancelHardExit();
+  });
+
+  afterEach(() => {
+    cancelHardExit();
+    vi.useRealTimers();
+  });
+
+  it('force-exits after the grace window with the current exit code', () => {
+    const log = createMockLogger();
+    const exit = vi.fn();
+    const prev = process.exitCode;
+    process.exitCode = 1;
+
+    armHardExit({ timeoutMs: 5_000, log, exit: exit as unknown as (c: number) => never });
+
+    expect(exit).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(4_999);
+    expect(exit).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(log.warn).toHaveBeenCalledTimes(1);
+
+    process.exitCode = prev;
+  });
+
+  it('falls back to code 1 when no exit code is set', () => {
+    const log = createMockLogger();
+    const exit = vi.fn();
+    const prev = process.exitCode;
+    process.exitCode = undefined;
+
+    armHardExit({ timeoutMs: 5_000, log, exit: exit as unknown as (c: number) => never });
+    vi.advanceTimersByTime(5_000);
+
+    expect(exit).toHaveBeenCalledWith(1);
+    process.exitCode = prev;
+  });
+
+  it('is idempotent: a second arm does not stack another timer', () => {
+    const log = createMockLogger();
+    const exit = vi.fn();
+
+    armHardExit({ timeoutMs: 5_000, log, exit: exit as unknown as (c: number) => never });
+    armHardExit({ timeoutMs: 1_000, log, exit: exit as unknown as (c: number) => never });
+
+    // The shorter second window must be ignored (first arm wins).
+    vi.advanceTimersByTime(1_000);
+    expect(exit).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(4_000);
+    expect(exit).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancelHardExit prevents the force-exit and re-arms cleanly', () => {
+    const log = createMockLogger();
+    const exit = vi.fn();
+
+    armHardExit({ timeoutMs: 5_000, log, exit: exit as unknown as (c: number) => never });
+    cancelHardExit();
+    vi.advanceTimersByTime(10_000);
+    expect(exit).not.toHaveBeenCalled();
+
+    // After cancel, arming again works (proves the armed flag was reset).
+    armHardExit({ timeoutMs: 2_000, log, exit: exit as unknown as (c: number) => never });
+    vi.advanceTimersByTime(2_000);
+    expect(exit).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #194. The continuous-mode watchdog "recovers" by exiting the process so Docker `restart: unless-stopped` / systemd restarts it. But the scenario that trips the watchdog is a **wedged BlueZ controller**, and node-ble / dbus-next holds an open D-Bus socket that pins the Node event loop open. The loop unwinds and logs `Stopped.`, but the process **never exits** — so the container sits `Up (unhealthy)` indefinitely and is never restarted (plain Docker/Compose only restarts on process *exit*, not on an unhealthy `HEALTHCHECK`). This matches the reporter's symptom exactly: "shows Unhealthy … doesn't seem to restart."

## Changes

- **`src/runtime/hard-exit.ts`** (new): `armHardExit()` — a hard-exit safety floor. Idempotent, `unref()`d, force-exits with the current exit code after a grace window.
- **`src/index.ts`**: arm it on the first `AbortController` abort (watchdog trip, SIGTERM, or any internal abort). Registered before anything can abort. `BLE_HARD_EXIT_GRACE_MS` env override (1000–60000 ms, default 5000); added to `--help`.
- **`tests/runtime/hard-exit.test.ts`** (new): grace-window exit, exit-code fallback, idempotency, cancel/re-arm.
- **`docs/troubleshooting.md`**: clarify the watchdog needs a restart policy, that plain Docker does **not** restart on `unhealthy` (needs Swarm/k8s/autoheal), and document the hard-exit floor.

The timer is `unref()`d so a clean drain still exits naturally well before it fires — this is only a floor, not the normal path. The existing double-signal force-exit and heartbeat-through-shutdown behavior are untouched.

## Test Plan

- [x] Tests pass (`npx vitest run` — 1527 passed)
- [x] Lint clean (`npx eslint src tests`)
- [x] TypeScript compiles (`npx tsc --noEmit`)
- [x] Prettier clean (`npx prettier --check`)
