### PR TITLE
fix(config): accept bare 32-hex CoreBluetooth UUID for scale_mac (#212)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Requires Node.js v22+ and a BLE adapter. See the **[full install guide](https://
 - **[10 body metrics](https://blescalesync.dev/body-composition).** BIA-based body composition from weight + impedance.
 - **[Multi-user](https://blescalesync.dev/multi-user).** Automatic weight-based identification with per-user exporters.
 - **Historical sync.** Replays a scale's onboard cache of offline measurements with their original timestamps to exporters that support back-dating (Garmin Connect, InfluxDB, File).
-- **[Interactive setup wizard](https://blescalesync.dev/guide/configuration).** Scale discovery, exporter config, connectivity tests.
+- **[Interactive setup wizard](https://blescalesync.dev/guide/configuration).** Scale discovery (MAC or macOS CoreBluetooth UUID), exporter config, connectivity tests.
 - **[BLE diagnostic tool](https://blescalesync.dev/troubleshooting).** `npm run diagnose` for detailed BLE troubleshooting.
 - **[Home Assistant Add-on](https://blescalesync.dev/guide/home-assistant-addon).** One-click install via My Home Assistant badge, MQTT auto-discovery, UI-driven config, Garmin token bootstrap, and MFA workaround.
 - **[ESP32 BLE proxy](https://blescalesync.dev/guide/esp32-proxy).** Use a remote ESP32 as a BLE radio over MQTT, with a built-in embedded broker for zero-config setup, simplified Docker deployment, and optional display.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -60,7 +60,7 @@ ble:
 
 | Field           | Required                    | Default        | Description                                                                                                                                           |
 | --------------- | --------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `scale_mac`     | Recommended                 | Auto-discovery | MAC address or CoreBluetooth UUID (macOS). Prevents connecting to a neighbor's scale.                                                                 |
+| `scale_mac`     | Recommended                 | Auto-discovery | MAC address, or a CoreBluetooth UUID on macOS (bare 32-hex as the wizard writes it, or the dashed form). Prevents connecting to a neighbor's scale.   |
 | `handler`       | No                          | `auto`         | Transport: `auto` (local radio), `mqtt-proxy` (ESP32 over MQTT), `esphome-proxy` (ESPHome Native API). See below.                                     |
 | `noble_driver`  | No                          | OS default     | `abandonware` or `stoprocent`. Overrides the default BLE driver. Only applies when `handler: auto`.                                                   |
 | `adapter`       | No                          | System default | Linux only. Select a specific Bluetooth adapter (e.g., `hci0`, `hci1`). See below.                                                                    |

--- a/src/ble/scale-id.ts
+++ b/src/ble/scale-id.ts
@@ -1,0 +1,24 @@
+/**
+ * Validation for a BLE scale identifier: a MAC address (Windows/Linux) or a
+ * CoreBluetooth UUID (macOS).
+ *
+ * noble reports the macOS identifier as `peripheral.id`, which is the bare 32-hex
+ * form with no dashes (e.g. `360c96baf290475b14ce7c28aa3b8e81`). The setup wizard
+ * stores that value verbatim, so the config schema, the env-var loader and the
+ * wizard must all accept it. The standard dashed 8-4-4-4-12 form is accepted too,
+ * so a value pasted from another tool still validates (#212).
+ *
+ * Leaf module with no imports: `config/` and `wizard/` import it without any risk
+ * of an import cycle.
+ */
+const MAC_REGEX = /^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$/;
+const CB_UUID_REGEX =
+  /^([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}|[0-9A-Fa-f]{32})$/;
+
+/** Human-readable hint reused in every "invalid scale id" message. */
+export const SCALE_ID_HINT = 'a MAC address (XX:XX:XX:XX:XX:XX) or CoreBluetooth UUID';
+
+/** True when `v` is a valid scale identifier (MAC or CoreBluetooth UUID). */
+export function isValidScaleId(v: string): boolean {
+  return MAC_REGEX.test(v) || CB_UUID_REGEX.test(v);
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,11 +1,6 @@
 import { z } from 'zod';
 import { isLoopback } from '../ble/loopback.js';
-
-// --- Regex patterns ---
-
-const MAC_REGEX = /^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$/;
-const CB_UUID_REGEX =
-  /^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/;
+import { isValidScaleId, SCALE_ID_HINT } from '../ble/scale-id.js';
 
 // --- Sub-schemas ---
 
@@ -80,8 +75,8 @@ export const BleSchema = z
   .object({
     scale_mac: z
       .string()
-      .refine((v) => MAC_REGEX.test(v) || CB_UUID_REGEX.test(v), {
-        message: 'Must be a MAC address (XX:XX:XX:XX:XX:XX) or CoreBluetooth UUID',
+      .refine((v) => isValidScaleId(v), {
+        message: `Must be ${SCALE_ID_HINT}`,
       })
       .optional()
       .nullable(),

--- a/src/validate-env.ts
+++ b/src/validate-env.ts
@@ -2,6 +2,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { config } from 'dotenv';
 import { createLogger } from './logger.js';
+import { isValidScaleId } from './ble/scale-id.js';
 import type { Gender, UserProfile } from './interfaces/scale-adapter.js';
 
 const log = createLogger('Config');
@@ -58,11 +59,6 @@ function parseBoolean(key: string, raw: string): boolean {
   fail(`${key} must be true/false/yes/no/1/0, got '${raw}'`);
 }
 
-const MAC_REGEX = /^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$/;
-/** CoreBluetooth UUID format used on macOS (e.g. 12345678-1234-1234-1234-123456789ABC). */
-const CB_UUID_REGEX =
-  /^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/;
-
 export function loadConfig(): Config {
   config({ path: join(ROOT, '.env') });
 
@@ -92,7 +88,7 @@ export function loadConfig(): Config {
   let scaleMac: string | undefined;
   const rawMac = process.env.SCALE_MAC;
   if (rawMac) {
-    if (!MAC_REGEX.test(rawMac) && !CB_UUID_REGEX.test(rawMac)) {
+    if (!isValidScaleId(rawMac)) {
       fail(
         `SCALE_MAC must be a MAC address (XX:XX:XX:XX:XX:XX) ` +
           `or CoreBluetooth UUID (macOS), got '${rawMac}'`,

--- a/src/wizard/steps/ble.ts
+++ b/src/wizard/steps/ble.ts
@@ -1,13 +1,11 @@
 import type { WizardStep, WizardContext } from '../types.js';
 import type { MqttProxyConfig, EsphomeProxyConfig } from '../../config/schema.js';
+import { isValidScaleId, SCALE_ID_HINT } from '../../ble/scale-id.js';
 import { success, warn, info } from '../ui.js';
 
-const MAC_REGEX = /^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$/;
-const UUID_REGEX = /^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/;
-
 function validateMac(v: string): string | true {
-  if (!MAC_REGEX.test(v) && !UUID_REGEX.test(v)) {
-    return 'Must be a MAC address (XX:XX:XX:XX:XX:XX) or CoreBluetooth UUID';
+  if (!isValidScaleId(v)) {
+    return `Must be ${SCALE_ID_HINT}`;
   }
   return true;
 }

--- a/tests/ble/scale-id.test.ts
+++ b/tests/ble/scale-id.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { isValidScaleId, SCALE_ID_HINT } from '../../src/ble/scale-id.js';
+
+describe('isValidScaleId', () => {
+  it('accepts a MAC address', () => {
+    expect(isValidScaleId('AA:BB:CC:DD:EE:FF')).toBe(true);
+    expect(isValidScaleId('ff:03:00:13:a1:04')).toBe(true);
+  });
+
+  it('accepts a dashed CoreBluetooth UUID', () => {
+    expect(isValidScaleId('12345678-1234-1234-1234-123456789ABC')).toBe(true);
+  });
+
+  it('accepts a bare 32-hex CoreBluetooth UUID (macOS peripheral.id, #212)', () => {
+    // The exact value the reporter's wizard produced.
+    expect(isValidScaleId('360c96baf290475b14ce7c28aa3b8e81')).toBe(true);
+    expect(isValidScaleId('360C96BAF290475B14CE7C28AA3B8E81')).toBe(true);
+  });
+
+  it('rejects malformed identifiers', () => {
+    expect(isValidScaleId('not-a-mac')).toBe(false);
+    expect(isValidScaleId('')).toBe(false);
+    // 31 hex (too short) and 33 hex (too long)
+    expect(isValidScaleId('360c96baf290475b14ce7c28aa3b8e8')).toBe(false);
+    expect(isValidScaleId('360c96baf290475b14ce7c28aa3b8e811')).toBe(false);
+    // MAC missing a group
+    expect(isValidScaleId('AA:BB:CC:DD:EE')).toBe(false);
+    // Dashed UUID with wrong group lengths
+    expect(isValidScaleId('1234567-1234-1234-1234-123456789ABC')).toBe(false);
+    // Non-hex characters
+    expect(isValidScaleId('360c96baf290475b14ce7c28aa3b8eZZ')).toBe(false);
+  });
+
+  it('exposes a hint that names both accepted forms', () => {
+    expect(SCALE_ID_HINT).toContain('MAC address');
+    expect(SCALE_ID_HINT).toContain('CoreBluetooth UUID');
+  });
+});

--- a/tests/config/schema.test.ts
+++ b/tests/config/schema.test.ts
@@ -275,6 +275,11 @@ describe('BleSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('accepts a bare 32-hex CoreBluetooth UUID (macOS, #212)', () => {
+    const result = BleSchema.safeParse({ scale_mac: '360c96baf290475b14ce7c28aa3b8e81' });
+    expect(result.success).toBe(true);
+  });
+
   it('rejects invalid MAC', () => {
     const result = BleSchema.safeParse({ scale_mac: 'not-a-mac' });
     expect(result.success).toBe(false);

--- a/tests/validate-env.test.ts
+++ b/tests/validate-env.test.ts
@@ -59,6 +59,12 @@ describe('loadConfig()', () => {
     expect(cfg.scaleMac).toBe('AA:BB:CC:DD:EE:FF');
   });
 
+  it('accepts a bare 32-hex CoreBluetooth UUID SCALE_MAC (macOS, #212)', () => {
+    setEnv({ SCALE_MAC: '360c96baf290475b14ce7c28aa3b8e81' });
+    const cfg = loadConfig();
+    expect(cfg.scaleMac).toBe('360c96baf290475b14ce7c28aa3b8e81');
+  });
+
   it('accepts case-insensitive USER_GENDER', () => {
     setEnv({ USER_GENDER: 'Female' });
     const cfg = loadConfig();

--- a/tests/wizard/ble.test.ts
+++ b/tests/wizard/ble.test.ts
@@ -39,6 +39,10 @@ describe('validateMac()', () => {
     expect(validateMac('12345678-1234-1234-1234-123456789ABC')).toBe(true);
   });
 
+  it('accepts a bare 32-hex CoreBluetooth UUID (macOS, #212)', () => {
+    expect(validateMac('360c96baf290475b14ce7c28aa3b8e81')).toBe(true);
+  });
+
   it('rejects invalid format', () => {
     expect(validateMac('not-a-mac')).toContain('Must be');
   });


### PR DESCRIPTION
## Summary

Fixes #212. On macOS, noble reports `peripheral.id` as a bare 32-hex CoreBluetooth UUID with no dashes (e.g. `360c96baf290475b14ce7c28aa3b8e81`). The setup wizard writes that value into `ble.scale_mac` when the user picks the scale from the scan list, but every copy of the identifier regex only accepted the dashed `8-4-4-4-12` form. So the config the wizard produced failed its own schema validation on the next run, with the misleading `Must be a MAC address ... or CoreBluetooth UUID` error even though it was a UUID.

Runtime matching was never the problem: `matchesTarget` strips dashes and compares against `peripheral.id`, so both forms already match at connect time. Only the validation regex was wrong.

## Approach (relax + de-duplicate)

The identifier regex was triplicated across `config/schema.ts`, `validate-env.ts` and `wizard/steps/ble.ts`, which is how it drifted. This consolidates them into one dependency-free module, `src/ble/scale-id.ts`, exporting `isValidScaleId()` and `SCALE_ID_HINT`, and the CoreBluetooth UUID pattern now accepts both the bare 32-hex and the dashed form:

```
/^([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}|[0-9A-Fa-f]{32})$/
```

No normalization is needed since runtime already strips dashes.

## Changes

- `src/ble/scale-id.ts` (new): shared `MAC_REGEX` + `CB_UUID_REGEX` + `isValidScaleId()` + `SCALE_ID_HINT`.
- `config/schema.ts`, `validate-env.ts`, `wizard/steps/ble.ts`: drop the local regex copies, import the shared validator.
- `docs/guide/configuration.md`, `README.md`: note that `scale_mac` accepts the macOS CoreBluetooth UUID in both forms.

## Tests

- `tests/ble/scale-id.test.ts` (new): accepts MAC, dashed UUID, and bare 32-hex including the exact #212 value; rejects 31/33-hex, malformed MAC, non-hex.
- Added bare-32-hex acceptance cases to the schema, env-var and wizard suites.
- Full suite: 1601 passing. typecheck, lint, prettier clean.

## Out of scope

- Wizard normalization to a single canonical form (not needed; runtime strips dashes).
- Targeting more than one scale per host (#124, multi-scale aggregation). The reporter has two scales on macOS; a single `scale_mac` still targets one.
