### PR TITLE
feat(scales): support Smart Scale A1 broadcasts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ firmware/*.bin
 # Garmin tokens (should not be committed)
 .garmin_tokens/
 .garmin_renpho_tokens/
+garmin-tokens/
+
+# Local service manager configuration
+systemd/
 
 # Docker Compose (local overrides)
 docker-compose.override.yml

--- a/src/ble/handler-node-ble/broadcast.ts
+++ b/src/ble/handler-node-ble/broadcast.ts
@@ -33,11 +33,11 @@ export function extractDbusBytes(val: unknown): Buffer | null {
 }
 
 /**
- * Read weight + impedance from BLE service-data advertisements without connecting.
+ * Read weight + impedance from BLE advertisements without connecting.
  *
  * Sets DuplicateData=true in the BlueZ discovery filter so every advertisement
  * triggers a PropertiesChanged signal, then subscribes to that signal on the
- * Device1 D-Bus object. Falls back to polling the ServiceData property every
+ * Device1 D-Bus object. Falls back to polling advertisement properties every
  * 500 ms if signal subscription fails.
  */
 export async function broadcastScanNodeBle(
@@ -49,7 +49,7 @@ export async function broadcastScanNodeBle(
 ): Promise<RawReading> {
   const { abortSignal, onLiveData } = opts;
 
-  // Tell BlueZ to report duplicate advertisements so ServiceData is refreshed
+  // Tell BlueZ to report duplicate advertisements so advertisement data is refreshed
   // on every packet from the scale, not just on first discovery.
   try {
     const { Variant } = await getDbusNext();
@@ -107,45 +107,69 @@ export async function broadcastScanNodeBle(
     const onAbort = () => fail(abortSignal!.reason ?? new DOMException('Aborted', 'AbortError'));
     abortSignal?.addEventListener('abort', onAbort, { once: true });
 
+    const handleReading = (reading: ScaleReading): boolean => {
+      if (onLiveData) onLiveData(reading);
+
+      if (adapter.isComplete(reading)) {
+        bleLog.info(`Broadcast reading: ${reading.weight.toFixed(2)} kg`);
+        finish({ reading, adapter });
+        return true;
+      }
+
+      bleLog.debug(
+        `${adapter.name} broadcast frame not yet complete ` +
+          `(weight=${reading.weight.toFixed(2)} kg, impedance=${reading.impedance})`,
+      );
+      bestWeightOnly = { reading, adapter };
+      if (!graceTimer) {
+        graceTimer = setTimeout(() => {
+          graceTimer = null;
+          bleLog.info(
+            `Broadcast reading (weight only, no impedance within ${IMPEDANCE_GRACE_MS / 1000}s): ` +
+              `${bestWeightOnly!.reading.weight.toFixed(2)} kg`,
+          );
+          finish(bestWeightOnly!);
+        }, IMPEDANCE_GRACE_MS);
+      }
+
+      return false;
+    };
+
     /** Try to parse ServiceData entries and resolve if a complete reading is found. */
     const tryServiceData = (sd: unknown): boolean => {
-      if (!sd || typeof sd !== 'object') return false;
+      if (!adapter.parseServiceData || !sd || typeof sd !== 'object') return false;
 
       const entries: Iterable<[unknown, unknown]> =
-        sd instanceof Map
-          ? (sd as Map<unknown, unknown>).entries()
-          : Object.entries(sd as Record<string, unknown>);
+        sd instanceof Map ? sd.entries() : Object.entries(sd as Record<string, unknown>);
 
       for (const [uuid, val] of entries) {
         const buf = extractDbusBytes(val);
         if (!buf) continue;
 
-        const reading = adapter.parseServiceData!(String(uuid), buf);
+        const reading = adapter.parseServiceData(String(uuid), buf);
         if (!reading) continue;
 
-        if (onLiveData) onLiveData(reading);
+        if (handleReading(reading)) return true;
+      }
 
-        if (adapter.isComplete(reading)) {
-          bleLog.info(`Broadcast reading: ${reading.weight.toFixed(2)} kg`);
-          finish({ reading, adapter });
-          return true;
-        }
+      return false;
+    };
 
-        bleLog.debug(
-          `${adapter.name} broadcast frame not yet complete ` +
-            `(weight=${reading.weight.toFixed(2)} kg, impedance=${reading.impedance})`,
-        );
-        bestWeightOnly = { reading, adapter };
-        if (!graceTimer) {
-          graceTimer = setTimeout(() => {
-            graceTimer = null;
-            bleLog.info(
-              `Broadcast reading (weight only, no impedance within ${IMPEDANCE_GRACE_MS / 1000}s): ` +
-                `${bestWeightOnly!.reading.weight.toFixed(2)} kg`,
-            );
-            finish(bestWeightOnly!);
-          }, IMPEDANCE_GRACE_MS);
-        }
+    /** Try to parse ManufacturerData entries and resolve if a complete reading is found. */
+    const tryManufacturerData = (md: unknown): boolean => {
+      if (!adapter.parseBroadcast || !md || typeof md !== 'object') return false;
+
+      const entries: Iterable<[unknown, unknown]> =
+        md instanceof Map ? md.entries() : Object.entries(md as Record<string, unknown>);
+
+      for (const [_companyId, val] of entries) {
+        const buf = extractDbusBytes(val);
+        if (!buf) continue;
+
+        const reading = adapter.parseBroadcast(buf);
+        if (!reading) continue;
+
+        if (handleReading(reading)) return true;
       }
 
       return false;
@@ -159,15 +183,16 @@ export async function broadcastScanNodeBle(
       onPropsChanged = (changedProps) => {
         if (done) return;
         if (changedProps.ServiceData) tryServiceData(changedProps.ServiceData);
+        if (changedProps.ManufacturerData) tryManufacturerData(changedProps.ManufacturerData);
       };
       deviceHelper.on('PropertiesChanged', onPropsChanged);
-      bleLog.debug('Subscribed to Device1 PropertiesChanged for ServiceData');
+      bleLog.debug('Subscribed to Device1 PropertiesChanged for advertisement data');
     } catch (err: unknown) {
       bleLog.debug(`PropertiesChanged subscription failed: ${errMsg(err)} (poll fallback active)`);
       onPropsChanged = null;
     }
 
-    // Poll ServiceData every 500 ms as a fallback (and for first-read before
+    // Poll advertisement data every 500 ms as a fallback (and for first-read before
     // the PropertiesChanged subscription is established).
     const deadline = Date.now() + DISCOVERY_TIMEOUT_MS;
     (async () => {
@@ -178,6 +203,12 @@ export async function broadcastScanNodeBle(
           tryServiceData(sd);
         } catch (err: unknown) {
           bleLog.debug(`ServiceData poll error: ${errMsg(err)}`);
+        }
+        try {
+          const md: unknown = await helperOf(device).prop('ManufacturerData');
+          tryManufacturerData(md);
+        } catch (err: unknown) {
+          bleLog.debug(`ManufacturerData poll error: ${errMsg(err)}`);
         }
         await sleep(500);
       }

--- a/src/ble/handler-node-ble/scan.ts
+++ b/src/ble/handler-node-ble/scan.ts
@@ -160,7 +160,10 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
       const preInfo: BleDeviceInfo = { localName: name, serviceUuids: [] };
       const preMatchedAdapter = adapters.find((a) => a.matches(preInfo));
 
-      if (preMatchedAdapter?.preferPassive && preMatchedAdapter.parseServiceData) {
+      if (
+        preMatchedAdapter?.preferPassive &&
+        (preMatchedAdapter.parseServiceData || preMatchedAdapter.parseBroadcast)
+      ) {
         matchedAdapter = preMatchedAdapter;
         bleLog.info(`Matched adapter: ${matchedAdapter.name}`);
         return await broadcastScanNodeBle(matchedAdapter, btAdapter, device, mac, {
@@ -231,7 +234,7 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
       deviceMac = result.mac;
 
       // Passive-mode adapters: read from service-data advertisements without connecting.
-      if (matchedAdapter.preferPassive && matchedAdapter.parseServiceData) {
+      if (matchedAdapter.preferPassive && (matchedAdapter.parseServiceData || matchedAdapter.parseBroadcast)) {
         bleLog.info(`Matched adapter: ${matchedAdapter.name}`);
         return await broadcastScanNodeBle(matchedAdapter, btAdapter, device, result.mac, {
           abortSignal,

--- a/src/runtime/loop.ts
+++ b/src/runtime/loop.ts
@@ -6,7 +6,7 @@ import { errMsg } from '../utils/error.js';
 const log = createLogger('Sync');
 
 const BACKOFF_INITIAL_MS = 5_000;
-const BACKOFF_MAX_MS = 60_000;
+const BACKOFF_MAX_MS = 5_000;
 
 export interface ReadingSource {
   start?(): Promise<void>;
@@ -29,7 +29,7 @@ export interface RuntimeLoopDeps {
 }
 
 /**
- * Exponential backoff on iteration error: 5s -> 10s -> 20s -> 40s -> 60s cap.
+ * Keep retry cadence short for scales with aggressive auto power-off.
  */
 export async function runContinuousLoop(deps: RuntimeLoopDeps): Promise<void> {
   const {

--- a/src/scales/one-byone.ts
+++ b/src/scales/one-byone.ts
@@ -26,6 +26,7 @@ export class OneByoneAdapter implements ScaleAdapter {
   readonly charNotifyUuid = uuid16(0xfff4);
   readonly charWriteUuid = uuid16(0xfff1);
   readonly normalizesWeight = true;
+  readonly preferPassive = true;
   readonly unlockCommand: number[] = [];
   readonly unlockIntervalMs = 0;
 
@@ -69,6 +70,7 @@ export class OneByoneAdapter implements ScaleAdapter {
     if (data.length < 5 || data[0] !== 0xcf) return null;
 
     const weight = data.readUInt16LE(3) / 100;
+    if (weight <= 0 || weight > 250) return null;
 
     let impedance = 0;
     if (data.length >= 10) {
@@ -80,6 +82,18 @@ export class OneByoneAdapter implements ScaleAdapter {
     }
 
     return { weight, impedance };
+  }
+
+  parseBroadcast(manufacturerData: Buffer): ScaleReading | null {
+    // T9120 advertisements observed via Noble include the MAC followed by a
+    // payload. During measurement, 1byone/Eufy variants may embed the same
+    // 0xCF measurement frame used by notifications. Ignore static wake frames.
+    for (let offset = 0; offset <= manufacturerData.length - 5; offset++) {
+      if (manufacturerData[offset] !== 0xcf) continue;
+      const reading = this.parseNotification(manufacturerData.subarray(offset));
+      if (reading) return reading;
+    }
+    return null;
   }
 
   isComplete(reading: ScaleReading): boolean {

--- a/tests/runtime/loop.test.ts
+++ b/tests/runtime/loop.test.ts
@@ -59,7 +59,7 @@ describe('runContinuousLoop', () => {
     vi.restoreAllMocks();
   });
 
-  it('backoff sequence on repeated failures: 5s -> 10s -> 20s -> 40s -> 60s cap', async () => {
+  it('keeps retry cadence at the 5s cap on repeated failures', async () => {
     const ac = new AbortController();
     const { source, nextReading } = makeSource();
     nextReading.mockRejectedValue(new Error('scale not found'));
@@ -83,25 +83,25 @@ describe('runContinuousLoop', () => {
     expect(nextReading).toHaveBeenCalledTimes(1);
     await vi.advanceTimersByTimeAsync(5_000);
 
-    // Iteration 2: fail, sleep 10s
+    // Iteration 2: fail, sleep 5s (capped)
     expect(nextReading).toHaveBeenCalledTimes(2);
-    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.advanceTimersByTimeAsync(5_000);
 
-    // Iteration 3: fail, sleep 20s
+    // Iteration 3: fail, sleep 5s (still capped)
     expect(nextReading).toHaveBeenCalledTimes(3);
-    await vi.advanceTimersByTimeAsync(20_000);
+    await vi.advanceTimersByTimeAsync(5_000);
 
-    // Iteration 4: fail, sleep 40s
+    // Iteration 4: fail, sleep 5s (still capped)
     expect(nextReading).toHaveBeenCalledTimes(4);
-    await vi.advanceTimersByTimeAsync(40_000);
+    await vi.advanceTimersByTimeAsync(5_000);
 
-    // Iteration 5: fail, sleep 60s (capped)
+    // Iteration 5: fail, sleep 5s (still capped)
     expect(nextReading).toHaveBeenCalledTimes(5);
-    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(5_000);
 
-    // Iteration 6: fail, sleep 60s (still capped, not 120s)
+    // Iteration 6: fail, sleep 5s (still capped)
     expect(nextReading).toHaveBeenCalledTimes(6);
-    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(5_000);
 
     expect(nextReading).toHaveBeenCalledTimes(7);
 


### PR DESCRIPTION
## Summary
- enable the 1byone/Eufy adapter to prefer passive BLE advertisement reads
- parse Smart Scale A1-style ManufacturerData broadcasts by locating embedded 0xCF measurement frames
- let the node-ble broadcast scanner handle ManufacturerData as well as ServiceData
- keep retry cadence short for scales that power off quickly
- ignore local Garmin token and systemd service files so secrets and machine-specific config are not committed

## Tests
- npm run build
- npm test