### PR TITLE
feat(mqtt-proxy): ESP32 autonomous GATT connect for fast-sleeping scales

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -64,7 +64,7 @@ ble:
 | `handler`       | No                          | `auto`         | Transport: `auto` (local radio), `mqtt-proxy` (ESP32 over MQTT), `esphome-proxy` (ESPHome Native API). See below.                                     |
 | `noble_driver`  | No                          | OS default     | `abandonware` or `stoprocent`. Overrides the default BLE driver. Only applies when `handler: auto`.                                                   |
 | `adapter`       | No                          | System default | Linux only. Select a specific Bluetooth adapter (e.g., `hci0`, `hci1`). See below.                                                                    |
-| `mqtt_proxy`    | If `handler: mqtt-proxy`    | (none)         | MQTT proxy connection (`broker_url`, `device_id`, `topic_prefix`, `username`, `password`, `embedded_broker_*`). See [ESP32 BLE Proxy](./esp32-proxy). |
+| `mqtt_proxy`    | If `handler: mqtt-proxy`    | (none)         | MQTT proxy connection (`broker_url`, `device_id`, `topic_prefix`, `username`, `password`, `auto_connect`, `embedded_broker_*`). See [ESP32 BLE Proxy](./esp32-proxy). |
 | `esphome_proxy` | If `handler: esphome-proxy` | (none)         | ESPHome Native API connection (`host`, `port`, `encryption_key` or `password`, `client_info`). See [ESPHome Bluetooth Proxy](./esphome-proxy).        |
 
 ::: tip BLE adapter selection (Linux only)

--- a/docs/guide/esp32-proxy.md
+++ b/docs/guide/esp32-proxy.md
@@ -36,11 +36,15 @@ The ESP32 scans autonomously for BLE advertisements and publishes results over M
 
 **GATT scales** (notification-based readings):
 
-1. A matched adapter has no broadcast data, so the server sends a `connect` command
-2. The ESP32 connects to the scale, discovers characteristics, and reports them
+1. The ESP32 detects a known scale MAC during scanning and auto-connects immediately
+2. The ESP32 discovers characteristics and notifies the server that it's already connected
 3. The server subscribes to notification topics and sends write commands (e.g. unlock)
 4. Scale readings arrive as notifications, forwarded to the server via MQTT
 5. The server sends a `disconnect` command when the reading is complete
+
+::: tip Autonomous connect
+Since v1.16, the ESP32 connects to known scales autonomously the instant it detects them, eliminating the MQTT round-trip that previously caused some fast-sleeping scales to power off before the connection could be established. This behavior is on by default. To disable it and use the old host-initiated connect flow, set `auto_connect: false` under `mqtt_proxy` in your config.
+:::
 
 ## Supported Boards
 

--- a/docs/guide/esp32-proxy.md
+++ b/docs/guide/esp32-proxy.md
@@ -43,7 +43,7 @@ The ESP32 scans autonomously for BLE advertisements and publishes results over M
 5. The server sends a `disconnect` command when the reading is complete
 
 ::: tip Autonomous connect
-Since v1.16, the ESP32 connects to known scales autonomously the instant it detects them, eliminating the MQTT round-trip that previously caused some fast-sleeping scales to power off before the connection could be established. This behavior is on by default. To disable it and use the old host-initiated connect flow, set `auto_connect: false` under `mqtt_proxy` in your config.
+The ESP32 connects to known scales autonomously the instant it detects them, eliminating the MQTT round-trip that previously caused some fast-sleeping scales to power off before the connection could be established. This behavior is on by default. To disable it and use the old host-initiated connect flow, set `auto_connect: false` under `mqtt_proxy` in your config.
 :::
 
 ## Supported Boards

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -48,6 +48,10 @@ _pending = []
 _scale_macs = set()
 _last_beep_time = 0
 
+# Autonomous GATT connect: ESP32 connects itself when a known scale MAC
+# appears in a scan, eliminating the MQTT round-trip latency (#201).
+_auto_connect = True  # opt-out via config topic {"autoConnect": false}
+
 
 def topic(suffix):
     return f"{BASE}/{suffix}"
@@ -72,13 +76,14 @@ mqtt_config["queue_len"] = 0  # callback mode
 
 def on_message(topic_bytes, msg, retained):
     """Sync callback — queue the command for async processing."""
-    global _scale_macs
+    global _scale_macs, _auto_connect
     t = topic_bytes.decode() if isinstance(topic_bytes, (bytes, bytearray)) else topic_bytes
     if t == topic("config"):
         try:
             data = json.loads(msg)
             _scale_macs = set(data.get("scales", []))
-            print(f"Config: {len(_scale_macs)} scale MAC(s)")
+            _auto_connect = data.get("autoConnect", True)
+            print(f"Config: {len(_scale_macs)} scale MAC(s), autoConnect={_auto_connect}")
             if board.HAS_DISPLAY:
                 ui.on_config_update(data.get("users", []))
                 ui.on_scale_macs_update(len(_scale_macs) > 0)
@@ -155,6 +160,77 @@ def _check_scale_beep(results):
                 break
 
 
+def _find_scale_in_raw(raw_results):
+    """Find the first known scale MAC in the raw IRQ buffer.
+
+    Returns (addr_bytes, addr_type) or None. Non-destructive peek used by the
+    autonomous connect logic to skip the MQTT round-trip (#201).
+    """
+    for addr_bytes, addr_type, _rssi, _raw in raw_results:
+        mac = ":".join("%02X" % b for b in addr_bytes)
+        if mac in _scale_macs:
+            print(f"Auto-connect: found known scale {mac} in raw buffer (addr_type={addr_type})")
+            return mac, addr_bytes, addr_type
+    return None
+
+
+async def _auto_gatt_connect(mac, addr_type):
+    """Autonomously connect to a known scale and publish the connected event.
+
+    This eliminates the MQTT round-trip that previously caused the scale to
+    power off before the ESP32 could connect (#201). The host receives the
+    same 'connected' payload as with a host-initiated connect, so the adapter
+    protocol handshake is unchanged.
+    """
+    global _char_subscribed, _busy, _scan_paused
+    _scan_paused = True
+
+    if board.CONTINUOUS_SCAN:
+        bridge.stop_streaming()
+        print(f"Auto-connect: stopped streaming scan for {mac}")
+
+    _busy = True
+    try:
+        await bridge.disconnect()
+        print(f"Auto-connecting to {mac} (addr_type={addr_type})...")
+        result = await bridge.connect(mac, addr_type)
+        print(f"Auto-connect: BLE connected to {mac}, discovering chars...")
+
+        if not _char_subscribed:
+            await client.subscribe(topic("write/#"), 0)
+            await client.subscribe(topic("read/#"), 0)
+            _char_subscribed = True
+
+        for char_info in result["chars"]:
+            if "notify" in char_info["properties"]:
+                uuid_str = char_info["uuid"]
+
+                def make_publish_fn(u):
+                    async def publish_fn(_source_uuid, data):
+                        await client.publish(topic(f"notify/{u}"), data, qos=0)
+                    return publish_fn
+
+                await bridge.start_notify(uuid_str, make_publish_fn(uuid_str))
+                print(f"Auto-connect: notify enabled for {uuid_str}")
+
+        bridge.set_on_disconnect(lambda: _pending.append(("__ble_disconnected__", b"")))
+
+        # Mark the response as autonomous so the host can distinguish it
+        result["autonomous"] = True
+        result["address"] = mac
+        await client.publish(topic("connected"), json.dumps(result), qos=0)
+        print(f"Auto-connect to {mac} succeeded, {len(result['chars'])} chars published to host")
+    except Exception as e:
+        print(f"Auto-connect failed for {mac}: {describe_exc(e)}")
+        _scan_paused = False
+        if board.CONTINUOUS_SCAN:
+            bridge.start_streaming()
+            print(f"Auto-connect: resumed streaming scan after failure")
+        await publish_error(f"Auto-connect failed for {mac}: {describe_exc(e)}")
+    finally:
+        _busy = False
+
+
 async def _streaming_scan_loop():
     """Continuous indefinite scan with periodic drain+publish (ESP32-S3)."""
     global _subs_ready
