### PR TITLE
chore: promote dev to main (v1.17.0 candidate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Requires Node.js v22+ and a BLE adapter. See the **[full install guide](https://
 
 ## Features
 
-- **[25+ scale brands](https://blescalesync.dev/guide/supported-scales).** Xiaomi (Mi Scale 2 passive broadcast), Renpho (Elis 1, ES-CS20M, FITINDEX, Sencor, QN-Scale), Eufy, Yunmai, Beurer (incl. BF720 / BF105), Sanitas (incl. SBF70 body composition), Medisana, and more.
+- **[25+ scale brands](https://blescalesync.dev/guide/supported-scales).** Xiaomi (Mi Scale 2 passive broadcast), Renpho (Elis 1, ES-CS20M, FITINDEX, Sencor, QN-Scale), GE (CS 10 G / Fit Plus), Eufy, Yunmai, Beurer (incl. BF720 / BF105), Sanitas (incl. SBF70 body composition), Medisana, and more.
 - **[9 export targets](https://blescalesync.dev/exporters).** Garmin Connect, Strava, Intervals.icu, MQTT (Home Assistant), InfluxDB, Webhook, Ntfy, Telegram, File (CSV/JSONL).
 - **[10 body metrics](https://blescalesync.dev/body-composition).** BIA-based body composition from weight + impedance.
 - **[Multi-user](https://blescalesync.dev/multi-user).** Automatic weight-based identification with per-user exporters.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Requires Node.js v22+ and a BLE adapter. See the **[full install guide](https://
 
 ## Features
 
-- **[25+ scale brands](https://blescalesync.dev/guide/supported-scales).** Xiaomi (Mi Scale 2 passive broadcast), Renpho (Elis 1, ES-CS20M, FITINDEX, Sencor, QN-Scale), GE (CS 10 G / Fit Plus), Eufy, Yunmai, Beurer (incl. BF720 / BF105), Sanitas (incl. SBF70 body composition), Medisana, and more.
+- **[25+ scale brands](https://blescalesync.dev/guide/supported-scales).** Xiaomi (Mi Scale 2 passive broadcast), Renpho (Elis 1, ES-CS20M, FITINDEX, Sencor, QN-Scale), GE (CS 10 G / Fit Plus), Robi (S9), Eufy, Yunmai, Beurer (incl. BF720 / BF105), Sanitas (incl. SBF70 body composition), Medisana, and more.
 - **[9 export targets](https://blescalesync.dev/exporters).** Garmin Connect, Strava, Intervals.icu, MQTT (Home Assistant), InfluxDB, Webhook, Ntfy, Telegram, File (CSV/JSONL).
 - **[10 body metrics](https://blescalesync.dev/body-composition).** BIA-based body composition from weight + impedance.
 - **[Multi-user](https://blescalesync.dev/multi-user).** Automatic weight-based identification with per-user exporters.

--- a/docs/guide/esp32-proxy.md
+++ b/docs/guide/esp32-proxy.md
@@ -59,6 +59,10 @@ Any ESP32 board running MicroPython with BLE support works. Tested on:
 
 The board is auto-detected from the chip family. Set `"board"` in `config.json` to override (e.g. `"esp_wroom_32"` for a generic WROOM-32 module, `"guition_4848"` for the display board, `"atom_echo"` for the Atom Echo). Auto-detect cannot distinguish a WROOM-32 from an Atom Echo, so WROOM-32 users must set the override (or pass `--board esp_wroom_32` to `flash.sh`).
 
+::: tip Broadcast vs GATT scales and RAM
+Broadcast-only scales (the reading is in the advertisement) work on every board listed above. GATT-connect scales, which need an active connection (e.g. QN Scale / Renpho ES-CS20M, Yunmai, Inlife, some Eufy), are RAM-heavy: the BLE stack allocates the connection from the ESP-IDF heap, which is separate from the MicroPython heap. On a no-PSRAM board (classic ESP-WROOM-32, Atom Echo) that heap can run out while WiFi and MQTT are active, so the connect times out or the board reboots. For GATT-connect scales use a board with PSRAM (ESP32-S3-DevKitC, Guition). Both classic ESP32 and S3 share one 2.4 GHz radio via time-division coexistence; the S3 advantage here is RAM, not the radio.
+:::
+
 ![Guition 4848 display showing scan status and user results](../images/esp32-display.png)
 
 ::: warning Not compatible
@@ -364,7 +368,7 @@ On shared-radio boards (ESP32-PICO), the firmware deactivates BLE after each sca
 - Check that your WiFi router is on a 2.4 GHz band (5 GHz won't work with ESP32)
 - Try reducing `SCAN_DURATION_MS` in the board config
 
-ESP32-S3 boards have hardware radio coexistence and don't need BLE deactivation.
+ESP32-S3 boards have enough RAM (PSRAM) to keep BLE active alongside WiFi, so they don't deactivate BLE after a scan. The radio is still shared on both chips (time-division coexistence); the difference is available memory.
 
 ### Scan timeout (30s) on first scan after boot
 
@@ -377,3 +381,18 @@ Boards without PSRAM have ~100 KB free after boot. If you see `MemoryError`:
 - The firmware already deduplicates scan results and runs `gc.collect()` aggressively
 - Reduce `SCAN_DURATION_MS` in `board_atom_echo.py` to find fewer devices
 - Avoid running other MicroPython code alongside the bridge
+
+### GATT connect times out or the ESP32 reboots (classic ESP32 / no PSRAM)
+
+A GATT-connect scale (one that needs an active connection, not just a broadcast) can make a no-PSRAM board time out on connect, or crash and reboot with a NimBLE error like `assertion:semaphor->handle / npl_freertos_sem_init` (Guru Meditation). The cause is the ESP-IDF heap running out: the BLE stack allocates the connection from that heap (separate from the MicroPython heap), and WiFi + MQTT leave little room on a classic ESP32 / Atom Echo. The crash is a C-level assertion inside the BLE stack, so it cannot be caught from Python; it can only be avoided by leaving enough free heap.
+
+The firmware mitigates this by freeing memory right before connecting and, on no-PSRAM boards, using a shorter connect window with a retry. It also prints the heap headroom over serial just before each connect:
+
+```
+IDF heap before connect: free=<bytes> largest=<bytes>
+```
+
+- A very small `largest` before a failed connect means you are out of RAM. Use a board with PSRAM (ESP32-S3-DevKitC, Guition) for GATT-connect scales.
+- A healthy `largest` plus a timeout points at radio contention instead; move the board closer to the scale and retry.
+
+Broadcast-only scales are unaffected and work on every board.

--- a/docs/superpowers/plans/235-fff0-ae00-qn-misdetect.md
+++ b/docs/superpowers/plans/235-fff0-ae00-qn-misdetect.md
@@ -1,0 +1,108 @@
+# Plan: #235 fff0+ae00 scale misidentified as Inlife instead of QN
+
+## Problem
+
+GE CS 10 G "Fit Plus" (MAC FF:07:00:0E:C7:4E) advertises both the fff0 cluster
+(fff0/fff1/fff2) and the QN-specific AE00 cluster (ae00/ae01/ae02). It is a QN
+protocol scale but resolves to the Inlife adapter, gets fff1/fff2, never receives
+valid user data, and disconnects.
+
+## Root cause (3 layers)
+
+1. `QnScaleAdapter.matches()` (src/scales/qn-scale.ts:303) does not recognize the
+   AE00 service. A named device whose name is not a QN brand fails `nameMatch`, and
+   the UUID fallback is gated on `!name`, so a named device carrying ae00/fff0
+   returns false.
+2. `InlifeScaleAdapter.matches()` (src/scales/inlife.ts:41) greedily returns true
+   for any device advertising fff0 when no characteristic list is supplied.
+3. The noble post-connect matcher (src/ble/handler-noble.ts:497 and the identical
+   src/ble/handler-noble-legacy.ts:497) builds `BleDeviceInfo` with only
+   `localName` + `serviceUuids`, omitting `characteristicUuids` even though the
+   characteristics are already discovered. So the #177 char-aware path is bypassed
+   in MAC-target mode on noble. node-ble (scan.ts:214) already passes them.
+
+Because QN is registry-ordered before Inlife, fixing layer 1 alone makes QN win.
+`ae00`/`ae01`/`ae02` occur only in qn-scale.ts across all adapters, so they are an
+unambiguous QN signal.
+
+## Changes
+
+### 1. src/scales/qn-scale.ts - recognize AE00 (fix A + char-aware C2)
+
+Add module constant near the other SVC constants:
+```js
+const SVC_AE00 = 'ae00';
+```
+
+In `matches()`, after computing `uuids` (line 313, already lowercased) and after
+the manufacturerData block, add a positive AE00 check that fires regardless of
+name, BEFORE the name logic:
+```js
+// AE00 is a QN-only service (Renpho ES-CS20M / newer firmware), never shared
+// with the fff0 Inlife/1byone/Eufy cluster. It positively identifies a QN
+// scale even when the device also carries a non-QN name and advertises fff0
+// (e.g. GE CS 10 G "Fit Plus", #235). Compare both the short 16-bit and the
+// full 128-bit forms, mirroring the hasQnVendor check below: serviceUuids and
+// characteristicUuids reach us as full normalizeUuid/uuid16 strings from real
+// handlers, but short forms appear in some scan paths and tests.
+const chars = (device.characteristicUuids || []).map((u) => u.toLowerCase());
+const hasAe00 =
+  uuids.some((u) => u === SVC_AE00 || u === uuid16(0xae00)) ||
+  chars.some((u) => u === 'ae01' || u === 'ae02' || u === CHR_AE01 || u === CHR_AE02);
+if (hasAe00) return true;
+```
+Note on UUID forms (verified): `uuid16(code)` returns the FULL 128-bit string
+(`0000ae00...805f9b34fb`), and `normalizeUuid` produces the same full form for
+16-bit UUIDs. `CHR_AE01`/`CHR_AE02` are already `uuid16(0xae01)`/`uuid16(0xae02)`,
+so they cover the full form; the literal `'ae01'`/`'ae02'` cover the short form.
+
+### 2. src/ble/handler-noble.ts - pass characteristicUuids post-connect (C1)
+
+At the target-MAC match (line ~497), build the characteristic UUID list from the
+already-discovered `services` and include it:
+```js
+const characteristicUuids = services.flatMap((s) =>
+  (s.characteristics ?? []).map((c) => normalizeUuid(c.uuid)),
+);
+const info: BleDeviceInfo = { localName: name, serviceUuids, characteristicUuids };
+```
+
+### 3. src/ble/handler-noble-legacy.ts - same change (C1 parity)
+
+Identical edit at the matching site (line ~497).
+
+### 4. tests/scales/adapter-resolution.test.ts - regression tests (#235)
+
+Add a `describe('adapter resolution (#235 fff0+ae00 QN/Inlife collision)')` block:
+- "Fit Plus" with name + serviceUuids [1800,180f,180a,fff0,ae00] resolves to "QN Scale".
+- Same device with serviceUuids [...,fff0] but ae01/ae02 only in characteristicUuids
+  (no top-level ae00 service) still resolves to "QN Scale" (char-aware path).
+- Negative guard: a plain Inlife (name 000fatscale01, fff0 + fff1/fff2, NO ae00)
+  still resolves to "Inlife".
+- Negative guard: a real QN device unaffected, e.g. unnamed fff0-only still QN
+  (existing behavior) - optional, keep if cheap.
+
+### 5. README.md - per project rule, update every commit
+
+Add a one-line note under the supported-scales / changelog-ish area that the QN
+adapter now also recognizes the AE00 service cluster (covers GE CS 10 G / Fit
+Plus style dual-service scales). Keep minimal, no version bump (release-please
+owns versions).
+
+## Out of scope
+
+- Inlife ae00 exclusion (layer 2 defensive): not needed since QN wins by registry
+  order once it matches. Skip to keep change minimal.
+- `force_adapter` config: separate enhancement, not a #235 fix.
+- node-ble / proxy handlers: already char-aware (scan.ts:214). No change.
+
+## Verification
+
+- `npx vitest run tests/scales/adapter-resolution.test.ts` green (new + existing).
+- Full `npm test`, `npm run lint`, `npx tsc --noEmit`, `npx prettier --check` clean.
+- Kill node processes before npm: `taskkill //F //IM node.exe`.
+
+## Commit
+
+Conventional: `fix(ble): match QN scales advertising AE00 alongside fff0 (#235)`.
+Push to dev.

--- a/firmware/ble_bridge.py
+++ b/firmware/ble_bridge.py
@@ -15,6 +15,27 @@ _ble = bluetooth.BLE()
 _BT_BASE_SUFFIX = "00001000800000805f9b34fb"
 
 
+def _log_idf_heap(when):
+    """Log ESP-IDF heap headroom (best-effort, no-op off-device).
+
+    NimBLE allocates its connection structures from the ESP-IDF heap, which is
+    separate from the MicroPython GC heap. On a no-PSRAM classic ESP32 this heap
+    can be exhausted by WiFi + MQTT, so a GATT connect fails to allocate and
+    NimBLE aborts with a C-level semaphore assertion (#139). Logging free + the
+    largest contiguous block right before connect tells a RAM ceiling (tiny
+    `largest`) apart from a radio-coexistence timeout (healthy `largest`).
+    """
+    try:
+        import esp32
+
+        regions = esp32.idf_heap_info(esp32.HEAP_DATA)
+        free = sum(r[1] for r in regions)
+        largest = max(r[2] for r in regions)
+        print("IDF heap %s: free=%d largest=%d" % (when, free, largest))
+    except Exception:
+        pass
+
+
 def _norm_uuid(uuid):
     """Convert MicroPython UUID to normalized 32-char hex (matches Node.js normalizeUuid)."""
     s = str(uuid)
@@ -334,16 +355,43 @@ class BleBridge:
         aioble_addr_type = aioble.ADDR_RANDOM if (addr_type & 1) else aioble.ADDR_PUBLIC
         device = aioble.Device(aioble_addr_type, addr_bytes)
 
-        # aioble forwards scan_duration_ms=None to gap_connect, which defaults
-        # to a 2 s scan window. Scales advertising in short bursts (Eufy P2
-        # Pro) routinely miss that window, leaving the outer 15 s timeout to
-        # raise TimeoutError. Match scan_duration_ms to timeout_ms so NimBLE
-        # keeps scanning across the full connect window.
-        try:
-            self._conn = await device.connect(timeout_ms=15000, scan_duration_ms=15000)
-        except Exception as e:
-            print(f"GATT connect failed for {address}: {type(e).__name__}: {e}")
-            raise
+        # Reclaim heap before connecting. NimBLE allocates its connection from
+        # the ESP-IDF heap, and an empty MicroPython split is returned to that
+        # heap during a GC pass (MICROPY_GC_SPLIT_HEAP_AUTO), so collecting after
+        # the scan buffers are freed gives NimBLE the best chance to allocate on
+        # a tight no-PSRAM board (#139). Two passes: the second can release a
+        # split that the first only emptied.
+        import gc
+
+        gc.collect()
+        gc.collect()
+        _log_idf_heap("before connect")
+
+        # aioble forwards scan_duration_ms to gap_connect (default 2 s). Scales
+        # advertising in short bursts (Eufy P2 Pro) miss that window, so match it
+        # to the connect timeout. Both are board-tunable: roomy boards keep the
+        # 15 s window, no-PSRAM boards use a shorter window + retries (with a GC
+        # between) to ease radio/heap pressure (#139).
+        timeout_ms = getattr(board, "CONNECT_TIMEOUT_MS", 15000)
+        scan_ms = getattr(board, "CONNECT_SCAN_MS", 15000)
+        retries = getattr(board, "CONNECT_RETRIES", 1)
+        last_exc = None
+        for attempt in range(1, retries + 1):
+            try:
+                self._conn = await device.connect(timeout_ms=timeout_ms, scan_duration_ms=scan_ms)
+                last_exc = None
+                break
+            except Exception as e:
+                last_exc = e
+                print(
+                    "GATT connect attempt %d/%d failed for %s: %s: %s"
+                    % (attempt, retries, address, type(e).__name__, e)
+                )
+                if attempt < retries:
+                    gc.collect()
+                    await asyncio.sleep_ms(500)
+        if last_exc is not None:
+            raise last_exc
         self._chars = {}
         chars_info = []
 

--- a/firmware/board_atom_echo.py
+++ b/firmware/board_atom_echo.py
@@ -17,6 +17,13 @@ SCAN_DURATION_MS = 8000
 # Memory-constrained: cap raw IRQ results
 MAX_SCAN_ENTRIES = 200
 
+# GATT connect tuning (#139). No PSRAM: shorter connect/scan window + retries
+# (with a GC between) to ease IDF-heap and shared-radio pressure during a NimBLE
+# central connection.
+CONNECT_TIMEOUT_MS = 10000
+CONNECT_SCAN_MS = 8000
+CONNECT_RETRIES = 2
+
 # Aggressive GC to avoid OOM (~100 KB free after imports)
 AGGRESSIVE_GC = True
 GC_INTERVAL = 200  # main-loop iterations between gc.collect()

--- a/firmware/board_esp32_s3.py
+++ b/firmware/board_esp32_s3.py
@@ -1,12 +1,14 @@
 """Board config: Generic ESP32-S3 (16 MB flash, 8 MB PSRAM).
 
-Hardware radio coexistence — BLE and WiFi run simultaneously, no need to
-deactivate BLE after scanning.  Plenty of RAM for large scan buffers.
+BLE and WiFi still share one 2.4 GHz radio via time-division coexistence (as on
+the classic ESP32), but the PSRAM gives plenty of RAM, so BLE can stay active
+between scans and there is IDF-heap headroom for large scan buffers and a NimBLE
+GATT connection. No need to deactivate BLE after scanning.
 """
 
 BOARD_NAME = "esp32_s3"
 
-# BLE/WiFi coexistence — hardware coexistence, no deactivation needed
+# BLE/WiFi coexistence — shared radio, but ample PSRAM, so no deactivation needed
 DEACTIVATE_BLE_AFTER_SCAN = False
 CONTINUOUS_SCAN = True
 PUBLISH_INTERVAL_MS = 2000   # drain+publish every 2s
@@ -18,6 +20,12 @@ SCAN_DURATION_MS = 8000
 
 # Large PSRAM — generous scan buffer
 MAX_SCAN_ENTRIES = 500
+
+# GATT connect tuning (#139). Ample PSRAM, so keep one long connect/scan window
+# (matches the historical behavior for short-burst advertisers like Eufy P2 Pro).
+CONNECT_TIMEOUT_MS = 15000
+CONNECT_SCAN_MS = 15000
+CONNECT_RETRIES = 1
 
 # No memory pressure
 AGGRESSIVE_GC = False

--- a/firmware/board_esp_wroom_32.py
+++ b/firmware/board_esp_wroom_32.py
@@ -24,6 +24,13 @@ SCAN_DURATION_MS = 5000
 # in ble_bridge.py drops entries past this cap without crashing.
 MAX_SCAN_ENTRIES = 80
 
+# GATT connect tuning (#139). No PSRAM, so the IDF heap is tight for a NimBLE
+# central connection: use a shorter connect/scan window and retry (with a GC
+# between attempts) instead of one long window that holds the shared radio.
+CONNECT_TIMEOUT_MS = 10000
+CONNECT_SCAN_MS = 8000
+CONNECT_RETRIES = 2
+
 AGGRESSIVE_GC = True
 GC_INTERVAL = 200
 

--- a/firmware/board_guition_4848.py
+++ b/firmware/board_guition_4848.py
@@ -9,7 +9,8 @@ Pin mapping from https://homeding.github.io/boards/esp32s3/panel-4848S040.htm
 
 BOARD_NAME = "guition_4848"
 
-# BLE/WiFi coexistence — hardware coexistence, no deactivation needed
+# BLE/WiFi coexistence — shared radio (time-division), but ample PSRAM, so no
+# deactivation needed
 DEACTIVATE_BLE_AFTER_SCAN = False
 CONTINUOUS_SCAN = True
 PUBLISH_INTERVAL_MS = 2000   # drain+publish every 2s
@@ -21,6 +22,11 @@ SCAN_DURATION_MS = 8000
 
 # Large PSRAM
 MAX_SCAN_ENTRIES = 500
+
+# GATT connect tuning (#139). Ample PSRAM, so keep one long connect/scan window.
+CONNECT_TIMEOUT_MS = 15000
+CONNECT_SCAN_MS = 15000
+CONNECT_RETRIES = 1
 
 # No memory pressure
 AGGRESSIVE_GC = False

--- a/firmware/tests/test_board_config.py
+++ b/firmware/tests/test_board_config.py
@@ -1,0 +1,62 @@
+"""Host-runnable tests for the per-board GATT connect tuning constants (#139).
+
+The board_*.py modules are pure constants (no MicroPython-only imports), so they
+import cleanly on a host. ble_bridge.connect() reads CONNECT_TIMEOUT_MS /
+CONNECT_SCAN_MS / CONNECT_RETRIES from the active board, so every board module
+must define them, and the no-PSRAM boards must use a tighter window + a retry.
+
+Run: python -m unittest discover -s firmware/tests
+"""
+
+import os
+import sys
+import importlib
+import unittest
+
+_FIRMWARE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _FIRMWARE_DIR not in sys.path:
+    sys.path.insert(0, _FIRMWARE_DIR)
+
+_ALL_BOARDS = [
+    "board_atom_echo",
+    "board_esp_wroom_32",
+    "board_esp32_s3",
+    "board_guition_4848",
+]
+_NO_PSRAM_BOARDS = ["board_atom_echo", "board_esp_wroom_32"]
+_PSRAM_BOARDS = ["board_esp32_s3", "board_guition_4848"]
+
+
+class TestBoardConnectConfig(unittest.TestCase):
+    def _load(self, name):
+        return importlib.import_module(name)
+
+    def test_all_boards_define_connect_constants(self):
+        for name in _ALL_BOARDS:
+            mod = self._load(name)
+            for const in ("CONNECT_TIMEOUT_MS", "CONNECT_SCAN_MS", "CONNECT_RETRIES"):
+                self.assertTrue(hasattr(mod, const), f"{name} missing {const}")
+                value = getattr(mod, const)
+                self.assertIsInstance(value, int, f"{name}.{const} must be int")
+                self.assertGreater(value, 0, f"{name}.{const} must be positive")
+
+    def test_no_psram_boards_use_tighter_window_and_retry(self):
+        s3_scan = self._load("board_esp32_s3").CONNECT_SCAN_MS
+        for name in _NO_PSRAM_BOARDS:
+            mod = self._load(name)
+            self.assertGreaterEqual(
+                mod.CONNECT_RETRIES, 2, f"{name} should retry on tight RAM"
+            )
+            self.assertLessEqual(
+                mod.CONNECT_SCAN_MS, s3_scan, f"{name} window should be <= the S3 window"
+            )
+
+    def test_psram_boards_keep_single_long_window(self):
+        for name in _PSRAM_BOARDS:
+            mod = self._load(name)
+            self.assertEqual(mod.CONNECT_RETRIES, 1, f"{name} should not need retries")
+            self.assertEqual(mod.CONNECT_SCAN_MS, 15000, f"{name} keeps the 15s window")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/ble/handler-noble-legacy.ts
+++ b/src/ble/handler-noble-legacy.ts
@@ -490,11 +490,16 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
         matchedAdapter = discoveredAdapter;
       } else {
         // Target-MAC mode: match adapter post-connect using full service list
+        // and the discovered characteristics, so char-aware adapters (#177, #235)
+        // can disambiguate devices that share a generic vendor service (fff0).
         const serviceUuids = services.map((s) => normalizeUuid(s.uuid));
+        const characteristicUuids = services.flatMap((s) =>
+          (s.characteristics ?? []).map((c) => normalizeUuid(c.uuid)),
+        );
         const name = peripheral.advertisement?.localName ?? '';
         bleLog.debug(`Services: [${serviceUuids.join(', ')}]`);
 
-        const info: BleDeviceInfo = { localName: name, serviceUuids };
+        const info: BleDeviceInfo = { localName: name, serviceUuids, characteristicUuids };
         const found = adapters.find((a) => a.matches(info));
         if (!found) {
           throw new Error(

--- a/src/ble/handler-noble.ts
+++ b/src/ble/handler-noble.ts
@@ -490,11 +490,16 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
         matchedAdapter = discoveredAdapter;
       } else {
         // Target-MAC mode: match adapter post-connect using full service list
+        // and the discovered characteristics, so char-aware adapters (#177, #235)
+        // can disambiguate devices that share a generic vendor service (fff0).
         const serviceUuids = services.map((s) => normalizeUuid(s.uuid));
+        const characteristicUuids = services.flatMap((s) =>
+          (s.characteristics ?? []).map((c) => normalizeUuid(c.uuid)),
+        );
         const name = peripheral.advertisement?.localName ?? '';
         bleLog.debug(`Services: [${serviceUuids.join(', ')}]`);
 
-        const info: BleDeviceInfo = { localName: name, serviceUuids };
+        const info: BleDeviceInfo = { localName: name, serviceUuids, characteristicUuids };
         const found = adapters.find((a) => a.matches(info));
         if (!found) {
           throw new Error(

--- a/src/ble/handler-node-ble/scan.ts
+++ b/src/ble/handler-node-ble/scan.ts
@@ -45,6 +45,37 @@ import { broadcastScanNodeBle } from './broadcast.js';
 import { tagBleFailure, bleFailureKind } from '../failure-kind.js';
 import { probeLiveness, makeLivenessAdapter } from './liveness.js';
 
+/** Max time to wait for a BLE pairing/bonding handshake before giving up. */
+const BONDING_TIMEOUT_MS = 15_000;
+
+/**
+ * Best-effort BLE bonding for adapters that need an encrypted link (#168).
+ *
+ * Some SIG scales (e.g. Beurer BF720, whose User Data Service 0x181C protects
+ * its CCCDs) drop the link when notifications are enabled on an unbonded
+ * connection. Pairing here, after connect and before subscribing, establishes
+ * the encryption those characteristics require. A failure is logged and the
+ * read continues unbonded so adapters that do not strictly need it are not
+ * blocked; pairing may need a registered BlueZ agent on some setups.
+ */
+async function ensureBonded(device: Device): Promise<void> {
+  try {
+    const paired = (await device.isPaired()) as unknown as boolean;
+    if (paired) {
+      bleLog.debug('Device already bonded');
+      return;
+    }
+    bleLog.info('Adapter requires bonding; attempting BLE pairing...');
+    await withTimeout(device.pair(), BONDING_TIMEOUT_MS, 'BLE pairing timed out');
+    bleLog.info('BLE pairing succeeded');
+  } catch (err) {
+    bleLog.warn(
+      `BLE pairing failed (continuing unbonded): ${errMsg(err)}. ` +
+        'A BlueZ pairing agent may be required for scales that mandate an encrypted link.',
+    );
+  }
+}
+
 /**
  * Scan for a BLE scale, read weight + impedance, and compute body composition.
  * Uses node-ble (BlueZ D-Bus). Requires bluetoothd running on Linux.
@@ -301,6 +332,12 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
         'GATT service discovery timed out',
       );
     }
+    // Establish an encrypted link before enabling notifications for adapters
+    // whose SIG services protect their CCCDs (#168). Best-effort: see ensureBonded.
+    if (matchedAdapter.requiresBonding) {
+      await ensureBonded(device);
+    }
+
     const raw = await withTimeout(
       waitForRawReading(
         charMap,

--- a/src/ble/shared.ts
+++ b/src/ble/shared.ts
@@ -218,9 +218,23 @@ async function subscribeAndInit(
         bleLog.debug(`Skipping optional notify binding ${binding.uuid} (not present on device)`);
         continue;
       }
-      const unsub = await subscribeToChar(charMap, binding.uuid, onNotification);
-      unsubscribers.push(unsub);
-      subscribed += 1;
+      bleLog.debug(`Subscribing to ${binding.uuid} (${binding.type})...`);
+      try {
+        const unsub = await subscribeToChar(charMap, binding.uuid, onNotification);
+        unsubscribers.push(unsub);
+        subscribed += 1;
+      } catch (err) {
+        // Name the exact characteristic that failed and surface the underlying
+        // BlueZ error. Enabling notifications/indications on a SIG service that
+        // mandates an encrypted link (e.g. Beurer BF720 User Data 0x181C) fails
+        // here when the device is not bonded, which otherwise looks like an
+        // opaque mid-handshake disconnect. #168
+        throw new Error(
+          `Failed to enable notifications on ${binding.uuid} (${binding.type}): ${errMsg(err)}. ` +
+            'The scale may require a bonded/encrypted link.',
+          { cause: err },
+        );
+      }
     }
     bleLog.info(`Subscribed to ${subscribed} notification(s). Step on the scale.`);
     await startInit();

--- a/src/interfaces/scale-adapter.ts
+++ b/src/interfaces/scale-adapter.ts
@@ -139,6 +139,14 @@ export interface ScaleAdapter {
   readonly preferPassive?: boolean;
 
   /**
+   * True if this adapter's characteristics need a bonded/encrypted BLE link
+   * (e.g. the SIG User Data Service on the Beurer BF720). The node-ble handler
+   * attempts a best-effort BLE pairing after connect and before subscribing.
+   * Best-effort: a pairing failure is logged and the read proceeds unbonded.
+   */
+  readonly requiresBonding?: boolean;
+
+  /**
    * All characteristics this adapter needs (notify, write, read).
    * When defined, ble.ts subscribes to ALL 'notify' bindings and discovers all 'write'/'read' ones.
    * When absent, ble.ts falls back to the legacy charNotifyUuid + charWriteUuid pair.

--- a/src/scales/beurer-bf720.ts
+++ b/src/scales/beurer-bf720.ts
@@ -74,6 +74,9 @@ export class BeurerBf720Adapter implements ScaleAdapter {
   readonly normalizesWeight = true;
   readonly unlockCommand: number[] = [];
   readonly unlockIntervalMs = 0;
+  // SIG User Data Service (0x181C) CCCD writes need an encrypted link; the
+  // node-ble handler attempts a best-effort bond before subscribing. #168
+  readonly requiresBonding = true;
 
   readonly characteristics: CharacteristicBinding[] = [
     { uuid: CHR_WEIGHT_MEASUREMENT, type: 'notify' },

--- a/src/scales/index.ts
+++ b/src/scales/index.ts
@@ -19,6 +19,7 @@ import { InlifeScaleAdapter } from './inlife.js';
 import { DigooScaleAdapter } from './digoo.js';
 import { OneByoneAdapter, OneByoneNewAdapter } from './one-byone.js';
 import { ActiveEraAdapter } from './active-era.js';
+import { RobiS9Adapter } from './robi-s9.js';
 import { MgbAdapter } from './mgb.js';
 import { HoffenAdapter } from './hoffen.js';
 import { SenssunAdapter } from './senssun.js';
@@ -56,6 +57,10 @@ export const adapters: ScaleAdapter[] = [
   new OneByoneAdapter(),
   new OneByoneNewAdapter(),
   new ActiveEraAdapter(),
+  // Robi S9 (Lefu/Fitdays FFB0-new) before MGB: both use service 0xFFB0, but the
+  // Robi speaks a different protocol and is matched by name or its FFB3 result
+  // characteristic, so it must win before the generic MGB FFB0 fallback (#228).
+  new RobiS9Adapter(),
   new MgbAdapter(),
   new HoffenAdapter(),
   // Generic standard GATT adapter last — matches by service UUID / brand names

--- a/src/scales/qn-scale.ts
+++ b/src/scales/qn-scale.ts
@@ -74,6 +74,9 @@ const CHR_AE02 = uuid16(0xae02);
 // Service UUIDs for matching
 const SVC_T1 = 'ffe0';
 const SVC_T2 = 'fff0';
+// AE00 vendor service (newer QN firmware, e.g. Renpho ES-CS20M). Unique to QN
+// scales — never shared with the fff0 Inlife/1byone/Eufy cluster (#235).
+const SVC_AE00 = 'ae00';
 
 // SIG Body Composition / Weight Scale services. A 'renpho'-named device that
 // advertises these but NO QN vendor service is a Renpho ES-WBE28 (#191),
@@ -311,6 +314,18 @@ export class QnScaleAdapter implements ScaleAdapter {
 
     const name = (device.localName || '').toLowerCase();
     const uuids = (device.serviceUuids || []).map((u) => u.toLowerCase());
+
+    // AE00 is a QN-only service (Renpho ES-CS20M / newer firmware), never shared
+    // with the fff0 Inlife/1byone/Eufy cluster. It positively identifies a QN
+    // scale even when the device also carries a non-QN name and advertises fff0
+    // (e.g. GE CS 10 G "Fit Plus", #235), so check it before name/fallback logic.
+    // Compare both short 16-bit and full 128-bit forms, mirroring hasQnVendor.
+    const chars = (device.characteristicUuids || []).map((u) => u.toLowerCase());
+    const hasAe00 =
+      uuids.some((u) => u === SVC_AE00 || u === uuid16(0xae00)) ||
+      chars.some((u) => u === 'ae01' || u === 'ae02' || u === CHR_AE01 || u === CHR_AE02);
+    if (hasAe00) return true;
+
     const hasQnVendor = uuids.some(
       (u) => u === SVC_T1 || u === SVC_T2 || u === uuid16(0xffe0) || u === uuid16(0xfff0),
     );

--- a/src/scales/robi-s9.ts
+++ b/src/scales/robi-s9.ts
@@ -1,0 +1,149 @@
+import type {
+  BleDeviceInfo,
+  CharacteristicBinding,
+  ConnectionContext,
+  ScaleAdapter,
+  ScaleReading,
+  UserProfile,
+  BodyComposition,
+} from '../interfaces/scale-adapter.js';
+import { uuid16, buildPayload } from './body-comp-helpers.js';
+import { bleLog } from '../ble/types.js';
+
+// ─── Robi S9 (Lefu / Fitdays FFB0-new protocol) ─────────────────────────────
+
+const CHR_FFB1 = uuid16(0xffb1); // write (handshake)
+const CHR_FFB2 = uuid16(0xffb2); // notify (live frames)
+const CHR_FFB3 = uuid16(0xffb3); // indicate (final result) - see binding note
+
+/**
+ * Captured handshake (#228 HCI snoop, Fitdays app). Replayed verbatim: the
+ * 20-byte frames carry a trailer checksum whose algorithm is not cracked, plus a
+ * unix-timestamp + token in the B1 frames, so regenerating them is unsafe. The
+ * timestamp is therefore stale on replay; the scale appears to accept it for a
+ * weigh-in. Order = seq 00..0a as the app sent them.
+ */
+const HANDSHAKE: string[] = [
+  '000300b000000000000000000000000000000010',
+  '011000b16a2eefa9003c01aa1e55b20f1b581403',
+  '021000b16a2eefa9003c01aa1e55b20f1b581403',
+  '030600b201aa1e55b20000000000000000000002',
+  '040200bd09000000000000000000000000000006',
+  '051000b16a2eefa9003c01aa1e55b20f1b581403',
+  '061000b16a2eefa9003c01aa1e55b20f1b581403',
+  '070600b201aa1e55b20000000000000000000002',
+  '081000b16a2eefa9003c01aa1e55b20f1b581403',
+  '090300b001000000000000000000000000000011',
+  '0a0300b002000000000000000000000000000012',
+];
+
+/**
+ * PROVISIONAL weight divisor. The `01 2c` (=0x012C=300) field in the result
+ * frame is constant across both the HCI capture and the reporter's earlier nRF
+ * 77.4 kg session, so it is NOT the weight. The real weight offset + scale are
+ * unconfirmed from a single capture without a known-weight weigh-in; this is a
+ * best-effort guess and is expected to be corrected after a DEBUG retest (#228).
+ */
+const WEIGHT_DIV = 10;
+
+/**
+ * Adapter for the Robi S9 smart scale (Fitdays app, Lefu-style FFB0 protocol).
+ *
+ * Shares service 0xFFB0 with the openScale MGB family but speaks a different
+ * 20-byte frame protocol (`[seq][len][00][type][payload][trailer]`): the phone
+ * runs a B0/B1/B2/BD handshake on FFB1, the scale streams A2 live frames on FFB2
+ * (notify) and the final result as an A3 frame on FFB3 (indicate). The MGB
+ * adapter sent the wrong init and never subscribed FFB3, so the scale dropped
+ * the link before any reading (#228).
+ *
+ * Decoded from the reporter's HCI snoop. The handshake (the fix for the
+ * disconnect) is replayed verbatim; the weight scale is provisional and the
+ * scrambled body composition is not decoded (BIA is used instead).
+ */
+export class RobiS9Adapter implements ScaleAdapter {
+  readonly name = 'Robi S9';
+  // Legacy single-char fields (unused in multi-char mode).
+  readonly charNotifyUuid = CHR_FFB2;
+  readonly charWriteUuid = CHR_FFB1;
+  readonly normalizesWeight = true;
+  readonly unlockCommand: number[] = [];
+  readonly unlockIntervalMs = 0;
+
+  // FFB3 is physically an indicate characteristic, but the shared subscribe loop
+  // only auto-subscribes bindings of type 'notify'. node-ble/noble enable
+  // indications transparently from the char's real properties, so declare it
+  // 'notify' to get it subscribed (same pattern as BeurerBf720).
+  readonly characteristics: CharacteristicBinding[] = [
+    { uuid: CHR_FFB1, type: 'write' },
+    { uuid: CHR_FFB2, type: 'notify' },
+    { uuid: CHR_FFB3, type: 'notify' },
+  ];
+
+  private cachedWeight = 0;
+  private cachedImpedance = 0;
+  private final = false;
+
+  matches(device: BleDeviceInfo): boolean {
+    const name = (device.localName || '').toLowerCase();
+    // Swan/Icomon/YG are the openScale MGB protocol, not this one.
+    if (name.startsWith('swan') || name === 'icomon' || name === 'yg') return false;
+    if (name.includes('robi')) return true;
+
+    // Nameless: require the FFB0 vendor service AND the FFB3 result characteristic
+    // (post-discovery) to disambiguate from MGB scales, which expose FFB1/FFB2
+    // but not the FFB3 indicate result char.
+    const uuids = (device.serviceUuids || []).map((u) => u.toLowerCase());
+    const hasFfb0 = uuids.some((u) => u === 'ffb0' || u === uuid16(0xffb0));
+    const chars = (device.characteristicUuids || []).map((u) => u.toLowerCase());
+    const hasFfb3 = chars.some((u) => u === 'ffb3' || u === CHR_FFB3);
+    return hasFfb0 && hasFfb3;
+  }
+
+  async onConnected(ctx: ConnectionContext): Promise<void> {
+    this.cachedWeight = 0;
+    this.cachedImpedance = 0;
+    this.final = false;
+    for (const hex of HANDSHAKE) {
+      await ctx.write(CHR_FFB1, Buffer.from(hex, 'hex'), true);
+      await new Promise((r) => setTimeout(r, 150));
+    }
+    bleLog.debug('Robi S9: handshake sent');
+  }
+
+  parseCharNotification(_charUuid: string, data: Buffer): ScaleReading | null {
+    if (data.length < 11 || data[2] !== 0x00) return null;
+    bleLog.debug(`Robi S9 frame: ${data.toString('hex')}`);
+
+    // Final result arrives as the A3 frame on FFB3. A2 (live) frames use a
+    // different alignment and are treated as progress only. A3 layout:
+    //   [..][a3][00][01 2c const][weight u16 BE][01 f4 impedance u16 BE]
+    if (data[3] === 0xa3) {
+      const w = data.readUInt16BE(7) / WEIGHT_DIV;
+      if (w > 0 && Number.isFinite(w)) {
+        this.cachedWeight = w;
+        this.cachedImpedance = data.readUInt16BE(9);
+        this.final = true;
+      }
+    }
+
+    if (this.final && this.cachedWeight > 0) {
+      return { weight: this.cachedWeight, impedance: this.cachedImpedance };
+    }
+    return null;
+  }
+
+  /** Legacy single-char path (unused in multi-char mode, kept for the interface). */
+  parseNotification(data: Buffer): ScaleReading | null {
+    return this.parseCharNotification(CHR_FFB2, data);
+  }
+
+  isComplete(reading: ScaleReading): boolean {
+    return reading.weight > 0 && this.final;
+  }
+
+  computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {
+    // Body composition via BIA from weight + impedance; the vendor's own
+    // body-comp frames are scrambled and not decoded.
+    return buildPayload(reading.weight, reading.impedance, {}, profile);
+  }
+}

--- a/tests/ble/shared.test.ts
+++ b/tests/ble/shared.test.ts
@@ -576,6 +576,27 @@ describe('waitForReading() — multi-char mode (characteristics[])', () => {
       'No notify characteristics',
     );
   });
+
+  // #168: a CCCD enable that fails (e.g. unbonded BF720 SIG service) must surface
+  // the exact characteristic + underlying error, not an opaque disconnect.
+  it('names the characteristic when enabling notifications fails', async () => {
+    const failingChar = createMockChar();
+    failingChar.subscribe = vi.fn(async () => {
+      throw new Error('org.bluez.Error.NotAuthorized');
+    });
+    const device = createMockDevice();
+    const { charMap } = createCharMap([[NOTIFY_UUID, failingChar]]);
+
+    const adapter = createLegacyAdapter({
+      characteristics: [{ uuid: NOTIFY_UUID, type: 'notify' }],
+      onConnected: vi.fn(),
+    });
+
+    const promise = waitForReading(charMap, device, adapter, PROFILE, '');
+    await expect(promise).rejects.toThrow('Failed to enable notifications on');
+    await expect(promise).rejects.toThrow(NOTIFY_UUID);
+    await expect(promise).rejects.toThrow('org.bluez.Error.NotAuthorized');
+  });
 });
 
 // ─── waitForRawReading tests ────────────────────────────────────────────────

--- a/tests/scales/adapter-resolution.test.ts
+++ b/tests/scales/adapter-resolution.test.ts
@@ -42,3 +42,45 @@ describe('adapter resolution (#177 0xFFF0 collision)', () => {
     expect(matched?.name).toBe('Beurer BF720/BF105');
   });
 });
+
+// Regression for #235: a GE CS 10 G ("Fit Plus") advertises a non-QN name and
+// BOTH the fff0 cluster (fff0/fff1/fff2) and the QN-only AE00 cluster
+// (ae00/ae01/ae02). Before the fix the QN adapter ignored AE00 and rejected the
+// named device, so the registry-later Inlife adapter grabbed it via its bare
+// fff0 fallback and drove the wrong fff1/fff2 protocol. AE00 must resolve to QN.
+describe('adapter resolution (#235 fff0+ae00 QN/Inlife collision)', () => {
+  it('resolves a "Fit Plus" (name + fff0 + ae00 service) to "QN Scale"', () => {
+    const info: BleDeviceInfo = {
+      localName: 'Fit Plus',
+      serviceUuids: [
+        uuid16(0x1800),
+        uuid16(0x180f),
+        uuid16(0x180a),
+        uuid16(0xfff0),
+        uuid16(0xae00),
+      ],
+    };
+    const matched = adapters.find((a) => a.matches(info));
+    expect(matched?.name).toBe('QN Scale');
+  });
+
+  it('resolves a "Fit Plus" via ae01/ae02 characteristics (no top-level ae00 service)', () => {
+    const info: BleDeviceInfo = {
+      localName: 'Fit Plus',
+      serviceUuids: [uuid16(0xfff0)],
+      characteristicUuids: [uuid16(0xfff1), uuid16(0xfff2), uuid16(0xae01), uuid16(0xae02)],
+    };
+    const matched = adapters.find((a) => a.matches(info));
+    expect(matched?.name).toBe('QN Scale');
+  });
+
+  it('does not regress a real Inlife device without AE00 -> "Inlife"', () => {
+    const info: BleDeviceInfo = {
+      localName: '000fatscale01',
+      serviceUuids: [uuid16(0xfff0)],
+      characteristicUuids: [uuid16(0xfff1), uuid16(0xfff2)],
+    };
+    const matched = adapters.find((a) => a.matches(info));
+    expect(matched?.name).toBe('Inlife');
+  });
+});

--- a/tests/scales/beurer-bf720.test.ts
+++ b/tests/scales/beurer-bf720.test.ts
@@ -35,6 +35,12 @@ function makeCtx(over: Partial<ConnectionContext> = {}): ConnectionContext {
 }
 
 describe('BeurerBf720Adapter', () => {
+  // #168: the SIG User Data Service protects its CCCDs, so the node-ble handler
+  // must attempt a bond before subscribing. The flag drives that path.
+  it('requires bonding', () => {
+    expect(makeAdapter().requiresBonding).toBe(true);
+  });
+
   describe('matches()', () => {
     it.each(['BF720', 'beurer bf105', 'My BF720 Scale'])('matches name "%s"', (name) => {
       expect(makeAdapter().matches(mockPeripheral(name))).toBe(true);

--- a/tests/scales/registry-collision.test.ts
+++ b/tests/scales/registry-collision.test.ts
@@ -58,6 +58,7 @@ const FIXTURES: Record<string, BleDeviceInfo> = {
   },
   '1byone Scale (new)': { localName: '1byone scale', serviceUuids: [] },
   'Active Era BS-06': { localName: 'AE BS-06', serviceUuids: [] },
+  'Robi S9': { localName: 'Robi S9', serviceUuids: [] },
   'MGB (Swan/Icomon/YG)': { localName: 'icomon', serviceUuids: [] },
   'Hoffen BS-8107': { localName: 'hoffen bs-8107', serviceUuids: [] },
   // Generic fallback: a non-excluded name + bare Weight Scale Service (0x181D).

--- a/tests/scales/robi-s9.test.ts
+++ b/tests/scales/robi-s9.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+import { RobiS9Adapter } from '../../src/scales/robi-s9.js';
+import { adapters } from '../../src/scales/index.js';
+import { uuid16 } from '../../src/scales/body-comp-helpers.js';
+import type { ConnectionContext } from '../../src/interfaces/scale-adapter.js';
+import { mockPeripheral, defaultProfile } from '../helpers/scale-test-utils.js';
+
+function makeAdapter() {
+  return new RobiS9Adapter();
+}
+
+describe('RobiS9Adapter', () => {
+  describe('matches() and registry resolution (#228)', () => {
+    it('matches a "Robi S9" name', () => {
+      expect(makeAdapter().matches(mockPeripheral('Robi S9'))).toBe(true);
+    });
+
+    it('resolves "Robi S9" to the Robi adapter, not MGB', () => {
+      const matched = adapters.find((a) => a.matches(mockPeripheral('Robi S9')));
+      expect(matched?.name).toBe('Robi S9');
+    });
+
+    it('matches a nameless device with FFB0 + FFB3 characteristic', () => {
+      const info = mockPeripheral('', [uuid16(0xffb0)], undefined, [
+        uuid16(0xffb1),
+        uuid16(0xffb2),
+        uuid16(0xffb3),
+      ]);
+      expect(makeAdapter().matches(info)).toBe(true);
+    });
+
+    it('does not match an MGB scale (Swan/Icomon/YG)', () => {
+      expect(makeAdapter().matches(mockPeripheral('swan123'))).toBe(false);
+      expect(makeAdapter().matches(mockPeripheral('icomon'))).toBe(false);
+      const mgb = adapters.find((a) => a.matches(mockPeripheral('swan123')));
+      expect(mgb?.name).toBe('MGB (Swan/Icomon/YG)');
+    });
+
+    it('does not steal a nameless FFB0 device without the FFB3 result char', () => {
+      const info = mockPeripheral('', [uuid16(0xffb0)], undefined, [
+        uuid16(0xffb1),
+        uuid16(0xffb2),
+      ]);
+      expect(makeAdapter().matches(info)).toBe(false);
+    });
+  });
+
+  describe('onConnected() handshake', () => {
+    it('replays the captured FFB1 handshake in order (seq 00..0a)', async () => {
+      const writes: Buffer[] = [];
+      const ctx = {
+        profile: defaultProfile(),
+        deviceAddress: 'AA',
+        availableChars: new Set<string>(),
+        write: vi.fn(async (_uuid: string, data: number[] | Buffer) => {
+          writes.push(Buffer.isBuffer(data) ? data : Buffer.from(data));
+        }),
+        read: vi.fn(),
+        subscribe: vi.fn(),
+      } as unknown as ConnectionContext;
+
+      await makeAdapter().onConnected(ctx);
+
+      expect(writes).toHaveLength(11);
+      // First frame is the B0 hello, last is B0 sub-code 02; seq increments 00..0a.
+      expect(writes[0].toString('hex')).toBe('000300b000000000000000000000000000000010');
+      writes.forEach((w, i) => expect(w[0]).toBe(i));
+    });
+  });
+
+  describe('parseCharNotification()', () => {
+    it('extracts a reading from the A3 final frame', () => {
+      const adapter = makeAdapter();
+      const a3 = Buffer.from('030800a300012c007601f400000000000000001b', 'hex');
+      const reading = adapter.parseCharNotification(uuid16(0xffb3), a3);
+      expect(reading).not.toBeNull();
+      expect(reading!.weight).toBeGreaterThan(0);
+      expect(reading!.impedance).toBe(0x01f4); // 500
+      expect(adapter.isComplete(reading!)).toBe(true);
+    });
+
+    it('ignores A2 live frames (no final result yet)', () => {
+      const adapter = makeAdapter();
+      const a2 = Buffer.from('1d0700a20400012c000000000000000000000013', 'hex');
+      expect(adapter.parseCharNotification(uuid16(0xffb2), a2)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Promotes dev to main for release. Contents (4):

- fix(ble): match QN scales advertising AE00 alongside fff0 (#235)
- fix(ble): attempt bonding and name failed CCCD subscribe for Beurer BF720 (#168)
- fix(firmware): ease GATT connect on no-PSRAM ESP32 + heap diagnostic (#139)
- feat(ble): add Robi S9 adapter (Lefu/Fitdays FFB0-new protocol) (#228)

Merge-commit strategy to preserve conventional commits for release-please.