### PR TITLE
fix(ble): send BLE address type on ESPHome proxy GATT connect (#215)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Requires Node.js v22+ and a BLE adapter. See the **[full install guide](https://
 - **[BLE diagnostic tool](https://blescalesync.dev/troubleshooting).** `npm run diagnose` for detailed BLE troubleshooting.
 - **[Home Assistant Add-on](https://blescalesync.dev/guide/home-assistant-addon).** One-click install via My Home Assistant badge, MQTT auto-discovery, UI-driven config, Garmin token bootstrap, and MFA workaround.
 - **[ESP32 BLE proxy](https://blescalesync.dev/guide/esp32-proxy).** Use a remote ESP32 as a BLE radio over MQTT, with a built-in embedded broker for zero-config setup, simplified Docker deployment, and optional display.
-- **[ESPHome Bluetooth proxy](https://blescalesync.dev/guide/esphome-proxy).** Reuse an existing ESPHome BT proxy mesh (Home Assistant) as a BLE radio via Native API: broadcast and GATT scales, multi-proxy with RSSI auto-pick.
+- **[ESPHome Bluetooth proxy](https://blescalesync.dev/guide/esphome-proxy).** Reuse an existing ESPHome BT proxy mesh (Home Assistant) as a BLE radio via Native API: broadcast and GATT scales (public and random BLE addresses), multi-proxy with RSSI auto-pick.
 - **BLE adapter selection.** `ble.adapter: hci1` for multi-adapter setups (Linux).
 - **Broadcast mode.** Supports non-connectable scales that only advertise weight via BLE advertisements.
 - **Linux stability hardening.** Auto-recovery for the BlueZ "stuck discovery" state via a consecutive-failure watchdog, plus optional [systemd `Type=notify`](https://blescalesync.dev/troubleshooting#ble-discovery-stops-working-after-hours-bluez-stuck-state) integration for whole-loop freezes.

--- a/docs/guide/esphome-proxy.md
+++ b/docs/guide/esphome-proxy.md
@@ -122,6 +122,11 @@ If a GATT scale still does not produce readings:
   If no proxy is close enough, move a proxy nearer or add one to the mesh.
 - Single-shot (`npm start`) returns a descriptive error; continuous mode
   (`CONTINUOUS_MODE=true`) keeps running and retries.
+- **ESPHome logs "Missing address type in connect request":** resolved. The
+  handler now sends the BLE address type (public or random, taken from the
+  scale's advertisement) with every GATT connect, and falls back to the other
+  type if the first attempt is refused. Update to the latest version if you
+  still see this on older builds.
 
 ### Multiple ESPHome proxies (mesh)
 

--- a/src/ble/handler-esphome-proxy/gatt.ts
+++ b/src/ble/handler-esphome-proxy/gatt.ts
@@ -29,14 +29,38 @@ interface ConnectResponse extends EsphomeDeviceConnection {
  * waitForRawReading() seam expects. ESPHome speaks numeric handles and a uint64
  * address; the translation is contained here so adapters stay UUID-based and
  * unchanged.
+ *
+ * ESPHome's V3 connect request requires the BLE `address_type`; omitting it makes
+ * newer firmware reject the connect with "Missing address type" (#215). When the
+ * type is known (captured from the advertisement) we try it first; otherwise, and
+ * as a fallback when the first attempt fails, we try the other type (public = 0,
+ * random = 1).
  */
-export async function openGattSession(client: EsphomeClient, mac: string): Promise<GattSession> {
+export async function openGattSession(
+  client: EsphomeClient,
+  mac: string,
+  addressType?: number,
+): Promise<GattSession> {
   const conn: EsphomeConnection = client.connection;
   const addr = macToInt(mac);
 
-  const connResp = (await conn.connectBluetoothDeviceService(addr)) as ConnectResponse;
-  if (!connResp || connResp.connected !== true) {
-    throw new Error(`ESPHome proxy could not connect to ${mac}`);
+  const candidates = addressType === undefined ? [0, 1] : [addressType, addressType === 0 ? 1 : 0];
+  let connResp: ConnectResponse | undefined;
+  let lastErr = 'no connect attempt made';
+  for (const type of candidates) {
+    try {
+      const resp = (await conn.connectBluetoothDeviceService(addr, type)) as ConnectResponse;
+      if (resp && resp.connected === true) {
+        connResp = resp;
+        break;
+      }
+      lastErr = `connected=false (addr_type=${type})`;
+    } catch (e) {
+      lastErr = `${errMsg(e)} (addr_type=${type})`;
+    }
+  }
+  if (!connResp) {
+    throw new Error(`ESPHome proxy could not connect to ${mac}: ${lastErr}`);
   }
   const services = (await conn.listBluetoothGATTServicesService(
     addr,

--- a/src/ble/handler-esphome-proxy/pool.ts
+++ b/src/ble/handler-esphome-proxy/pool.ts
@@ -59,6 +59,10 @@ export class EsphomeProxyPool {
   private adHandlers = new Map<string, (ad: EsphomeBleAdvertisement) => void>();
   // macLc -> proxyId -> latest sighting
   private sightings = new Map<string, Map<string, Sighting>>();
+  // macLc -> BLE address type (public/random) last reported in an advertisement.
+  // ESPHome's V3 connect request requires this; a device's type is stable, so any
+  // proxy that saw it teaches the whole pool. Kept in lockstep with `sightings`.
+  private addressTypes = new Map<string, number>();
   private subscribers = new Set<AdvertCb>();
   private started = false;
 
@@ -97,6 +101,7 @@ export class EsphomeProxyPool {
     this.clients.clear();
     this.adHandlers.clear();
     this.sightings.clear();
+    this.addressTypes.clear();
     this.started = false;
   }
 
@@ -117,12 +122,13 @@ export class EsphomeProxyPool {
    */
   async connectGatt(mac: string): Promise<GattSession> {
     const order = this.proxyOrderFor(mac);
+    const addressType = this.addressTypes.get(mac.toLowerCase());
     const errors: string[] = [];
     for (const id of order) {
       const client = this.clients.get(id);
       if (!client) continue;
       try {
-        return await openGattSession(client, mac);
+        return await openGattSession(client, mac, addressType);
       } catch (e) {
         errors.push(`${id}: ${errMsg(e)}`);
       }
@@ -130,6 +136,11 @@ export class EsphomeProxyPool {
     throw new Error(
       `ESPHome GATT connect failed for ${mac} on all proxies: ${errors.join('; ') || 'no proxy available'}`,
     );
+  }
+
+  /** BLE address type last seen for `mac`, or undefined if no advert reported one. */
+  addressTypeFor(mac: string): number | undefined {
+    return this.addressTypes.get(mac.toLowerCase());
   }
 
   /** Proxy that most recently saw `mac` (RSSI tiebreak) within the TTL, or null. */
@@ -171,7 +182,11 @@ export class EsphomeProxyPool {
       for (const [id, s] of perProxy) {
         if (now - s.ts > SIGHTING_TTL_MS) perProxy.delete(id);
       }
-      if (perProxy.size === 0) this.sightings.delete(mac);
+      if (perProxy.size === 0) {
+        this.sightings.delete(mac);
+        // Keep the address-type cache from outliving the sightings it belongs to.
+        this.addressTypes.delete(mac);
+      }
     }
   }
 
@@ -187,6 +202,9 @@ export class EsphomeProxyPool {
       this.sightings.set(macLc, perProxy);
     }
     perProxy.set(proxyId, { rssi: ad.rssi, ts: now });
+    // Record the BLE address type (public = 0 is valid and falsy, so guard on
+    // the type, not truthiness) so connectGatt can satisfy ESPHome's V3 connect.
+    if (typeof ad.addressType === 'number') this.addressTypes.set(macLc, ad.addressType);
 
     const info = toBleDeviceInfo(ad);
     for (const cb of this.subscribers) cb(info, mac);

--- a/tests/ble/esphome-proxy/gatt.test.ts
+++ b/tests/ble/esphome-proxy/gatt.test.ts
@@ -123,5 +123,30 @@ describe('openGattSession', () => {
     await expect(
       openGattSession({ connection: conn } as never, '00:00:00:00:00:01'),
     ).rejects.toThrow(/could not connect/i);
+    // Both address-type candidates are tried before giving up (#215).
+    expect(conn.connectBluetoothDeviceService).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes the known address type to the connect request (#215)', async () => {
+    const conn = fakeConnection();
+    const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01', 1);
+    expect(conn.connectBluetoothDeviceService).toHaveBeenCalledTimes(1);
+    expect(conn.connectBluetoothDeviceService).toHaveBeenCalledWith(ADDR, 1);
+    await session.close();
+  });
+
+  it('falls back to the other address type when the first fails (#215)', async () => {
+    const conn = fakeConnection();
+    conn.connectBluetoothDeviceService = vi
+      .fn()
+      .mockResolvedValueOnce({ address: ADDR, connected: false })
+      .mockResolvedValueOnce({ address: ADDR, connected: true, mtu: 23 });
+    // Unknown type -> candidates [0, 1]; first (public) fails, second (random) works.
+    const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01');
+    expect(conn.connectBluetoothDeviceService).toHaveBeenCalledTimes(2);
+    expect(conn.connectBluetoothDeviceService).toHaveBeenNthCalledWith(1, ADDR, 0);
+    expect(conn.connectBluetoothDeviceService).toHaveBeenNthCalledWith(2, ADDR, 1);
+    expect(session.charMap.has(normalizeUuid('2a9d'))).toBe(true);
+    await session.close();
   });
 });

--- a/tests/ble/esphome-proxy/pool.test.ts
+++ b/tests/ble/esphome-proxy/pool.test.ts
@@ -42,19 +42,35 @@ vi.mock('../../../src/ble/handler-esphome-proxy/client.js', () => ({
   safeDisconnect: vi.fn(async () => {}),
 }));
 
-import { EsphomeProxyPool } from '../../../src/ble/handler-esphome-proxy/pool.js';
+// Mock the GATT bridge so connectGatt() does not need real GATT discovery stubs;
+// we only assert how the pool calls it (which address type it forwards). Other
+// tests in this file never call connectGatt, so the mock does not affect them.
+vi.mock('../../../src/ble/handler-esphome-proxy/gatt.js', () => ({
+  openGattSession: vi.fn(async () => ({
+    charMap: new Map(),
+    device: { onDisconnect() {} },
+    close: async () => {},
+  })),
+}));
 
-const adv = (addr: number, rssi: number) => ({
+import { EsphomeProxyPool } from '../../../src/ble/handler-esphome-proxy/pool.js';
+import { openGattSession } from '../../../src/ble/handler-esphome-proxy/gatt.js';
+
+const adv = (addr: number, rssi: number, addressType?: number) => ({
   address: addr,
   name: 'QN-Scale',
   rssi,
   serviceUuidsList: [],
   serviceDataList: [],
   manufacturerDataList: [],
+  ...(addressType === undefined ? {} : { addressType }),
 });
 
 describe('EsphomeProxyPool', () => {
-  beforeEach(() => fakeClients.clear());
+  beforeEach(() => {
+    fakeClients.clear();
+    vi.mocked(openGattSession).mockClear();
+  });
 
   it('aggregates advertisements from every proxy', async () => {
     const pool = new EsphomeProxyPool({
@@ -88,6 +104,36 @@ describe('EsphomeProxyPool', () => {
     await pool.stop();
   });
 
+  it('captures the address type from advertisements (#215)', async () => {
+    const pool = new EsphomeProxyPool({
+      host: 'p1',
+      port: 6053,
+      client_info: 'x',
+      additional_proxies: [],
+    } as never);
+    await pool.start();
+    fakeClients.get('p1')!._emit('ble', adv(0xaabbccddeeff, -50, 1));
+    expect(pool.addressTypeFor('aa:bb:cc:dd:ee:ff')).toBe(1);
+    // Public = 0 is valid and falsy: must still be captured, not dropped.
+    fakeClients.get('p1')!._emit('ble', adv(0x112233445566, -50, 0));
+    expect(pool.addressTypeFor('11:22:33:44:55:66')).toBe(0);
+    await pool.stop();
+  });
+
+  it('connectGatt forwards the captured address type to openGattSession (#215)', async () => {
+    const pool = new EsphomeProxyPool({
+      host: 'p1',
+      port: 6053,
+      client_info: 'x',
+      additional_proxies: [],
+    } as never);
+    await pool.start();
+    fakeClients.get('p1')!._emit('ble', adv(0xaabbccddeeff, -50, 1));
+    await pool.connectGatt('AA:BB:CC:DD:EE:FF');
+    expect(openGattSession).toHaveBeenCalledWith(expect.anything(), 'AA:BB:CC:DD:EE:FF', 1);
+    await pool.stop();
+  });
+
   it('returns null when no proxy has seen the MAC', async () => {
     const pool = new EsphomeProxyPool({
       host: 'p1',
@@ -111,8 +157,9 @@ describe('EsphomeProxyPool', () => {
       } as never);
       await pool.start();
 
-      fakeClients.get('p1')!._emit('ble', adv(0x112233445566, -50));
+      fakeClients.get('p1')!._emit('ble', adv(0x112233445566, -50, 1));
       expect(pool.pickProxyFor('11:22:33:44:55:66')).toBe('p1:6053');
+      expect(pool.addressTypeFor('11:22:33:44:55:66')).toBe(1);
 
       // Advance past SIGHTING_TTL_MS (60s) then record a different MAC. The
       // stale entry must be swept, not just filtered out on read.
@@ -123,6 +170,8 @@ describe('EsphomeProxyPool', () => {
       expect(internal.sightings.has('11:22:33:44:55:66')).toBe(false);
       expect(pool.pickProxyFor('11:22:33:44:55:66')).toBeNull();
       expect(pool.pickProxyFor('aa:bb:cc:dd:ee:ff')).toBe('p1:6053');
+      // The address-type cache must be swept in lockstep with the sightings.
+      expect(pool.addressTypeFor('11:22:33:44:55:66')).toBeUndefined();
 
       await pool.stop();
     } finally {


### PR DESCRIPTION
## Summary

Fixes #215. ESPHome's V3 connect request requires the BLE `address_type`. The Phase 2 GATT bridge called `connectBluetoothDeviceService(addr)` without it, so newer ESPHome firmware rejected every connect with `Missing address type in connect request` and no GATT scale (e.g. Beurer BF788 with standard WSS/BCS GATT) was ever read.

## Approach (A + C)

- **A (primary):** the pool captures `address_type` from each advertisement. The type is a device property, so any proxy that sees the scale teaches the whole pool. It is forwarded through `connectGatt` to `openGattSession` and onto the connect call.
- **C (fallback):** when the type is unknown (no advert recorded one) or the first attempt is refused, the connect loop tries the other type. Order is known-first then the opposite; unknown means public (0) then random (1).

Both transport paths (single-shot `scan.ts` and continuous `watcher.ts`) call `pool.connectGatt(address)` unchanged, so the type is threaded entirely inside the pool with no caller signature changes. The address-type cache is swept in lockstep with the per-MAC sightings so it cannot leak.

## Changes

- `pool.ts`: per-MAC `addressTypes` map filled in `onAd` (guarded on `typeof === 'number'` because public = 0 is valid and falsy), evicted alongside sightings, exposed via `addressTypeFor()`, looked up in `connectGatt`.
- `gatt.ts`: `openGattSession(client, mac, addressType?)` with a connect candidate loop.
- `docs/guide/esphome-proxy.md` + `README.md`: troubleshooting note and feature wording.

## Tests

- `gatt.test.ts`: passes the known type, falls back to the other type, both candidates tried before failing.
- `pool.test.ts`: captures the type from advertisements (including public 0), forwards it to `openGattSession`, and sweeps the cache on eviction.
- Full suite: 1597 passing. typecheck, lint, prettier all clean.

## Backward compatibility

The library already sent the V3 connect type; adding `has_address_type` + `address_type` is read only by firmware that supports V3, so older ESPHome is unaffected.

## Out of scope

The `using outdated API 0.0, update to 1.14+` warning is the `@2colors/esphome-native-api` library advertising an old native API version. It is a soft deprecation warning, not the connect failure cause, and is left for a separate maintenance task.