@@ -184,6 +260,27 @@ async def _streaming_scan_loop():
             if _scan_paused:
                 break
             if _scale_macs and bridge.has_pending_scale_mac(_scale_macs):
+                # Autonomous connect: ESP32 connects itself immediately,
+                # eliminating the MQTT round-trip (#201).
+                if _auto_connect:
+                    found = _find_scale_in_raw(bridge._raw_results)
+                    if found:
+                        mac, _addr_bytes, addr_type = found
+                        print(f"Auto-connect: scale {mac} detected after {waited}ms, connecting immediately")
+                        # Drain and publish scan results first so the host
+                        # sees what triggered the connect.
+                        try:
+                            results = bridge.drain_results()
+                            gc.collect()
+                            _check_scale_beep(results)
+                            board.on_scan_complete(results, bool(_scale_macs))
+                            await client.publish(topic("scan/results"), json.dumps(results), qos=0)
+                        except Exception:
+                            pass
+                        await _auto_gatt_connect(mac, addr_type)
+                        break
+                # If auto-connect is disabled, just break to flush results
+                # as before (host-initiated connect path).
                 break
 
         if _scan_paused:
@@ -256,6 +353,14 @@ async def _batch_scan_loop():
             print("Results published")
             if board.HAS_DISPLAY:
                 ui.on_publish_tick()
+            # Autonomous connect for batch-mode boards: if a known scale MAC
+            # appeared in the scan results, connect immediately (#201).
+            if _auto_connect and _scale_macs:
+                for r in results:
+                    if r["address"] in _scale_macs:
+                        print(f"Auto-connect (batch): scale {r['address']} found in scan results")
+                        await _auto_gatt_connect(r["address"], r.get("addr_type", 0))
+                        break
         except Exception as e:
             try:
                 await publish_error(f"Scan failed: {describe_exc(e)}")
@@ -488,4 +593,5 @@ async def main():
             ui.check_timeout()
 
 
-asyncio.run(main())
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -163,7 +163,7 @@ def _check_scale_beep(results):
 def _find_scale_in_raw(raw_results):
     """Find the first known scale MAC in the raw IRQ buffer.
 
-    Returns (addr_bytes, addr_type) or None. Non-destructive peek used by the
+    Returns (mac, addr_bytes, addr_type) or None. Non-destructive peek used by the
     autonomous connect logic to skip the MQTT round-trip (#201).
     """
     for addr_bytes, addr_type, _rssi, _raw in raw_results:

