### PR TITLE
fix(ble): read ESPHome proxy pre-decoded GATT uuid (#229)

### DIFF
--- a/src/ble/handler-esphome-proxy/esphome-gatt-proto.ts
+++ b/src/ble/handler-esphome-proxy/esphome-gatt-proto.ts
@@ -11,7 +11,11 @@ import { normalizeUuid } from '../types.js';
  * ESP ever hands the halves reversed, swap the two reads here (this is the
  * single point of change called out as risk #2 in the design spec).
  */
-export function esphomeUuidToString(uuidList: Array<string | number | bigint>): string {
+export function esphomeUuidToString(uuidList?: Array<string | number | bigint>): string {
+  // Defensive: @2colors/esphome-native-api pre-decodes GATT uuids into a `uuid`
+  // string and drops `uuidList`, so this fallback path may be handed nothing. A
+  // missing/empty list must never throw and kill the whole GATT session (#229).
+  if (!uuidList || uuidList.length === 0) return '';
   if (uuidList.length === 1) {
     const only = uuidList[0];
     if (typeof only === 'string') return normalizeUuid(only);
@@ -30,15 +34,24 @@ export function esphomeUuidToString(uuidList: Array<string | number | bigint>): 
   return normalizeUuid(full.toString(16).padStart(32, '0'));
 }
 
-/** Minimal structural types for the connection GATT messages we consume. */
+/**
+ * Minimal structural types for the connection GATT messages we consume.
+ *
+ * `@2colors/esphome-native-api` runs every message through `mapMessageByType()`,
+ * which for the GATT services response replaces the raw `uuidList` uint64 pair
+ * with a pre-decoded `uuid` string. We prefer `uuid` and keep `uuidList` as a
+ * fallback in case a different library version delivers the raw shape.
+ */
 export interface EsphomeGattCharacteristic {
-  uuidList: Array<string | number | bigint>;
+  uuid?: string;
+  uuidList?: Array<string | number | bigint>;
   handle: number;
   properties: number;
 }
 
 export interface EsphomeGattService {
-  uuidList: Array<string | number | bigint>;
+  uuid?: string;
+  uuidList?: Array<string | number | bigint>;
   handle: number;
   characteristicsList: EsphomeGattCharacteristic[];
 }

--- a/src/ble/handler-esphome-proxy/gatt.ts
+++ b/src/ble/handler-esphome-proxy/gatt.ts
@@ -1,5 +1,5 @@
 import type { BleChar, BleDevice } from '../shared.js';
-import { bleLog, errMsg } from '../types.js';
+import { bleLog, errMsg, normalizeUuid } from '../types.js';
 import type { EsphomeClient, EsphomeConnection } from './client.js';
 import { macToInt } from './advert.js';
 import {
@@ -81,7 +81,11 @@ export async function openGattSession(
   const charMap = new Map<string, BleChar>();
   for (const svc of services.servicesList ?? []) {
     for (const ch of svc.characteristicsList ?? []) {
-      const uuid = esphomeUuidToString(ch.uuidList);
+      // The library hands us a pre-decoded `uuid` string; `uuidList` is the
+      // raw-shape fallback. Skip entries we cannot identify rather than letting
+      // one malformed characteristic throw and abort the whole session (#229).
+      const uuid = ch.uuid ? normalizeUuid(ch.uuid) : esphomeUuidToString(ch.uuidList);
+      if (!uuid) continue;
       const handle = ch.handle;
 
       const char: BleChar = {

--- a/tests/ble/esphome-proxy/esphome-gatt-proto.test.ts
+++ b/tests/ble/esphome-proxy/esphome-gatt-proto.test.ts
@@ -31,4 +31,9 @@ describe('esphomeUuidToString', () => {
     const full = 0x00002a9d00001000800000805f9b34fbn;
     expect(esphomeUuidToString([full])).toBe(normalizeUuid('2a9d'));
   });
+
+  it('returns empty string for a missing/empty uuidList (no throw)', () => {
+    expect(esphomeUuidToString(undefined)).toBe('');
+    expect(esphomeUuidToString([])).toBe('');
+  });
 });

--- a/tests/ble/esphome-proxy/gatt.test.ts
+++ b/tests/ble/esphome-proxy/gatt.test.ts
@@ -24,17 +24,21 @@ function fakeConnection() {
     },
     connectBluetoothDeviceService: vi.fn(async () => ({ address: ADDR, connected: true, mtu: 23 })),
     disconnectBluetoothDeviceService: vi.fn(async () => ({ address: ADDR, connected: false })),
+    // Shape as emitted by @2colors/esphome-native-api 1.3.6: mapMessageByType()
+    // pre-decodes the GATT uuid uint64 pair into a `uuid` string and DROPS
+    // `uuidList`. The bridge must read `uuid`, not the (now absent) `uuidList`.
     listBluetoothGATTServicesService: vi.fn(async () => ({
       address: ADDR,
       servicesList: [
         {
-          uuidList: ['0000181d-0000-1000-8000-00805f9b34fb'],
+          uuid: '0000181d-0000-1000-8000-00805f9b34fb',
           handle: 1,
           characteristicsList: [
             {
-              uuidList: ['00002a9d-0000-1000-8000-00805f9b34fb'],
+              uuid: '00002a9d-0000-1000-8000-00805f9b34fb',
               handle: 7,
               properties: 0x10,
+              descriptorsList: [],
             },
           ],
         },
@@ -65,6 +69,32 @@ describe('openGattSession', () => {
     );
     await session.close();
     expect(conn.disconnectBluetoothDeviceService).toHaveBeenCalledWith(ADDR);
+  });
+
+  it('skips a malformed characteristic (no uuid/uuidList) without crashing', async () => {
+    const conn = fakeConnection();
+    conn.listBluetoothGATTServicesService = vi.fn(async () => ({
+      address: ADDR,
+      servicesList: [
+        {
+          uuid: '0000181d-0000-1000-8000-00805f9b34fb',
+          handle: 1,
+          characteristicsList: [
+            { handle: 5, properties: 0x10, descriptorsList: [] }, // no uuid -> skip
+            {
+              uuid: '00002a9d-0000-1000-8000-00805f9b34fb',
+              handle: 7,
+              properties: 0x10,
+              descriptorsList: [],
+            },
+          ],
+        },
+      ],
+    }));
+    const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01');
+    expect(session.charMap.has(normalizeUuid('2a9d'))).toBe(true);
+    expect(session.charMap.size).toBe(1);
+    await session.close();
   });
 
   it('writes the full payload in a single call (no MTU chunking)', async () => {


### PR DESCRIPTION
## #229 ESPHome proxy GATT crash: `Cannot read properties of undefined (reading 'length')`

### Root cause
`@2colors/esphome-native-api` 1.3.6 passes every message through `mapMessageByType()`. For `BluetoothGATTGetServicesResponse` it strips the raw `uuidList` uint64 pair off each service/characteristic and replaces it with a pre-decoded `uuid` string. The Phase 2 GATT bridge still read `ch.uuidList` (now `undefined`) and passed it to `esphomeUuidToString()`, which ran `.length` on undefined and threw, aborting every GATT read over the proxy right after a successful connect + service discovery.

### Why CI missed it
The old test fixture invented a `uuidList` shape that matched neither the real library nor raw google-protobuf, so it only exercised an imaginary contract. Green CI, crashing hardware. This was the first real-HW test of the GATT path.

### Fix
- Resolve the characteristic UUID from the library's `uuid` string; keep the `uuidList` `[high, low]` decoder as a fallback for other library versions.
- Skip any characteristic whose UUID cannot be resolved instead of crashing the session; `esphomeUuidToString()` returns `''` for a missing/empty list rather than throwing.
- Test fixture rewritten to mirror the actual 1.3.6 output, plus a regression test for malformed entries.

No adapter changes. 1630 tests green, lint/tsc/prettier clean.

Closes nothing yet on purpose: stays open until the reporter confirms on the Beurer BF788.