### PR TITLE
feat(ble): add Renpho R-MSC04 scale adapter and tests

### DIFF
--- a/src/scales/index.ts
+++ b/src/scales/index.ts
@@ -2,6 +2,7 @@ import type { ScaleAdapter } from '../interfaces/scale-adapter.js';
 import { QnScaleAdapter } from './qn-scale.js';
 import { RenphoScaleAdapter } from './renpho.js';
 import { RenphoEs26bbAdapter } from './renpho-es26bb.js';
+import { RenphoMsc04Adapter } from './renpho-msc04.js';
 import { MiScale2Adapter } from './mi-scale-2.js';
 import { XiaomiS800Adapter } from './xiaomi-s800.js';
 import { BeurerBf720Adapter } from './beurer-bf720.js';
@@ -39,6 +40,7 @@ export const adapters: ScaleAdapter[] = [
   new QnScaleAdapter(),
   new RenphoScaleAdapter(),
   new RenphoEs26bbAdapter(),
+  new RenphoMsc04Adapter(),
   // Beurer SIG scales (BF720/BF105) advertise/expose Body Composition 0x181B
   // and would otherwise be grabbed by the Mi Scale 2 adapter, so match them
   // first (by BF720/BF105 name or Beurer company id 0x0611).

--- a/src/scales/renpho-msc04.ts
+++ b/src/scales/renpho-msc04.ts
@@ -1,0 +1,256 @@
+import type {
+  BleDeviceInfo,
+  ConnectionContext,
+  ScaleAdapterCore,
+  GattWiring,
+  ScaleReading,
+  UserProfile,
+  BodyComposition,
+} from '../interfaces/scale-adapter.js';
+import { uuid16, buildPayload } from './body-comp-helpers.js';
+import type { MatchDescriptor } from './match-descriptor.js';
+import { bleLog } from '../ble/types.js';
+
+// Service 0x1A10 — custom Renpho scale service (shared with ES-26BB)
+const CHR_CONTROL = uuid16(0x2a11); // write  — commands to scale
+const CHR_STATUS = uuid16(0x2a10); // notify — status / progress
+const CHR_RESULTS = uuid16(0x2a12); // indicate — final BIA measurement
+
+// 55-AA frame magic
+const MAGIC0 = 0x55;
+const MAGIC1 = 0xaa;
+
+// Request a measurement session.
+// Identical to ES-26BB start command: 55 AA 90 00 04 01 00 00 00 94
+const START_CMD = [0x55, 0xaa, 0x90, 0x00, 0x04, 0x01, 0x00, 0x00, 0x00, 0x94];
+
+// Ack a cached offline measurement so the scale stops replaying it on every
+// connect.  Last byte = sum(prev) & 0xFF = (55+AA+95+00+01+01) & FF = 96.
+const OFFLINE_ACK = [0x55, 0xaa, 0x95, 0x00, 0x01, 0x01, 0x96];
+
+// Command bytes on the indication characteristic
+const CMD_MEAS_SHORT = 0x25; // 36-byte payload (post-composition result)
+const CMD_MEAS_LONG = 0x26; // 40-byte payload (pre-composition + result)
+
+/**
+ * Extended scale reading that carries the pre-computed BIA metrics the
+ * R-MSC04 transmits in the indication frame.  Stored on the adapter instance
+ * between parseNotification() and computeMetrics().
+ */
+interface ExtendedBia {
+  bodyFatPct: number;
+  bmi: number;
+  skelMuscleMassKg: number;
+  boneMassKg: number;
+  visceralFat: number;
+}
+
+function isChecksumValid(data: Buffer): boolean {
+  if (data.length < 2) return false;
+  let sum = 0;
+  for (let i = 0; i < data.length - 1; i++) sum = (sum + data[i]) & 0xff;
+  return sum === data[data.length - 1];
+}
+
+/**
+ * Adapter for the Renpho R-MSC04 body composition scale.
+ *
+ * ─── GATT layout (service 0x1A10) ───────────────────────────────────────────
+ *   0x2A11  write    — send 55-AA commands (start, offline ack)
+ *   0x2A10  notify   — status / progress events (not parsed here)
+ *   0x2A12  indicate — final BIA measurement frame (55-AA cmd 0x25 / 0x26)
+ *
+ * ─── Session flow ───────────────────────────────────────────────────────────
+ *   1. Write START_CMD to 0x2A11 after connect.
+ *   2. Scale streams status notifications on 0x2A10 (ignored).
+ *   3. Scale sends final measurement indication on 0x2A12.
+ *   4. Ack with OFFLINE_ACK so cached frames are cleared from scale memory.
+ *
+ * ─── Measurement frame layout (55-AA frame on 0x2A12) ──────────────────────
+ *   [0-1]  magic: 55 AA
+ *   [2]    cmd:   0x25 (short) | 0x26 (long, 4 extra bytes before weight)
+ *   [3]    sub:   0x00
+ *   [4]    payload_len: 0x24 (36) | 0x28 (40)
+ *   [5 .. 5+payload_len-1]  payload:
+ *     [0]        user_id
+ *     [1-2]      sequence (LE uint16)
+ *     [3]        flags/padding (cmd 0x25)  ← body_start = 4
+ *     [3-6]      extra fields  (cmd 0x26)  ← body_start = 8
+ *     body[0-1]  weight           BE uint16 / 100   → kg
+ *     body[2-3]  padding          0x0A 0x00
+ *     body[4-5]  unknown_A        LE uint16
+ *     body[6-7]  unknown_B        LE uint16
+ *     body[8-9]  BIA impedance    LE uint16 / 10    → Ω  (~181 Ω typical)
+ *     body[10-11] body fat %      LE uint16 / 100   → %
+ *     body[12-13] unknown_C       LE uint16
+ *     body[14-15] BMI             LE uint16 / 100
+ *     body[16-17] unknown_D       LE uint16
+ *     body[18-19] unknown_E       LE uint16
+ *     body[20-21] unknown_F       LE uint16
+ *     body[22-23] skeletal muscle LE uint16 / 10    → kg
+ *     body[24-25] bone mass       BE uint16 / 100   → kg
+ *     body[26..]  remaining (not yet decoded)
+ *     payload[last]  visceral fat rating (raw byte)
+ *   [5+payload_len]  checksum  (sum of all preceding bytes & 0xFF)
+ *
+ * Verified against two captured weigh-in sessions (macOS HCI capture):
+ *   cmd 0x26: weight=78.80 kg  fat=19.88%  muscle=44.0 kg  bone=1.94 kg  visceral=5
+ *   cmd 0x25: weight=78.05 kg  fat=19.67%  muscle=42.8 kg  bone=1.90 kg  visceral=5
+ */
+export class RenphoMsc04Adapter implements ScaleAdapterCore, GattWiring {
+  readonly name = 'Renpho R-MSC04';
+  readonly match: MatchDescriptor = {
+    // Sit between ES-26BB (230) and the generic Renpho ES-WBE28 (240).
+    priority: 235,
+    names: { exact: ['r-msc04'] },
+    manufacturerId: 0x1a10,
+    custom: true,
+  };
+  readonly charNotifyUuid = CHR_RESULTS;
+  readonly charWriteUuid = CHR_CONTROL;
+  readonly normalizesWeight = true;
+
+  private ctx: ConnectionContext | null = null;
+  private _bia: ExtendedBia | null = null;
+
+  matches(device: BleDeviceInfo): boolean {
+    const name = (device.localName ?? '').toLowerCase();
+    if (name === 'r-msc04') return true;
+    // Secondary match: Renpho company ID 0x1A10 in manufacturer data
+    if (device.manufacturerData?.id === 0x1a10) return true;
+    return false;
+  }
+
+  async onConnected(ctx: ConnectionContext): Promise<void> {
+    this.ctx = ctx;
+
+    // Subscribe to the status notify char (best-effort — non-fatal if absent).
+    const statusNorm = CHR_STATUS.replace(/-/g, '');
+    if (ctx.availableChars.has(statusNorm)) {
+      try {
+        await ctx.subscribe(CHR_STATUS);
+      } catch (e) {
+        bleLog.debug(
+          `R-MSC04: status char subscribe failed: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+    }
+
+    // Kick off a measurement session.
+    try {
+      await ctx.write(CHR_CONTROL, START_CMD, false);
+      bleLog.debug(
+        `R-MSC04: start cmd sent [${START_CMD.map((b) => b.toString(16).padStart(2, '0')).join(' ')}]`,
+      );
+    } catch (e) {
+      bleLog.warn(`R-MSC04: start cmd failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  /**
+   * Parse a 55-AA indication frame from the R-MSC04 (0x2A12).
+   *
+   * Only cmd 0x25 and 0x26 measurement frames are returned as readings; all
+   * other 55-AA commands (status, ack confirmations, etc.) return null.
+   * After a successful parse, an offline-ack is fired so the scale clears
+   * the cached frame and does not replay it on the next connect.
+   */
+  parseNotification(data: Buffer): ScaleReading | null {
+    // Minimum: 55 AA cmd sub len  + at least 26 body bytes + checksum
+    if (data.length < 33) return null;
+    if (data[0] !== MAGIC0 || data[1] !== MAGIC1) return null;
+
+    const cmd = data[2];
+    if (cmd !== CMD_MEAS_SHORT && cmd !== CMD_MEAS_LONG) return null;
+
+    const payloadLen = data[4];
+    const expectedTotal = 5 + payloadLen + 1;
+    if (data.length < expectedTotal) {
+      bleLog.debug(`R-MSC04: frame too short (got=${data.length} want=${expectedTotal})`);
+      return null;
+    }
+
+    const frame = data.slice(0, expectedTotal);
+    if (!isChecksumValid(frame)) {
+      bleLog.debug('R-MSC04: dropping frame with bad checksum');
+      return null;
+    }
+
+    const payload = data.slice(5, 5 + payloadLen);
+    // body_start: 4 for cmd 0x25, 8 for cmd 0x26 (4 extra header bytes)
+    const bodyStart = cmd === CMD_MEAS_LONG ? 8 : 4;
+
+    if (payload.length < bodyStart + 26) {
+      bleLog.debug('R-MSC04: payload too short for body composition fields');
+      return null;
+    }
+
+    const weightRaw = payload.readUInt16BE(bodyStart + 0);
+    const weight = weightRaw / 100;
+    if (weight <= 0 || !Number.isFinite(weight)) return null;
+
+    const impedance = payload.readUInt16LE(bodyStart + 8) / 10; // Ω
+    const bodyFatPct = payload.readUInt16LE(bodyStart + 10) / 100;
+    const bmi = payload.readUInt16LE(bodyStart + 14) / 100;
+    const skelMuscleMassKg = payload.readUInt16LE(bodyStart + 22) / 10;
+    const boneMassKg = payload.readUInt16BE(bodyStart + 24) / 100;
+    const visceralFat = payload[payload.length - 1];
+
+    bleLog.debug(
+      `R-MSC04: weight=${weight}kg fat=${bodyFatPct}% bmi=${bmi} ` +
+        `muscle=${skelMuscleMassKg}kg bone=${boneMassKg}kg ` +
+        `visceral=${visceralFat} Z=${impedance}Ω`,
+    );
+
+    this._bia = { bodyFatPct, bmi, skelMuscleMassKg, boneMassKg, visceralFat };
+
+    // Fire-and-forget ack so cached frames are cleared from scale memory.
+    void this.sendOfflineAck();
+
+    return { weight, impedance };
+  }
+
+  isComplete(reading: ScaleReading): boolean {
+    return reading.weight > 10 && reading.impedance > 0;
+  }
+
+  /**
+   * Build the full BodyComposition output.
+   *
+   * Pre-computed BIA values from the scale (fat%, muscle mass, bone mass,
+   * visceral fat) are passed directly to buildPayload() so they override the
+   * generic BIA estimation formulas.  The scale's on-device calculation uses
+   * the user profile stored in the Renpho app; the HA user profile is used
+   * only for the derived fields that the scale does not transmit (BMR,
+   * metabolic age, physique rating).
+   */
+  computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {
+    const bia = this._bia;
+    return buildPayload(
+      reading.weight,
+      reading.impedance,
+      {
+        fat: bia?.bodyFatPct,
+        bone: bia?.boneMassKg,
+        // buildPayload expects muscle% of body weight; scale gives absolute kg
+        muscle: bia != null ? (bia.skelMuscleMassKg / reading.weight) * 100 : undefined,
+        visceralFat: bia?.visceralFat,
+      },
+      profile,
+    );
+  }
+
+  private async sendOfflineAck(): Promise<void> {
+    const ctx = this.ctx;
+    if (!ctx) return;
+    try {
+      await ctx.write(CHR_CONTROL, OFFLINE_ACK, true);
+      bleLog.debug('R-MSC04: offline ack sent');
+    } catch (e) {
+      bleLog.warn(
+        `R-MSC04: offline ack failed (scale may replay cached frame on next connect): ` +
+          `${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+  }
+}

--- a/tests/scales/registry-collision.test.ts
+++ b/tests/scales/registry-collision.test.ts
@@ -34,6 +34,7 @@ const FIXTURES: Record<string, BleDeviceInfo> = {
   // vendor service, so QN now defers and it resolves to RenphoScaleAdapter.
   'Renpho ES-WBE28': { localName: 'Renpho Body Scale', serviceUuids: ['181b', '181d'] },
   'Renpho ES-26BB': { localName: 'es-26bb-b', serviceUuids: [] },
+  'Renpho R-MSC04': { localName: 'R-MSC04', serviceUuids: [] },
   'Beurer BF720/BF105': { localName: 'BF720', serviceUuids: [] },
   'Xiaomi Mi Scale 2': { localName: 'MIBFS', serviceUuids: [] },
   'Xiaomi Mijia Scale S800': { localName: 'Mijia Scale S800 A1AB', serviceUuids: [] },

--- a/tests/scales/renpho-msc04.test.ts
+++ b/tests/scales/renpho-msc04.test.ts
@@ -1,0 +1,375 @@
+import { describe, it, expect, vi } from 'vitest';
+import { RenphoMsc04Adapter } from '../../src/scales/renpho-msc04.js';
+import type { ConnectionContext } from '../../src/interfaces/scale-adapter.js';
+import {
+  mockPeripheral,
+  defaultProfile,
+  assertPayloadRanges,
+} from '../helpers/scale-test-utils.js';
+
+function makeAdapter() {
+  return new RenphoMsc04Adapter();
+}
+
+/** Build a well-formed 55-AA checksum (sum of all bytes before last & 0xFF). */
+function applyChecksum(buf: Buffer): Buffer {
+  let sum = 0;
+  for (let i = 0; i < buf.length - 1; i++) sum = (sum + buf[i]) & 0xff;
+  buf[buf.length - 1] = sum;
+  return buf;
+}
+
+/**
+ * Build a valid R-MSC04 measurement frame.
+ *
+ * @param weightX100  weight × 100 (e.g. 7805 for 78.05 kg)
+ * @param impedanceX10 raw BIA impedance × 10 (e.g. 1813 for 181.3 Ω)
+ * @param cmd  0x25 (short) or 0x26 (long)
+ * @param overrides  optional per-field overrides (LE uint16 × 100 for pct fields)
+ */
+function makeMeasFrame(
+  weightX100: number,
+  impedanceX10: number,
+  cmd = 0x25,
+  overrides: {
+    bodyFatX100?: number;
+    bmiX100?: number;
+    skelMuscleX10?: number; // LE uint16
+    boneMassX100?: number; // BE uint16
+    visceralFat?: number;
+  } = {},
+): Buffer {
+  const bodyStart = cmd === 0x26 ? 8 : 4;
+  const payloadLen = cmd === 0x26 ? 40 : 36;
+
+  const payload = Buffer.alloc(payloadLen, 0);
+
+  // user_id = 1, seq = 0
+  payload[0] = 0x01;
+
+  // body fields
+  payload.writeUInt16BE(weightX100, bodyStart + 0);
+  payload[bodyStart + 2] = 0x0a; // padding
+  payload.writeUInt16LE(impedanceX10, bodyStart + 8);
+  payload.writeUInt16LE(overrides.bodyFatX100 ?? 1967, bodyStart + 10);
+  payload.writeUInt16LE(overrides.bmiX100 ?? 2406, bodyStart + 14);
+  payload.writeUInt16LE(overrides.skelMuscleX10 ?? 428, bodyStart + 22);
+  payload.writeUInt16BE(overrides.boneMassX100 ?? 190, bodyStart + 24);
+  payload[payloadLen - 1] = overrides.visceralFat ?? 5;
+
+  // Full frame: 55 AA cmd 00 payloadLen payload checksum
+  const frame = Buffer.alloc(5 + payloadLen + 1);
+  frame[0] = 0x55;
+  frame[1] = 0xaa;
+  frame[2] = cmd;
+  frame[3] = 0x00;
+  frame[4] = payloadLen;
+  payload.copy(frame, 5);
+  return applyChecksum(frame);
+}
+
+function makeMockCtx(): { ctx: ConnectionContext; write: ReturnType<typeof vi.fn> } {
+  const write = vi.fn().mockResolvedValue(undefined);
+  return {
+    ctx: {
+      write,
+      read: vi.fn().mockResolvedValue(Buffer.alloc(0)),
+      subscribe: vi.fn().mockResolvedValue(undefined),
+      profile: defaultProfile(),
+      deviceAddress: '60:30:F2:73:6A:7B',
+      availableChars: new Set<string>(),
+    } satisfies ConnectionContext,
+    write,
+  };
+}
+
+// Real captured bytes from R-MSC04 HCI trace (session 5, cmd 0x25):
+// weight=78.05 kg, fat=19.67%, muscle=42.8 kg, bone=1.90 kg, visceral=5
+const REAL_FRAME_S5 = Buffer.from(
+  '55aa2500240511000 01e7d0a0085 0a0b0a1507af077800660903090106d906ac0100be010b01ce00059d'.replace(
+    /\s/g,
+    '',
+  ),
+  'hex',
+);
+
+// Real captured bytes (session 1, cmd 0x26):
+// weight=78.80 kg, fat=19.88%, muscle=44.0 kg, bone=1.94 kg, visceral=5
+const REAL_FRAME_S1 = Buffer.from(
+  '55aa260028011100188 8c600001ec80a0084 09eb0a1207c407860066 08ec08fd06e206b80100c2010d01cb000548'.replace(
+    /\s/g,
+    '',
+  ),
+  'hex',
+);
+
+describe('RenphoMsc04Adapter', () => {
+  // ─── matches() ────────────────────────────────────────────────────────────
+
+  describe('matches()', () => {
+    it('matches exact name "r-msc04" (lower)', () => {
+      expect(makeAdapter().matches(mockPeripheral('r-msc04'))).toBe(true);
+    });
+
+    it('matches case-insensitive name', () => {
+      expect(makeAdapter().matches(mockPeripheral('R-MSC04'))).toBe(true);
+    });
+
+    it('matches by manufacturer id 0x1A10 when no name', () => {
+      expect(
+        makeAdapter().matches({
+          localName: '',
+          serviceUuids: [],
+          manufacturerData: { id: 0x1a10, data: Buffer.alloc(0) },
+        }),
+      ).toBe(true);
+    });
+
+    it('does not match unrelated name', () => {
+      expect(makeAdapter().matches(mockPeripheral('es-26bb-b'))).toBe(false);
+    });
+
+    it('does not match wrong manufacturer id', () => {
+      expect(
+        makeAdapter().matches({
+          localName: '',
+          serviceUuids: [],
+          manufacturerData: { id: 0x004c, data: Buffer.alloc(0) },
+        }),
+      ).toBe(false);
+    });
+  });
+
+  // ─── parseNotification() — synthetic frames ────────────────────────────────
+
+  describe('parseNotification() — cmd 0x25 (short form)', () => {
+    it('parses weight and impedance', () => {
+      const frame = makeMeasFrame(7805, 1813, 0x25);
+      const r = makeAdapter().parseNotification(frame);
+      expect(r).not.toBeNull();
+      expect(r!.weight).toBeCloseTo(78.05, 2);
+      expect(r!.impedance).toBeCloseTo(181.3, 1);
+    });
+
+    it('returns null for invalid checksum', () => {
+      const frame = makeMeasFrame(7805, 1813, 0x25);
+      frame[frame.length - 1] ^= 0xff; // corrupt
+      expect(makeAdapter().parseNotification(frame)).toBeNull();
+    });
+
+    it('returns null when weight is zero', () => {
+      expect(makeAdapter().parseNotification(makeMeasFrame(0, 1813))).toBeNull();
+    });
+
+    it('returns null for too-short buffer', () => {
+      expect(makeAdapter().parseNotification(Buffer.alloc(10))).toBeNull();
+    });
+
+    it('returns null for wrong magic bytes', () => {
+      const frame = makeMeasFrame(7805, 1813);
+      frame[0] = 0x00;
+      expect(makeAdapter().parseNotification(frame)).toBeNull();
+    });
+
+    it('returns null for unrelated 55-AA command (e.g. status 0x90)', () => {
+      const buf = Buffer.alloc(12, 0);
+      buf[0] = 0x55;
+      buf[1] = 0xaa;
+      buf[2] = 0x90; // start response, not a measurement
+      buf[4] = 6;
+      applyChecksum(buf);
+      expect(makeAdapter().parseNotification(buf)).toBeNull();
+    });
+  });
+
+  describe('parseNotification() — cmd 0x26 (long form)', () => {
+    it('parses weight and impedance', () => {
+      const frame = makeMeasFrame(7880, 1810, 0x26);
+      const r = makeAdapter().parseNotification(frame);
+      expect(r).not.toBeNull();
+      expect(r!.weight).toBeCloseTo(78.8, 2);
+      expect(r!.impedance).toBeCloseTo(181.0, 1);
+    });
+  });
+
+  // ─── real captured frames ─────────────────────────────────────────────────
+
+  describe('parseNotification() — real captured frames', () => {
+    it('decodes session-5 frame (cmd 0x25, 78.05 kg)', () => {
+      const r = makeAdapter().parseNotification(REAL_FRAME_S5);
+      expect(r).not.toBeNull();
+      expect(r!.weight).toBeCloseTo(78.05, 2);
+      expect(r!.impedance).toBeCloseTo(181.3, 1);
+    });
+
+    it('decodes session-1 frame (cmd 0x26, 78.80 kg)', () => {
+      const r = makeAdapter().parseNotification(REAL_FRAME_S1);
+      expect(r).not.toBeNull();
+      expect(r!.weight).toBeCloseTo(78.8, 2);
+      expect(r!.impedance).toBeCloseTo(181.0, 1);
+    });
+  });
+
+  // ─── offline ack ─────────────────────────────────────────────────────────
+
+  describe('offline ack', () => {
+    it('sends ack after parsing a measurement frame', async () => {
+      const adapter = makeAdapter();
+      const { ctx, write } = makeMockCtx();
+      await adapter.onConnected(ctx);
+      write.mockClear();
+
+      const r = adapter.parseNotification(makeMeasFrame(7805, 1813));
+      expect(r).not.toBeNull();
+
+      await Promise.resolve();
+      expect(write).toHaveBeenCalledTimes(1);
+      const [, data, withResponse] = write.mock.calls[0];
+      expect(Array.from(data as number[])).toEqual([0x55, 0xaa, 0x95, 0x00, 0x01, 0x01, 0x96]);
+      expect(withResponse).toBe(true);
+    });
+
+    it('does not throw when ack write fails', async () => {
+      const adapter = makeAdapter();
+      const write = vi.fn().mockRejectedValue(new Error('disconnected'));
+      const ctx: ConnectionContext = {
+        write,
+        read: vi.fn().mockResolvedValue(Buffer.alloc(0)),
+        subscribe: vi.fn().mockResolvedValue(undefined),
+        profile: defaultProfile(),
+        deviceAddress: '60:30:F2:73:6A:7B',
+        availableChars: new Set<string>(),
+      };
+      await adapter.onConnected(ctx).catch(() => {});
+      write.mockClear();
+      adapter.parseNotification(makeMeasFrame(7805, 1813));
+      await Promise.resolve();
+      await Promise.resolve();
+      // Should not throw even though write rejected
+    });
+
+    it('does not ack when no ctx (parser called before onConnected)', async () => {
+      const adapter = makeAdapter();
+      const r = adapter.parseNotification(makeMeasFrame(7805, 1813));
+      expect(r).not.toBeNull();
+      // No ctx → no write; just ensure it does not throw
+    });
+  });
+
+  // ─── onConnected() ────────────────────────────────────────────────────────
+
+  describe('onConnected()', () => {
+    it('sends START_CMD to control characteristic', async () => {
+      const adapter = makeAdapter();
+      const { ctx, write } = makeMockCtx();
+      await adapter.onConnected(ctx);
+
+      const startCall = write.mock.calls.find(([uuid]) => uuid === adapter.charWriteUuid);
+      expect(startCall).toBeDefined();
+      expect(Array.from(startCall![1] as number[])).toEqual([
+        0x55, 0xaa, 0x90, 0x00, 0x04, 0x01, 0x00, 0x00, 0x00, 0x94,
+      ]);
+      expect(startCall![2]).toBe(false); // write without response
+    });
+
+    it('survives start-cmd write failure without throwing', async () => {
+      const adapter = makeAdapter();
+      const ctx: ConnectionContext = {
+        write: vi.fn().mockRejectedValue(new Error('timeout')),
+        read: vi.fn().mockResolvedValue(Buffer.alloc(0)),
+        subscribe: vi.fn().mockResolvedValue(undefined),
+        profile: defaultProfile(),
+        deviceAddress: '60:30:F2:73:6A:7B',
+        availableChars: new Set<string>(),
+      };
+      await expect(adapter.onConnected(ctx)).resolves.toBeUndefined();
+    });
+
+    it('subscribes to status char when available', async () => {
+      const adapter = makeAdapter();
+      const subscribe = vi.fn().mockResolvedValue(undefined);
+      const statusNorm = adapter.charNotifyUuid; // just for ref; we set the set manually
+      const statusCharNorm = '00002a1000001000800000805f9b34fb'; // uuid16(0x2a10) normalised
+      const ctx: ConnectionContext = {
+        write: vi.fn().mockResolvedValue(undefined),
+        read: vi.fn().mockResolvedValue(Buffer.alloc(0)),
+        subscribe,
+        profile: defaultProfile(),
+        deviceAddress: '60:30:F2:73:6A:7B',
+        availableChars: new Set<string>([statusCharNorm]),
+      };
+      await adapter.onConnected(ctx);
+      expect(subscribe).toHaveBeenCalledTimes(1);
+      void statusNorm; // suppress unused-variable lint
+    });
+
+    it('skips status subscribe when char not in availableChars', async () => {
+      const adapter = makeAdapter();
+      const subscribe = vi.fn().mockResolvedValue(undefined);
+      const ctx: ConnectionContext = {
+        write: vi.fn().mockResolvedValue(undefined),
+        read: vi.fn().mockResolvedValue(Buffer.alloc(0)),
+        subscribe,
+        profile: defaultProfile(),
+        deviceAddress: '60:30:F2:73:6A:7B',
+        availableChars: new Set<string>(), // empty
+      };
+      await adapter.onConnected(ctx);
+      expect(subscribe).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── isComplete() ────────────────────────────────────────────────────────
+
+  describe('isComplete()', () => {
+    it('returns true for weight > 10 and impedance > 0', () => {
+      expect(makeAdapter().isComplete({ weight: 78, impedance: 181 })).toBe(true);
+    });
+
+    it('returns false when weight <= 10', () => {
+      expect(makeAdapter().isComplete({ weight: 5, impedance: 181 })).toBe(false);
+    });
+
+    it('returns false when impedance is 0', () => {
+      expect(makeAdapter().isComplete({ weight: 78, impedance: 0 })).toBe(false);
+    });
+  });
+
+  // ─── computeMetrics() ────────────────────────────────────────────────────
+
+  describe('computeMetrics()', () => {
+    it('returns valid BodyComposition after a parsed frame', () => {
+      const adapter = makeAdapter();
+      adapter.parseNotification(makeMeasFrame(7805, 1813));
+      const payload = adapter.computeMetrics({ weight: 78.05, impedance: 181.3 }, defaultProfile());
+      expect(payload.weight).toBeCloseTo(78.05, 2);
+      assertPayloadRanges(payload);
+    });
+
+    it('uses scale-provided body-fat and visceral-fat', () => {
+      const adapter = makeAdapter();
+      // fat=19.67%, visceral=5
+      adapter.parseNotification(
+        makeMeasFrame(7805, 1813, 0x25, { bodyFatX100: 1967, visceralFat: 5 }),
+      );
+      const payload = adapter.computeMetrics({ weight: 78.05, impedance: 181.3 }, defaultProfile());
+      expect(payload.bodyFatPercent).toBeCloseTo(19.67, 1);
+      expect(payload.visceralFat).toBe(5);
+    });
+
+    it('uses scale-provided bone mass', () => {
+      const adapter = makeAdapter();
+      adapter.parseNotification(makeMeasFrame(7805, 1813, 0x25, { boneMassX100: 190 }));
+      const payload = adapter.computeMetrics({ weight: 78.05, impedance: 181.3 }, defaultProfile());
+      expect(payload.boneMass).toBeCloseTo(1.9, 1);
+    });
+
+    it('falls back gracefully when no prior frame was parsed', () => {
+      // computeMetrics without a prior parseNotification should not throw
+      const adapter = makeAdapter();
+      const payload = adapter.computeMetrics({ weight: 78, impedance: 181 }, defaultProfile());
+      expect(payload.weight).toBe(78);
+      assertPayloadRanges(payload);
+    });
+  });
+});

--- a/tests/wizard/_test-config-ni.yaml
+++ b/tests/wizard/_test-config-ni.yaml
@@ -1,0 +1,17 @@
+version: 1
+scale:
+  weight_unit: kg
+  height_unit: cm
+unknown_user: nearest
+users:
+  - name: Bob
+    slug: bob
+    height: 180
+    birth_date: 1990-06-15
+    gender: male
+    is_athlete: false
+    weight_range:
+      min: 70
+      max: 100
+    last_known_weight: null
+update_check: true


### PR DESCRIPTION
## Summary

Add Support for R-MSC04 based on discovery and Apple PacketLogger.
Code was generated using claude.ai and is not yet manally tested. all contained tests are working, however.
this PR is more to inform about the work done and potential usage of this to prevent duplicate work analyzing the files.

## Changes

Added file for scale + tests as well as registered the new scale

-

## Test Plan

<!-- How did you verify this works? -->

- [X] Tests pass (`npm test`)
- [X] Lint clean (`npm run lint`)
- [X] TypeScript compiles (`npx tsc --noEmit`)
- [ ] Tested manually (describe below)


## Notes

As above:
Code was generated using claude.ai and is not yet manally tested. all contained tests are working, however.
this PR is more to inform about the work done and potential usage of this to prevent duplicate work analyzing the files.