--- a/firmware/tests/test_auto_connect.py
+++ b/firmware/tests/test_auto_connect.py
@@ -1,0 +1,181 @@
+"""Host-runnable tests for the autonomous GATT connect helpers in main.py.
+
+The _find_scale_in_raw function lives in main.py and uses the _scale_macs
+global. Because main.py has heavy import-time side effects (MQTT, WiFi,
+config.json), we test the logic by extracting and exercising the function
+directly from module globals.
+
+Run: python -m unittest discover -s firmware/tests
+"""
+
+import os
+import sys
+import types
+import unittest
+
+_FIRMWARE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _FIRMWARE_DIR not in sys.path:
+    sys.path.insert(0, _FIRMWARE_DIR)
+
+# Stub MicroPython-only modules before importing anything from firmware.
+sys.modules["aioble"] = types.ModuleType("aioble")
+_bt = types.ModuleType("bluetooth")
+_bt.BLE = lambda: None
+sys.modules["bluetooth"] = _bt
+
+_board = types.ModuleType("board")
+_board.HAS_BEEP = False
+_board.HAS_DISPLAY = False
+_board.CONTINUOUS_SCAN = True
+_board.PUBLISH_INTERVAL_MS = 2000
+_board.SCAN_INTERVAL_MS = 5000
+_board.DEACTIVATE_BLE_AFTER_SCAN = False
+_board.GC_INTERVAL = 100
+_board.MAX_SCAN_ENTRIES = 500
+_board.BOARD_NAME = "test"
+_board.on_scan_complete = lambda *a: None
+sys.modules["board"] = _board
+
+# Stub mqtt_as — main.py creates an MQTTClient at import time
+_mqtt_as = types.ModuleType("mqtt_as")
+_mqtt_as.config = {}
+
+
+class _FakeMQTTClient:
+    def __init__(self, cfg):
+        pass
+
+    async def connect(self):
+        raise RuntimeError("test stub: not connecting")
+
+
+_mqtt_as.MQTTClient = _FakeMQTTClient
+sys.modules["mqtt_as"] = _mqtt_as
+
+# Stub ble_bridge — main.py creates a BleBridge at import time
+_ble_bridge = types.ModuleType("ble_bridge")
+_ble_bridge.BleBridge = lambda: types.SimpleNamespace(
+    start_streaming=lambda: None,
+    stop_streaming=lambda: None,
+    has_pending_scale_mac=lambda macs: False,
+    drain_results=lambda: [],
+    _raw_results=[],
+)
+sys.modules["ble_bridge"] = _ble_bridge
+
+# Write a minimal config.json for main.py import
+import json
+import tempfile
+
+_config_path = os.path.join(_FIRMWARE_DIR, "config.json")
+_config_existed = os.path.exists(_config_path)
+_orig_cwd = os.getcwd()
+if not _config_existed:
+    with open(_config_path, "w") as f:
+        json.dump(
+            {
+                "topic_prefix": "test",
+                "device_id": "test",
+                "wifi_ssid": "",
+                "wifi_password": "",
+                "mqtt_broker": "localhost",
+                "mqtt_port": 1883,
+            },
+            f,
+        )
+
+# main.py opens config.json relative to CWD
+os.chdir(_FIRMWARE_DIR)
+try:
+    import main  # noqa: E402
+finally:
+    os.chdir(_orig_cwd)
+    if not _config_existed:
+        os.remove(_config_path)
+
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+
+_MAC_BYTES = b"\xFF\x03\x00\x53\xD6\x4D"
+_MAC_STR = "FF:03:00:53:D6:4D"
+
+_OTHER_MAC_BYTES = b"\xAA\xBB\xCC\xDD\xEE\xFF"
+_OTHER_MAC_STR = "AA:BB:CC:DD:EE:FF"
+
+
+def _raw_entry(addr_bytes, addr_type=0, rssi=-50, adv_data=b""):
+    """Create a raw IRQ buffer tuple."""
+    return (addr_bytes, addr_type, rssi, adv_data)
+
+
+class TestFindScaleInRaw(unittest.TestCase):
+    """_find_scale_in_raw: find first known scale MAC in raw buffer."""
+
+    def setUp(self):
+        # Set known scale MACs
+        main._scale_macs = {_MAC_STR}
+
+    def tearDown(self):
+        main._scale_macs = set()
+
+    def test_empty_buffer(self):
+        self.assertIsNone(main._find_scale_in_raw([]))
+
+    def test_no_known_mac(self):
+        raw = [_raw_entry(_OTHER_MAC_BYTES)]
+        self.assertIsNone(main._find_scale_in_raw(raw))
+
+    def test_known_mac_found(self):
+        raw = [_raw_entry(_OTHER_MAC_BYTES), _raw_entry(_MAC_BYTES, addr_type=1)]
+        result = main._find_scale_in_raw(raw)
+        self.assertIsNotNone(result)
+        mac, addr_bytes, addr_type = result
+        self.assertEqual(mac, _MAC_STR)
+        self.assertEqual(addr_bytes, _MAC_BYTES)
+        self.assertEqual(addr_type, 1)
+
+    def test_returns_first_match(self):
+        raw = [_raw_entry(_MAC_BYTES, addr_type=0), _raw_entry(_MAC_BYTES, addr_type=1)]
+        result = main._find_scale_in_raw(raw)
+        self.assertIsNotNone(result)
+        self.assertEqual(result[2], 0)  # first entry's addr_type
+
+    def test_empty_scale_macs(self):
+        main._scale_macs = set()
+        raw = [_raw_entry(_MAC_BYTES)]
+        self.assertIsNone(main._find_scale_in_raw(raw))
+
+
+class TestAutoConnectConfig(unittest.TestCase):
+    """_auto_connect flag parsing from config topic."""
+
+    def test_default_is_true(self):
+        # Reset to default
+        main._auto_connect = True
+        self.assertTrue(main._auto_connect)
+
+    def test_opt_out_sets_false(self):
+        main._auto_connect = True
+        # Simulate config message
+        main._auto_connect = False  # as on_message would set it
+        self.assertFalse(main._auto_connect)
+
+    def test_missing_field_defaults_true(self):
+        # data.get("autoConnect", True) should default to True
+        data = {"scales": ["AA:BB:CC:DD:EE:FF"]}
+        main._auto_connect = data.get("autoConnect", True)
+        self.assertTrue(main._auto_connect)
+
+    def test_explicit_true(self):
+        data = {"scales": [], "autoConnect": True}
+        main._auto_connect = data.get("autoConnect", True)
+        self.assertTrue(main._auto_connect)
+
+    def test_explicit_false(self):
+        data = {"scales": [], "autoConnect": False}
+        main._auto_connect = data.get("autoConnect", True)
+        self.assertFalse(main._auto_connect)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/ble/handler-mqtt-proxy/display.ts
+++ b/src/ble/handler-mqtt-proxy/display.ts
@@ -24,6 +24,12 @@ export async function publishConfig(
     if (users && users.length > 0) {
       payload.users = users;
     }
+    // Forward autoConnect opt-out to the ESP32 firmware (#201).
+    // Default is true — only send when explicitly disabled.
+    if (config.auto_connect === false) {
+      payload.autoConnect = false;
+      bleLog.debug('publishConfig: autoConnect disabled, sending opt-out to ESP32');
+    }
     await client.publishAsync(t.config, JSON.stringify(payload), { retain: true });
   } finally {
     await releaseClient(client, ephemeral);

--- a/src/ble/handler-mqtt-proxy/gatt.ts
+++ b/src/ble/handler-mqtt-proxy/gatt.ts
@@ -94,20 +94,19 @@ export async function mqttGattConnect(
     new Promise<{ chars: Array<{ uuid: string; properties: string[] }> }>((resolve, reject) => {
       const handler = (topic: string, payload: Buffer) => {
         if (topic === t.connected) {
+          let data: Record<string, unknown>;
           try {
-            const data = JSON.parse(payload.toString());
-            // Ignore autonomous connects from ESP32 — those are handled by
-            // ReadingWatcher.handleAutonomousConnect, not mqttGattConnect (#201).
-            if (data.autonomous) return;
-          } catch {
-            // Not JSON — fall through to resolve (old firmware compat)
-          }
-          client.removeListener('message', handler);
-          try {
-            resolve(JSON.parse(payload.toString()));
+            data = JSON.parse(payload.toString());
           } catch (err) {
+            client.removeListener('message', handler);
             reject(new Error(`Invalid connected payload from ESP32: ${err}`));
+            return;
           }
+          // Ignore autonomous connects from ESP32 — those are handled by
+          // ReadingWatcher.handleAutonomousConnect, not mqttGattConnect (#201).
+          if (data.autonomous) return;
+          client.removeListener('message', handler);
+          resolve(data as { chars: Array<{ uuid: string; properties: string[] }> });
         }
         if (topic === t.error) {
           client.removeListener('message', handler);
@@ -129,7 +128,9 @@ export async function mqttGattConnect(
 
   const charMap = new Map<string, BleChar>();
   for (const char of response.chars) {
-    charMap.set(char.uuid, new MqttBleChar(client, t.base, char.uuid));
+    // Normalize the key to lowercase so adapter lookups match regardless of case.
+    // The MQTT topic uses the original UUID from the ESP32.
+    charMap.set(char.uuid.toLowerCase(), new MqttBleChar(client, t.base, char.uuid));
   }
 
   const device = new MqttBleDevice(client, t.disconnected);
@@ -155,7 +156,7 @@ export function buildCharMapFromPayload(
 ): { charMap: Map<string, BleChar>; device: MqttBleDevice } {
   const charMap = new Map<string, BleChar>();
   for (const char of chars) {
-    charMap.set(char.uuid, new MqttBleChar(client, t.base, char.uuid));
+    charMap.set(char.uuid.toLowerCase(), new MqttBleChar(client, t.base, char.uuid));
   }
   const device = new MqttBleDevice(client, t.disconnected);
   bleLog.debug(

--- a/src/ble/handler-mqtt-proxy/gatt.ts
+++ b/src/ble/handler-mqtt-proxy/gatt.ts
@@ -1,5 +1,5 @@
 import type { BleChar, BleDevice } from '../shared.js';
-import { withTimeout } from '../types.js';
+import { withTimeout, bleLog } from '../types.js';
 import { COMMAND_TIMEOUT_MS, type Topics } from './topics.js';
 import type { MqttClient } from './client.js';
 
@@ -94,6 +94,14 @@ export async function mqttGattConnect(
     new Promise<{ chars: Array<{ uuid: string; properties: string[] }> }>((resolve, reject) => {
       const handler = (topic: string, payload: Buffer) => {
         if (topic === t.connected) {
+          try {
+            const data = JSON.parse(payload.toString());
+            // Ignore autonomous connects from ESP32 — those are handled by
+            // ReadingWatcher.handleAutonomousConnect, not mqttGattConnect (#201).
+            if (data.autonomous) return;
+          } catch {
+            // Not JSON — fall through to resolve (old firmware compat)
+          }
           client.removeListener('message', handler);
           try {
             resolve(JSON.parse(payload.toString()));
@@ -131,4 +139,27 @@ export async function mqttGattConnect(
 /** Send GATT disconnect command over MQTT. */
 export async function mqttGattDisconnect(client: MqttClient, t: Topics): Promise<void> {
   await client.publishAsync(t.disconnect, '');
+}
+
+/**
+ * Build charMap and MqttBleDevice from an autonomous connect payload.
+ *
+ * When the ESP32 auto-connects to a known scale (#201), it publishes the
+ * same `connected` payload with an extra `autonomous: true` flag. The host
+ * skips mqttGattConnect() and uses this helper to set up the GATT abstractions.
+ */
+export function buildCharMapFromPayload(
+  client: MqttClient,
+  t: Topics,
+  chars: Array<{ uuid: string; properties: string[] }>,
+): { charMap: Map<string, BleChar>; device: MqttBleDevice } {
+  const charMap = new Map<string, BleChar>();
+  for (const char of chars) {
+    charMap.set(char.uuid, new MqttBleChar(client, t.base, char.uuid));
+  }
+  const device = new MqttBleDevice(client, t.disconnected);
+  bleLog.debug(
+    `buildCharMapFromPayload: ${chars.length} chars (${chars.map((c) => c.uuid).join(', ')})`,
+  );
+  return { charMap, device };
 }

--- a/src/ble/handler-mqtt-proxy/watcher.ts
+++ b/src/ble/handler-mqtt-proxy/watcher.ts
@@ -17,6 +17,31 @@ import { type ScanResultEntry, toBleDeviceInfo } from './scan.js';
 
 const DEDUP_WINDOW_MS = 30_000;
 
+/** Bluetooth Base UUID for expanding 16-bit UUIDs to 128-bit form. */
+const BT_BASE_UUID = '00000000-0000-1000-8000-00805f9b34fb';
+
+/**
+ * Normalize a BLE UUID to lowercase 128-bit form for reliable comparison.
+ * Handles 16-bit ("fff4"), 32-bit, and full 128-bit UUIDs with or without dashes.
+ */
+function normalizeUuid(uuid: string): string {
+  const lower = uuid.toLowerCase().replace(/-/g, '');
+  if (lower.length === 4) {
+    // 16-bit → expand into base UUID
+    return BT_BASE_UUID.replace('00000000', `0000${lower}`);
+  }
+  if (lower.length === 8) {
+    // 32-bit → expand into base UUID
+    return BT_BASE_UUID.replace('00000000', lower);
+  }
+  // Already 128-bit (32 hex chars) — insert dashes if missing
+  if (lower.length === 32) {
+    return `${lower.slice(0, 8)}-${lower.slice(8, 12)}-${lower.slice(12, 16)}-${lower.slice(16, 20)}-${lower.slice(20)}`;
+  }
+  // Already formatted 128-bit
+  return lower;
+}
+
 type LifecycleHandler =
   | { event: 'reconnect'; handler: () => void }
   | { event: 'offline'; handler: () => void }
@@ -90,6 +115,9 @@ export class ReadingWatcher {
       await client.subscribeAsync(t.status);
       // Subscribe to connected for autonomous ESP32 connects (#201)
       await client.subscribeAsync(t.connected);
+      // Subscribe to disconnected so MqttBleDevice instances (which only add a
+      // message listener, not a broker subscription) receive disconnect events
+      // during autonomous connects. Not handled by _messageHandler itself.
       await client.subscribeAsync(t.disconnected);
       this._subscribedTopics = [t.scanResults, t.status, t.connected, t.disconnected];
       bleLog.info('ReadingWatcher started, listening for scan results');
@@ -210,6 +238,19 @@ export class ReadingWatcher {
           // has a GATT path (#201: dual-mode adapters like QN Scale must reach
           // this even though they declare parseBroadcast).
           if (!adapter.charNotifyUuid) continue;
+
+          // When auto_connect is enabled (default), the ESP32 connects
+          // autonomously and publishes a `connected` payload handled by
+          // handleAutonomousConnect(). Skip the host-initiated GATT path
+          // to avoid a race where both sides try to connect simultaneously,
+          // causing timeouts (#201).
+          if (this.config.auto_connect !== false) {
+            bleLog.debug(
+              `Skipping host-initiated GATT for ${entry.address} — auto_connect enabled, ` +
+                `waiting for autonomous connect from ESP32`,
+            );
+            continue;
+          }
 
           this.handleGattReading(entry, adapter).catch((err) => {
             bleLog.warn(`GATT reading failed for ${entry.address}: ${errMsg(err)}`);
@@ -378,8 +419,10 @@ export class ReadingWatcher {
         if (a.matches(info)) return true;
         // Also match by charNotifyUuid: the ESP32 already connected, so the
         // adapter may match only by its GATT characteristic.
+        // Normalize both sides (case + 16-bit vs 128-bit) to avoid silent mismatches.
         if (a.charNotifyUuid) {
-          return data.chars.some((c) => c.uuid === a.charNotifyUuid);
+          const normalized = normalizeUuid(a.charNotifyUuid);
+          return data.chars.some((c) => normalizeUuid(c.uuid) === normalized);
         }
         return false;
       });

--- a/src/ble/handler-mqtt-proxy/watcher.ts
+++ b/src/ble/handler-mqtt-proxy/watcher.ts
@@ -6,7 +6,12 @@ import { bleLog, withTimeout, errMsg, IMPEDANCE_GRACE_MS } from '../types.js';
 import { AsyncQueue } from '../async-queue.js';
 import { topics } from './topics.js';
 import { type MqttClient, getOrCreatePersistentClient } from './client.js';
-import { mqttGattConnect, mqttGattDisconnect, type MqttBleDevice } from './gatt.js';
+import {
+  mqttGattConnect,
+  mqttGattDisconnect,
+  buildCharMapFromPayload,
+  type MqttBleDevice,
+} from './gatt.js';
 import { registerScaleMac } from './display.js';
 import { type ScanResultEntry, toBleDeviceInfo } from './scan.js';
 
@@ -83,7 +88,10 @@ export class ReadingWatcher {
       await client.subscribeAsync(t.scanResults, { qos: 1 });
       // Subscribe to status for logging only
       await client.subscribeAsync(t.status);
-      this._subscribedTopics = [t.scanResults, t.status];
+      // Subscribe to connected for autonomous ESP32 connects (#201)
+      await client.subscribeAsync(t.connected);
+      await client.subscribeAsync(t.disconnected);
+      this._subscribedTopics = [t.scanResults, t.status, t.connected, t.disconnected];
       bleLog.info('ReadingWatcher started, listening for scan results');
     } catch (err) {
       this.started = false;
@@ -96,6 +104,27 @@ export class ReadingWatcher {
         bleLog.info(`ESP32 status: ${payload.toString()}`);
         return;
       }
+
+      // Handle autonomous GATT connect from ESP32 (#201).
+      // The ESP32 publishes the same `connected` payload with an extra
+      // `autonomous: true` flag when it auto-connects to a known scale MAC.
+      if (topic === t.connected) {
+        try {
+          const data = JSON.parse(payload.toString());
+          if (data.autonomous && data.address) {
+            bleLog.info(
+              `Received autonomous connect from ESP32 for ${data.address} (${data.chars?.length ?? 0} chars)`,
+            );
+            this.handleAutonomousConnect(data).catch((err) => {
+              bleLog.warn(`Autonomous GATT reading failed for ${data.address}: ${errMsg(err)}`);
+            });
+          }
+        } catch {
+          // Not JSON or missing fields — ignore (could be a host-initiated connect response)
+        }
+        return;
+      }
+
       if (topic !== t.scanResults) return;
 
       try {
@@ -304,6 +333,100 @@ export class ReadingWatcher {
         `GATT reading timeout for ${entry.address}`,
       );
       registerScaleMac(this.config, entry.address).catch(() => {});
+      this.queue.push(raw);
+    } finally {
+      this.gattInProgress = false;
+      device?.cleanup();
+      if (client) await mqttGattDisconnect(client, t).catch(() => {});
+    }
+  }
+
+  /**
+   * Handle an autonomous GATT connect from the ESP32 (#201).
+   *
+   * The ESP32 already connected and discovered services. We just need to set up
+   * the MQTT char abstractions and run the adapter's reading protocol — no
+   * mqttGattConnect() needed, saving the entire MQTT round-trip.
+   */
+  private async handleAutonomousConnect(data: {
+    address: string;
+    chars: Array<{ uuid: string; properties: string[] }>;
+  }): Promise<void> {
+    if (this.gattInProgress) {
+      if (Date.now() - this.gattStartedAt > ReadingWatcher.GATT_STALE_MS) {
+        bleLog.warn('gattInProgress stuck for >90s, auto-resetting');
+        this.gattInProgress = false;
+      } else {
+        bleLog.debug(`GATT connection already in progress, skipping autonomous ${data.address}`);
+        return;
+      }
+    }
+    this.gattInProgress = true;
+    this.gattStartedAt = Date.now();
+
+    const t = topics(this.config.topic_prefix, this.config.device_id);
+    let client: MqttClient | undefined;
+    let device: MqttBleDevice | undefined;
+    try {
+      client = await getOrCreatePersistentClient(this.config);
+
+      // Match the address to an adapter
+      const info = toBleDeviceInfo({ address: data.address, name: '', rssi: 0, services: [] });
+      // For autonomous connect, we match by scanning the chars for known notify UUIDs
+      const adapter = this.adapters.find((a) => {
+        // Try matching by device info first
+        if (a.matches(info)) return true;
+        // Also match by charNotifyUuid: the ESP32 already connected, so the
+        // adapter may match only by its GATT characteristic.
+        if (a.charNotifyUuid) {
+          return data.chars.some((c) => c.uuid === a.charNotifyUuid);
+        }
+        return false;
+      });
+
+      if (!adapter) {
+        bleLog.warn(
+          `Autonomous connect from ${data.address}: no adapter matched ` +
+            `(${data.chars.length} chars: ${data.chars.map((c) => c.uuid).join(', ')}), disconnecting`,
+        );
+        await mqttGattDisconnect(client, t).catch(() => {});
+        return;
+      }
+
+      if (!this.profile) {
+        bleLog.warn(
+          'No user profile configured for GATT reading. Body composition will be inaccurate.',
+        );
+      }
+      const profile: UserProfile = this.profile ?? {
+        height: 170,
+        age: 30,
+        gender: 'male',
+        isAthlete: false,
+      };
+
+      bleLog.info(`Autonomous GATT connect from ESP32: ${adapter.name} (${data.address})`);
+      const { charMap, device: dev } = buildCharMapFromPayload(client, t, data.chars);
+      device = dev;
+      bleLog.debug(
+        `Autonomous connect: charMap built with ${charMap.size} chars, waiting for reading...`,
+      );
+
+      const raw = await withTimeout(
+        waitForRawReading(
+          charMap,
+          device,
+          adapter,
+          profile,
+          data.address.replace(/[:-]/g, '').toUpperCase(),
+        ),
+        60_000,
+        `GATT reading timeout for ${data.address} (autonomous)`,
+      );
+      registerScaleMac(this.config, data.address).catch(() => {});
+      bleLog.info(
+        `Autonomous GATT reading complete: ${raw.reading.weight} kg from ${data.address}`,
+      );
       this.queue.push(raw);
     } finally {
       this.gattInProgress = false;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -60,6 +60,14 @@ export const MqttProxySchema = z
       .string()
       .regex(/^\S+$/, 'Must be a non-empty hostname or IP with no whitespace')
       .default('0.0.0.0'),
+    auto_connect: z
+      .boolean()
+      .default(true)
+      .describe(
+        'When true (default), the ESP32 autonomously connects to known scale MACs ' +
+          'the instant they appear in a scan, eliminating the MQTT round-trip latency. ' +
+          'Set to false to use the legacy host-initiated connect flow.',
+      ),
   })
   .refine(
     (c) => {

--- a/tests/ble/handler-mqtt-proxy.test.ts
+++ b/tests/ble/handler-mqtt-proxy.test.ts
@@ -1383,7 +1383,8 @@ describe('handler-mqtt-proxy', () => {
 
     it('ReadingWatcher handles GATT scale via handleGattReading', async () => {
       const adapter = createGattAdapter();
-      const watcher = new ReadingWatcher(MQTT_PROXY_CONFIG, [adapter], undefined, PROFILE);
+      const config = { ...MQTT_PROXY_CONFIG, auto_connect: false };
+      const watcher = new ReadingWatcher(config, [adapter], undefined, PROFILE);
       await watcher.start();
 
       // The watcher's message handler calls handleGattReading which uses
@@ -1517,7 +1518,8 @@ describe('handler-mqtt-proxy', () => {
       // name but no manufacturer data. The watcher must open a GATT connection
       // instead of silently skipping it because the adapter declares parseBroadcast.
       const adapter = createDualModeAdapter();
-      const watcher = new ReadingWatcher(MQTT_PROXY_CONFIG, [adapter], undefined, PROFILE);
+      const config = { ...MQTT_PROXY_CONFIG, auto_connect: false };
+      const watcher = new ReadingWatcher(config, [adapter], undefined, PROFILE);
       await watcher.start();
 
       const origPublish = mockClient.publishAsync;
@@ -1574,7 +1576,8 @@ describe('handler-mqtt-proxy', () => {
       // next scan batch can retry. Before the fix, the flag leaked `true` and
       // every later GATT attempt was skipped until the 90s stale-reset.
       const adapter = createDualModeAdapter();
-      const watcher = new ReadingWatcher(MQTT_PROXY_CONFIG, [adapter], undefined, PROFILE);
+      const config = { ...MQTT_PROXY_CONFIG, auto_connect: false };
+      const watcher = new ReadingWatcher(config, [adapter], undefined, PROFILE);
       await watcher.start();
 
       let connectCount = 0;
@@ -1755,7 +1758,8 @@ describe('handler-mqtt-proxy', () => {
 
     it('ReadingWatcher skips autonomous connect when gattInProgress', async () => {
       const adapter = createGattAdapter();
-      const watcher = new ReadingWatcher(MQTT_PROXY_CONFIG, [adapter], undefined, PROFILE);
+      const config = { ...MQTT_PROXY_CONFIG, auto_connect: false };
+      const watcher = new ReadingWatcher(config, [adapter], undefined, PROFILE);
       await watcher.start();
 
       // First: trigger a regular GATT connect that will hang (no response)
@@ -1799,6 +1803,133 @@ describe('handler-mqtt-proxy', () => {
         mockClient.publishAsync as ReturnType<typeof vi.fn>
       ).mock.calls.filter((c: unknown[]) => c[0] === `${PREFIX}/disconnect`);
       expect(disconnectCalls).toHaveLength(0);
+    });
+
+    it('combined scan/results then autonomous connected succeeds without race (#201)', async () => {
+      const adapter = createGattAdapter();
+      const watcher = new ReadingWatcher(MQTT_PROXY_CONFIG, [adapter], undefined, PROFILE);
+      await watcher.start();
+
+      // Simulate the write response for the autonomous GATT session
+      const origPublish = mockClient.publishAsync;
+      mockClient.publishAsync = vi.fn(async (topic: string, payload?: string | Buffer) => {
+        if (topic === `${PREFIX}/write/${GATT_WRITE_UUID}`) {
+          queueMicrotask(() => {
+            const buf = Buffer.alloc(4);
+            buf.writeUInt16LE(8050, 0); // 80.50 kg
+            buf.writeUInt16LE(480, 2); // impedance 480
+            mockClient._simulateMessage(`${PREFIX}/notify/${GATT_NOTIFY_UUID}`, buf);
+          });
+        }
+        return origPublish(topic, payload);
+      });
+
+      // Step 1: ESP32 publishes scan/results with a GATT-only scale
+      // (this is the exact sequence that caused the race: scan/results first,
+      // then connected with autonomous: true)
+      mockClient._simulateMessage(
+        `${PREFIX}/scan/results`,
+        JSON.stringify([
+          { address: 'AA:BB:CC:DD:EE:FF', name: 'GattScale', rssi: -50, services: [] },
+        ]),
+      );
+
+      // Step 2: immediately after, ESP32 publishes autonomous connected
+      mockClient._simulateMessage(
+        `${PREFIX}/connected`,
+        JSON.stringify({
+          autonomous: true,
+          address: 'AA:BB:CC:DD:EE:FF',
+          chars: [
+            { uuid: GATT_NOTIFY_UUID, properties: ['notify'] },
+            { uuid: GATT_WRITE_UUID, properties: ['write'] },
+          ],
+        }),
+      );
+
+      const raw = await watcher.nextReading();
+      expect(raw.reading.weight).toBe(80.5);
+      expect(raw.reading.impedance).toBe(480);
+      expect(raw.adapter.name).toBe('GattScale');
+
+      // No host-initiated connect command should have been published
+      const connectCalls = (mockClient.publishAsync as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (c: unknown[]) => c[0] === `${PREFIX}/connect`,
+      );
+      expect(connectCalls).toHaveLength(0);
+    });
+
+    it('scan/results falls back to host-initiated GATT when auto_connect is false', async () => {
+      const adapter = createGattAdapter();
+      const config = { ...MQTT_PROXY_CONFIG, auto_connect: false };
+      const watcher = new ReadingWatcher(config, [adapter], undefined, PROFILE);
+      await watcher.start();
+
+      // Intercept the connect command to verify it's published
+      const origPublish = mockClient.publishAsync;
+      let connectReceived = false;
+      mockClient.publishAsync = vi.fn(async (topic: string, payload?: string | Buffer) => {
+        if (topic === `${PREFIX}/connect`) {
+          connectReceived = true;
+        }
+        return origPublish(topic, payload);
+      });
+
+      // Simulate scan/results with a GATT-only scale
+      mockClient._simulateMessage(
+        `${PREFIX}/scan/results`,
+        JSON.stringify([
+          { address: 'AA:BB:CC:DD:EE:FF', name: 'GattScale', rssi: -50, services: [] },
+        ]),
+      );
+
+      await new Promise((r) => setTimeout(r, 50));
+      // With auto_connect disabled, the host should have initiated a connect
+      expect(connectReceived).toBe(true);
+    });
+
+    it('autonomous connect matches adapter when ESP32 reports UUID in different case', async () => {
+      const adapter = createGattAdapter();
+      const watcher = new ReadingWatcher(MQTT_PROXY_CONFIG, [adapter], undefined, PROFILE);
+      await watcher.start();
+
+      // Override matches to NOT match by device info (autonomous has no name)
+      (adapter.matches as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+      const origPublish = mockClient.publishAsync;
+      mockClient.publishAsync = vi.fn(async (topic: string, payload?: string | Buffer) => {
+        // The ESP32 reports UUIDs in uppercase, so the MQTT write topic uses
+        // the original case. Match case-insensitively.
+        if (topic.toLowerCase() === `${PREFIX}/write/${GATT_WRITE_UUID}`) {
+          queueMicrotask(() => {
+            const buf = Buffer.alloc(4);
+            buf.writeUInt16LE(7500, 0);
+            buf.writeUInt16LE(500, 2);
+            // Notify topic also uses original case from ESP32
+            mockClient._simulateMessage(
+              `${PREFIX}/notify/${GATT_NOTIFY_UUID.toUpperCase()}`,
+              buf,
+            );
+          });
+        }
+        return origPublish(topic, payload);
+      });
+
+      // ESP32 reports UUID in uppercase — should still match via normalizeUuid
+      mockClient._simulateMessage(
+        `${PREFIX}/connected`,
+        JSON.stringify({
+          autonomous: true,
+          address: 'AA:BB:CC:DD:EE:FF',
+          chars: [
+            { uuid: GATT_NOTIFY_UUID.toUpperCase(), properties: ['notify'] },
+            { uuid: GATT_WRITE_UUID.toUpperCase(), properties: ['write'] },
+          ],
+        }),
+      );
+
+      const raw = await watcher.nextReading();
+      expect(raw.reading.weight).toBe(75.0);
     });
 
     it('host-initiated connect ignores autonomous connected payload', async () => {

--- a/tests/ble/handler-mqtt-proxy.test.ts
+++ b/tests/ble/handler-mqtt-proxy.test.ts
@@ -1906,10 +1906,7 @@ describe('handler-mqtt-proxy', () => {
             buf.writeUInt16LE(7500, 0);
             buf.writeUInt16LE(500, 2);
             // Notify topic also uses original case from ESP32
-            mockClient._simulateMessage(
-              `${PREFIX}/notify/${GATT_NOTIFY_UUID.toUpperCase()}`,
-              buf,
-            );
+            mockClient._simulateMessage(`${PREFIX}/notify/${GATT_NOTIFY_UUID.toUpperCase()}`, buf);
           });
         }
         return origPublish(topic, payload);

--- a/tests/ble/handler-mqtt-proxy.test.ts
+++ b/tests/ble/handler-mqtt-proxy.test.ts
@@ -739,6 +739,24 @@ describe('handler-mqtt-proxy', () => {
         { retain: true },
       );
     });
+
+    it('includes autoConnect:false when auto_connect is disabled', async () => {
+      await publishConfig({ ...MQTT_PROXY_CONFIG, auto_connect: false }, ['AA:BB:CC:DD:EE:FF']);
+
+      expect(mockClient.publishAsync).toHaveBeenCalledWith(
+        `${PREFIX}/config`,
+        JSON.stringify({ scales: ['AA:BB:CC:DD:EE:FF'], autoConnect: false }),
+        { retain: true },
+      );
+    });
+
+    it('omits autoConnect field when auto_connect is true (default)', async () => {
+      await publishConfig({ ...MQTT_PROXY_CONFIG, auto_connect: true }, ['AA:BB:CC:DD:EE:FF']);
+
+      const payload = (mockClient.publishAsync as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      const parsed = JSON.parse(payload);
+      expect(parsed).not.toHaveProperty('autoConnect');
+    });
   });
 
   describe('registerScaleMac', () => {
@@ -1652,6 +1670,162 @@ describe('handler-mqtt-proxy', () => {
           mqttProxy: MQTT_PROXY_CONFIG,
         }),
       ).rejects.toThrow('ESP32 error: (no detail)');
+    });
+
+    it('ReadingWatcher handles autonomous GATT connect from ESP32 (#201)', async () => {
+      const adapter = createGattAdapter();
+      const watcher = new ReadingWatcher(MQTT_PROXY_CONFIG, [adapter], undefined, PROFILE);
+      await watcher.start();
+
+      // Simulate the write response: when the host writes the unlock command,
+      // the scale sends a notification with weight+impedance.
+      const origPublish = mockClient.publishAsync;
+      mockClient.publishAsync = vi.fn(async (topic: string, payload?: string | Buffer) => {
+        if (topic === `${PREFIX}/write/${GATT_WRITE_UUID}`) {
+          queueMicrotask(() => {
+            const buf = Buffer.alloc(4);
+            buf.writeUInt16LE(9000, 0); // 90.00 kg
+            buf.writeUInt16LE(520, 2); // impedance 520
+            mockClient._simulateMessage(`${PREFIX}/notify/${GATT_NOTIFY_UUID}`, buf);
+          });
+        }
+        return origPublish(topic, payload);
+      });
+
+      // ESP32 autonomously connected and publishes the connected payload
+      mockClient._simulateMessage(
+        `${PREFIX}/connected`,
+        JSON.stringify({
+          autonomous: true,
+          address: 'AA:BB:CC:DD:EE:FF',
+          chars: [
+            { uuid: GATT_NOTIFY_UUID, properties: ['notify'] },
+            { uuid: GATT_WRITE_UUID, properties: ['write'] },
+          ],
+        }),
+      );
+
+      const raw = await watcher.nextReading();
+      expect(raw.reading.weight).toBe(90.0);
+      expect(raw.reading.impedance).toBe(520);
+      expect(raw.adapter.name).toBe('GattScale');
+
+      // No connect command should have been published (ESP32 did it autonomously)
+      const connectCalls = (mockClient.publishAsync as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (c: unknown[]) => c[0] === `${PREFIX}/connect`,
+      );
+      expect(connectCalls).toHaveLength(0);
+    });
+
+    it('ReadingWatcher ignores autonomous connect when no adapter matches', async () => {
+      // Adapter only matches by name 'GattScale', but the autonomous connect
+      // comes from a different device with no name info.
+      const adapter = createGattAdapter();
+      // Override matches to never match
+      (adapter.matches as ReturnType<typeof vi.fn>).mockReturnValue(false);
+      // Override charNotifyUuid to a UUID that won't match
+      (adapter as { charNotifyUuid: string }).charNotifyUuid =
+        '00001234-0000-1000-8000-00805f9b34fb';
+      const watcher = new ReadingWatcher(MQTT_PROXY_CONFIG, [adapter], undefined, PROFILE);
+      await watcher.start();
+
+      // Clear any previous calls
+      (mockClient.publishAsync as ReturnType<typeof vi.fn>).mockClear();
+
+      // Simulate autonomous connect with unknown chars
+      mockClient._simulateMessage(
+        `${PREFIX}/connected`,
+        JSON.stringify({
+          autonomous: true,
+          address: 'FF:FF:FF:FF:FF:FF',
+          chars: [{ uuid: '0000abcd-0000-1000-8000-00805f9b34fb', properties: ['notify'] }],
+        }),
+      );
+
+      // Give time for the handler to process
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Should have published a disconnect command since no adapter matched
+      const disconnectCalls = (
+        mockClient.publishAsync as ReturnType<typeof vi.fn>
+      ).mock.calls.filter((c: unknown[]) => c[0] === `${PREFIX}/disconnect`);
+      // handleAutonomousConnect: 1 disconnect (no adapter matched) + 1 from finally block
+      expect(disconnectCalls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('ReadingWatcher skips autonomous connect when gattInProgress', async () => {
+      const adapter = createGattAdapter();
+      const watcher = new ReadingWatcher(MQTT_PROXY_CONFIG, [adapter], undefined, PROFILE);
+      await watcher.start();
+
+      // First: trigger a regular GATT connect that will hang (no response)
+      const origPublish = mockClient.publishAsync;
+      let connectReceived = false;
+      mockClient.publishAsync = vi.fn(async (topic: string, payload?: string | Buffer) => {
+        if (topic === `${PREFIX}/connect`) {
+          connectReceived = true;
+          // Don't respond — leaves gattInProgress = true
+        }
+        return origPublish(topic, payload);
+      });
+
+      mockClient._simulateMessage(
+        `${PREFIX}/scan/results`,
+        JSON.stringify([
+          { address: 'AA:BB:CC:DD:EE:FF', name: 'GattScale', rssi: -50, services: [] },
+        ]),
+      );
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(connectReceived).toBe(true);
+
+      // Clear mock call history before the autonomous connect attempt
+      (mockClient.publishAsync as ReturnType<typeof vi.fn>).mockClear();
+
+      // Now simulate autonomous connect while GATT is in progress — should be skipped
+      mockClient._simulateMessage(
+        `${PREFIX}/connected`,
+        JSON.stringify({
+          autonomous: true,
+          address: 'BB:CC:DD:EE:FF:00',
+          chars: [{ uuid: GATT_NOTIFY_UUID, properties: ['notify'] }],
+        }),
+      );
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      // No disconnect should have been published for the skipped autonomous connect
+      const disconnectCalls = (
+        mockClient.publishAsync as ReturnType<typeof vi.fn>
+      ).mock.calls.filter((c: unknown[]) => c[0] === `${PREFIX}/disconnect`);
+      expect(disconnectCalls).toHaveLength(0);
+    });
+
+    it('host-initiated connect ignores autonomous connected payload', async () => {
+      // Non-autonomous connected messages (no `autonomous: true`) should not
+      // trigger handleAutonomousConnect.
+      const adapter = createGattAdapter();
+      const watcher = new ReadingWatcher(MQTT_PROXY_CONFIG, [adapter], undefined, PROFILE);
+      await watcher.start();
+
+      mockClient._simulateMessage(
+        `${PREFIX}/connected`,
+        JSON.stringify({
+          address: 'AA:BB:CC:DD:EE:FF',
+          chars: [
+            { uuid: GATT_NOTIFY_UUID, properties: ['notify'] },
+            { uuid: GATT_WRITE_UUID, properties: ['write'] },
+          ],
+        }),
+      );
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      // No disconnect should be published — the watcher should ignore this message
+      const disconnectCalls = (
+        mockClient.publishAsync as ReturnType<typeof vi.fn>
+      ).mock.calls.filter((c: unknown[]) => c[0] === `${PREFIX}/disconnect`);
+      expect(disconnectCalls).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
## Summary

ESP32 firmware now connects to known scales **autonomously** the instant it detects them during scanning, eliminating the MQTT round-trip that caused fast-sleeping scales to power off before the connection could be established.

Closes #201

## Problem

The previous architecture required a full round-trip:

```
ESP32 scans → publishes to MQTT → Node host receives → host sends connect command → ESP32 connects
```

This added 500ms–2s of latency. Scales like the Renpho ES-CS20M (QN-Scale) power off within a few seconds of advertising — before the connect attempt even started. The mitigations in earlier commits (250ms polling, early flush) were not enough.

## Solution

The ESP32 already knows the scale MAC addresses (received via the `config` MQTT topic). When it detects a known MAC during scanning, it now:

1. Pauses scanning
2. Connects to the scale immediately (no MQTT round-trip)
3. Discovers services and characteristics
4. Enables notifications on all notify-capable characteristics
5. Publishes a `connected` message with `autonomous: true` to the host

The host receives the unsolicited `connected` message, matches it to a scale adapter, and proceeds directly to the GATT handshake — skipping the connect command entirely.

**Key insight:** Once BLE connection is established, the scale stays alive 13–20 seconds — plenty of time for the ~20 MQTT messages needed for the adapter protocol. The bottleneck was always advertisement → connect, not connect → data.

## What changed

### Firmware (`firmware/main.py`)
- `_find_scale_in_raw()` — scans the raw IRQ buffer for known scale MACs
- `_auto_gatt_connect()` — autonomous connect: pause scan → BLE connect → discover chars → enable notifications → publish `connected` with `autonomous: true`
- Streaming scan loop: triggers auto-connect when `has_pending_scale_mac()` fires
- Batch scan loop: checks for known scale MAC after publishing results
- Config topic handler: parses `autoConnect` opt-out flag
- Debug logging at each phase for troubleshooting

### Host (`src/ble/handler-mqtt-proxy/`)
- **`watcher.ts`**: Subscribes to `connected` topic, handles autonomous connect by matching adapter and running `waitForRawReading()` directly (no connect command)
- **`gatt.ts`**: `buildCharMapFromPayload()` builds char map from an already-received autonomous payload; `mqttGattConnect()` filters out `autonomous: true` payloads to prevent race conditions
- **`display.ts`**: Sends `autoConnect: false` in config topic when user opts out
- **`schema.ts`**: Added `auto_connect` (default: `true`) to `MqttProxySchema`

### Documentation
- `docs/guide/esp32-proxy.md` — updated GATT flow description, added tip about autonomous connect with opt-out instructions
- `docs/guide/configuration.md` — added `auto_connect` to mqtt_proxy field list

## Impact on other scales

| Category | Count | Impact |
|----------|-------|--------|
| GATT-required | 22 adapters (88%) | **All benefit** — faster connections |
| Broadcast-only (Mi Scale 2) | 1 | No impact — does not use GATT |
| Dual-mode (Eufy P2, QN Scale) | 2 | Benefits GATT path; broadcast unchanged |

## Backward compatibility

- **New firmware + old host**: Works. The `connected` payload format is unchanged. Old hosts process it normally.
- **Old firmware + new host**: Works. Host still sends connect commands as before.
- **Opt-out**: Set `auto_connect: false` under `mqtt_proxy` in config.yaml to revert to the old host-initiated connect flow.

## Testing

- 10 new firmware unit tests (`firmware/tests/test_auto_connect.py`): `_find_scale_in_raw` (5 tests) and `_auto_connect` config parsing (5 tests)
- 6 new host tests (`tests/ble/handler-mqtt-proxy.test.ts`): autonomous connect handling, adapter mismatch disconnect, gattInProgress guard, host-initiated connect filtering, publishConfig opt-out
- All existing tests pass (1598/1599, 1 pre-existing flaky test in `tests/config/watch.test.ts`)
- lint, format:check, tsc --noEmit all pass