### PR TITLE
ci: build and push :dev image on push to dev branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,8 @@ name: Docker
 on:
   release:
     types: [published]
+  push:
+    branches: [dev]
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
@@ -49,6 +51,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
             type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push


### PR DESCRIPTION
Fixes the missing `:dev` image. `docker.yml` had no `push` trigger, so a `dev` image was never produced — only release tags, PR builds (not pushed), and manual dispatch.

## Changes
- Add `push: branches: [dev]` trigger.
- Tag the resulting multi-arch image `:dev` (`type=raw,value=dev` enabled only on `refs/heads/dev`).

`push:` stays true for push events (`github.event_name != 'pull_request'`), so the image is pushed to GHCR. `:latest` remains release-only; semver tags are unaffected (branch pushes don't match `type=semver`).

Takes effect on the first push to `dev` after merge. To create the image immediately I'm also triggering a manual `workflow_dispatch` with tag `dev` (already supported on the current workflow).