### PR TITLE
fix(renpho): perform consent handshake so the ES-WBE28 streams readings

### DIFF
--- a/src/scales/renpho.ts
+++ b/src/scales/renpho.ts
@@ -1,43 +1,98 @@
 import type {
   BleDeviceInfo,
+  CharacteristicBinding,
+  ConnectionContext,
   ScaleAdapterCore,
   GattWiring,
-  Unlockable,
+  MultiCharNotify,
+  HoldForComposition,
   ScaleReading,
   UserProfile,
   BodyComposition,
 } from '../interfaces/scale-adapter.js';
-import { uuid16, buildPayload } from './body-comp-helpers.js';
+import { uuid16, buildPayload, computeBiaFat, type ScaleBodyComp } from './body-comp-helpers.js';
+import { bleLog } from '../ble/types.js';
 import type { MatchDescriptor } from './match-descriptor.js';
 
 /**
- * Ported from openScale's RenphoHandler.kt
+ * Handler for RENPHO ES-WBE28 / "Renpho-Scale" (Elis 1 family).
  *
- * Handler for RENPHO ES-WBE28 — a newer Renpho model that uses standard BLE
- * services (Body Composition 0x181B, User Data 0x181C, Weight Scale 0x181D,
- * Current Time 0x1805) but with vendor-specific payload encoding.
+ * Reverse-engineered from an Android btsnoop HCI capture of the physical device
+ * and verified against it. Despite openScale's older RenphoHandler.kt treating
+ * this as a proprietary weight-only device, the ES-WBE28 speaks pure Bluetooth
+ * SIG GATT:
  *
- * Weight is published on the Weight Measurement characteristic (0x2A9D) in a
- * proprietary format: data[0] must equal 0x2E, weight = LE uint16 at [1-2] / 20.0.
+ *   Weight Scale       0x181D → Weight Measurement       0x2A9D (notify)
+ *   Body Composition   0x181B → Body Comp. Measurement    0x2A9C (indicate)
+ *   User Data          0x181C → User Control Point        0x2A9F (consent)
  *
- * Vendor handshake:
- *   MAGIC0 [0x10, 0x01, 0x00, 0x11] → written to 0xFFE2
- *   MAGIC1 [0x03, 0x00, 0x01, 0x04] → written to 0xFFE2
- *   MAGIC_UCP [0x02, 0xAA, 0x0F, 0x27] → written to 0x2A9F (consent user 0xAA, code 9999)
+ * The scale stays completely SILENT until a registered user "consents" through
+ * the User Data Service. Merely subscribing to 0x2A9D and poking the vendor
+ * channel (the previous implementation) never unlocks it, so the scale connects
+ * and then disconnects without ever streaming. We must replay the app's init:
  *
- * Mutual exclusion with QnScaleAdapter:
- *   RenphoHandler claims "renpho-scale" devices that do NOT advertise 0xFFE0/0xFFF0.
- *   Devices WITH 0xFFE0/0xFFF0 are handled by QnScaleAdapter (QNHandler.kt).
+ *   1. Subscribe to the vendor (0xFFE1) + User Control Point (0x2A9F) channels.
+ *   2. Vendor handshake — three writes to 0xFFE2 (opaque config query).
+ *   3. UCP consent — write 02 AA 0F 27 to 0x2A9F (user 0xAA=170, code 9999).
+ *   4. Profile writes (gender/height/DOB/age + vendor 0x2AFF) to satisfy the
+ *      scale's on-device maths.
+ *   5. Enable the weight + body-composition notifications LAST (order matters —
+ *      the app enables these CCCDs only after consent + profile).
+ *
+ * The consent user index (170) and code (9999) are the returning-user values
+ * captured from the RENPHO app's own registration; they are fixed for this
+ * device family. Body composition is recomputed on the host from raw impedance
+ * (BIA) rather than trusting the scale's per-profile derived numbers, which are
+ * only correct for the single profile the scale was registered with.
+ *
+ * Mutual exclusion with QnScaleAdapter: RenphoScaleAdapter claims "renpho"
+ * devices that do NOT advertise the QN vendor services (0xFFE0 / 0xFFF0).
  */
 
-const CHR_WEIGHT = uuid16(0x2a9d); // notify — proprietary weight encoding
-const CHR_CUSTOM0 = uuid16(0xffe2); // write  — vendor magic commands
+// Standard SIG characteristics.
+const CHR_WEIGHT = uuid16(0x2a9d); // notify   — Weight Measurement
+const CHR_BODYCOMP = uuid16(0x2a9c); // indicate — Body Composition Measurement
+const CHR_UCP = uuid16(0x2a9f); // User Control Point (consent + response)
 
-// QN vendor service UUIDs (used for exclusion)
+// Vendor 0xFFE0 service used for the opaque config handshake.
+const CHR_VENDOR_NOTIFY = uuid16(0xffe1);
+const CHR_VENDOR_WRITE = uuid16(0xffe2);
+
+// User Data Service profile characteristics.
+const CHR_GENDER = uuid16(0x2a8c);
+const CHR_AGE = uuid16(0x2a80);
+const CHR_DOB = uuid16(0x2a85);
+const CHR_HEIGHT = uuid16(0x2a8e);
+const CHR_VENDOR_2AFF = uuid16(0x2aff);
+
+// QN vendor service UUIDs (used for exclusion).
 const SVC_QN_T1 = 'ffe0';
 const SVC_QN_T2 = 'fff0';
 
-export class RenphoScaleAdapter implements ScaleAdapterCore, GattWiring, Unlockable {
+// Vendor handshake, replayed verbatim from the app capture (writes to 0xFFE2).
+const HANDSHAKE: number[][] = [
+  [0x10, 0x01, 0x00, 0x11],
+  [0x03, 0x00, 0x01, 0x04],
+  [0x19, 0x00, 0x19],
+];
+
+// User Control Point consent (returning-user values captured from the app).
+const UCP_CONSENT = 0x02;
+const UCP_RESPONSE = 0x20;
+const UCP_RESULT_SUCCESS = 0x01;
+const CONSENT_USER_INDEX = 0xaa; // 170
+const CONSENT_CODE = 9999; // 0x270F → wire bytes 0F 27 (LE)
+
+// RENPHO deviates from the SIG standard: mass fields use a 0.05 kg resolution
+// (10× the spec's 0.005), confirmed against the physical scale and internally
+// consistent with fat% and fat-free mass (raw 1900 → 95.0 kg).
+const KG_PER_UNIT = 0.05;
+const LB_PER_UNIT = 0.1;
+const LB_TO_KG = 0.45359237;
+
+export class RenphoScaleAdapter
+  implements ScaleAdapterCore, GattWiring, MultiCharNotify, HoldForComposition
+{
   readonly name = 'Renpho ES-WBE28';
   readonly match: MatchDescriptor = {
     priority: 240,
@@ -45,22 +100,35 @@ export class RenphoScaleAdapter implements ScaleAdapterCore, GattWiring, Unlocka
     names: { includes: ['renpho'] },
     serviceUuids: ['181b', '181d'],
   };
+  // Legacy single-char fallback (unused in multi-char mode).
   readonly charNotifyUuid = CHR_WEIGHT;
-  readonly charWriteUuid = CHR_CUSTOM0;
+  readonly charWriteUuid = CHR_VENDOR_WRITE;
   readonly normalizesWeight = true;
-  /** MAGIC0 — kicks the device into measurement mode. */
-  readonly unlockCommand = [0x10, 0x01, 0x00, 0x11];
-  readonly unlockIntervalMs = 3000;
+
+  // Only the channels that must be live BEFORE the handshake are auto-subscribed
+  // here. The weight + body-composition CCCDs are enabled LAST, inside
+  // onConnected(), to mirror the app's ordering.
+  readonly characteristics: CharacteristicBinding[] = [
+    { uuid: CHR_VENDOR_NOTIFY, type: 'notify' },
+    { uuid: CHR_UCP, type: 'notify' },
+    { uuid: CHR_VENDOR_WRITE, type: 'write' },
+  ];
+
+  // Hold the link open briefly after the weight settles so the multi-packet
+  // body-composition indications (carrying impedance) can land.
+  readonly completionHoldMs = 8000;
+
+  private cachedWeight = 0;
+  private cachedImpedance = 0;
 
   /**
-   * Match "renpho-scale" (or "renpho") devices that do NOT advertise QN vendor
-   * service UUIDs (0xFFE0 / 0xFFF0). Those are handled by QnScaleAdapter.
+   * Match "renpho" devices that do NOT advertise QN vendor service UUIDs
+   * (0xFFE0 / 0xFFF0). Those are handled by QnScaleAdapter.
    */
   matches(device: BleDeviceInfo): boolean {
     const name = (device.localName || '').toLowerCase();
     if (!name.includes('renpho')) return false;
 
-    // Reject QN-protocol devices (mutual exclusion from RenphoHandler.kt)
     const uuids = (device.serviceUuids || []).map((u) => u.toLowerCase());
     const hasQn = uuids.some(
       (u) => u === SVC_QN_T1 || u === SVC_QN_T2 || u === uuid16(0xffe0) || u === uuid16(0xfff0),
@@ -68,35 +136,178 @@ export class RenphoScaleAdapter implements ScaleAdapterCore, GattWiring, Unlocka
     return !hasQn;
   }
 
-  /**
-   * Parse a Renpho ES-WBE28 weight notification on 0x2A9D.
-   *
-   * Proprietary layout (from RenphoHandler.kt):
-   *   [0]    0x2E — valid frame marker
-   *   [1]    weight low byte  (LE)
-   *   [2]    weight high byte (LE)
-   *   weight_kg = ((data[2] << 8) | data[1]) / 20.0
-   */
+  async onConnected(ctx: ConnectionContext): Promise<void> {
+    // Reset per-connection state (adapter instance is shared across sessions).
+    this.cachedWeight = 0;
+    this.cachedImpedance = 0;
+
+    const required = [CHR_UCP, CHR_VENDOR_WRITE];
+    const missing = required.filter((u) => !ctx.availableChars.has(u));
+    if (missing.length > 0) {
+      throw new Error(
+        `Renpho ES-WBE28: required characteristics not discovered (${missing.join(', ')}). ` +
+          'Likely a transient GATT discovery race. Try again.',
+      );
+    }
+
+    // 1. Vendor handshake — three opaque config writes to 0xFFE2.
+    for (const cmd of HANDSHAKE) {
+      await ctx.write(CHR_VENDOR_WRITE, cmd, true);
+    }
+
+    // 2. User Control Point consent (opcode, user index, code LE).
+    await ctx.write(
+      CHR_UCP,
+      [UCP_CONSENT, CONSENT_USER_INDEX & 0xff, CONSENT_CODE & 0xff, (CONSENT_CODE >> 8) & 0xff],
+      true,
+    );
+
+    // 3. Profile writes — only unlock measurements / feed the scale's ignored
+    //    on-device maths. Guarded by availableChars so a firmware variant
+    //    missing one does not abort the whole init.
+    for (const [uuid, payload] of this.buildProfileWrites(ctx.profile)) {
+      if (ctx.availableChars.has(uuid)) await ctx.write(uuid, payload, true);
+    }
+
+    // 4. Enable measurement notifications LAST, as the app does.
+    await ctx.subscribe(CHR_WEIGHT);
+    await ctx.subscribe(CHR_BODYCOMP);
+    bleLog.debug('Renpho ES-WBE28: consent + profile sent, measurement notifications enabled');
+  }
+
+  /** Ordered (characteristic, bytes) profile writes mirroring the app. */
+  private buildProfileWrites(profile: UserProfile): Array<[string, number[]]> {
+    const gender = profile.gender === 'female' ? 1 : 0;
+    const age = Math.max(1, Math.round(profile.age));
+    const heightCm = Math.max(1, Math.round(profile.height));
+    const birthYear = new Date().getFullYear() - age;
+    return [
+      [CHR_GENDER, [gender]],
+      [CHR_HEIGHT, [heightCm & 0xff, (heightCm >> 8) & 0xff]],
+      [CHR_DOB, [birthYear & 0xff, (birthYear >> 8) & 0xff, 1, 1]],
+      [CHR_AGE, [age & 0xff]],
+      [CHR_VENDOR_2AFF, [0x04, 0x00]],
+    ];
+  }
+
+  parseCharNotification(charUuid: string, data: Buffer): ScaleReading | null {
+    if (charUuid === CHR_UCP) {
+      this.handleUcpResponse(data);
+      return null;
+    }
+    if (charUuid === CHR_VENDOR_NOTIFY) {
+      return null; // opaque handshake acks — nothing to decode
+    }
+    if (charUuid === CHR_WEIGHT) {
+      this.parseWeightMeasurement(data);
+      return this.buildReading();
+    }
+    if (charUuid === CHR_BODYCOMP) {
+      this.parseBodyComposition(data);
+      return this.buildReading();
+    }
+    return null;
+  }
+
+  /** Legacy single-char path: weight measurement frames only. */
   parseNotification(data: Buffer): ScaleReading | null {
-    if (data.length < 3) return null;
-    if (data[0] !== 0x2e) return null;
+    this.parseWeightMeasurement(data);
+    return this.buildReading();
+  }
 
+  private handleUcpResponse(data: Buffer): void {
+    if (data.length < 3 || data[0] !== UCP_RESPONSE) return;
+    if (data[2] === UCP_RESULT_SUCCESS) {
+      bleLog.debug('Renpho ES-WBE28: consent accepted, awaiting measurement');
+    } else {
+      bleLog.warn(
+        `Renpho ES-WBE28: User Control Point result 0x${data[2].toString(16)} ` +
+          '(consent not accepted). The scale may need re-registering in the RENPHO app.',
+      );
+    }
+  }
+
+  /**
+   * Decode a 0x2A9D Weight Measurement notification. Standard SIG layout with
+   * RENPHO's 0.05 kg resolution deviation. data[0] is a FLAGS byte (bit0 = unit,
+   * bit1 = timestamp, ...), NOT a fixed frame marker.
+   */
+  private parseWeightMeasurement(data: Buffer): void {
+    if (data.length < 3) return;
+    const flags = data[0];
+    const imperial = (flags & 0x01) !== 0;
     const raw = data.readUInt16LE(1);
-    const weight = raw / 20.0;
+    let weight = raw * (imperial ? LB_PER_UNIT : KG_PER_UNIT);
+    if (imperial) weight *= LB_TO_KG;
+    if (weight > 0 && Number.isFinite(weight)) this.cachedWeight = weight;
+  }
 
-    if (weight <= 0 || !Number.isFinite(weight)) return null;
+  /**
+   * Decode a 0x2A9C Body Composition Measurement packet, extracting impedance
+   * (the profile-independent field we need for host-side BIA). RENPHO splits the
+   * measurement across two indications and its per-packet flags can advertise
+   * fields that don't actually fit; so we walk fields in SIG bit-order and stop
+   * the moment the buffer is exhausted. We keep the FIRST impedance seen.
+   */
+  private parseBodyComposition(data: Buffer): void {
+    if (data.length < 4) return;
+    const flags = data.readUInt16LE(0);
+    const imperial = (flags & 0x0001) !== 0;
+    const step = imperial ? LB_PER_UNIT : KG_PER_UNIT;
+    const n = data.length;
 
-    // No impedance available from this device
-    return { weight, impedance: 0 };
+    // (flag, size, field). null flag = always present. Order is the SIG bit order.
+    const plan: Array<[number | null, number, 'impedance' | 'weight' | null]> = [
+      [null, 2, null], // body fat % (mandatory) — ignored; we recompute from impedance
+      [0x0002, 7, null], // timestamp
+      [0x0004, 1, null], // user id
+      [0x0008, 2, null], // basal metabolism
+      [0x0010, 2, null], // muscle %
+      [0x0020, 2, null], // muscle mass
+      [0x0040, 2, null], // fat free mass
+      [0x0080, 2, null], // soft lean mass
+      [0x0100, 2, null], // body water mass
+      [0x0200, 2, 'impedance'], // impedance ×0.1 Ω
+      [0x0400, 2, 'weight'], // weight ×step
+      [0x0800, 2, null], // height
+    ];
+
+    let off = 2;
+    for (const [flag, size, field] of plan) {
+      if (flag !== null && !(flags & flag)) continue;
+      if (off + size > n) break; // belongs to a later packet
+      if (field === 'impedance' && this.cachedImpedance <= 0) {
+        this.cachedImpedance = data.readUInt16LE(off) * 0.1;
+      } else if (field === 'weight' && this.cachedWeight <= 0) {
+        const w = data.readUInt16LE(off) * step;
+        if (w > 0 && Number.isFinite(w)) this.cachedWeight = w;
+      }
+      off += size;
+    }
+  }
+
+  private buildReading(): ScaleReading | null {
+    if (this.cachedWeight <= 0) return null;
+    return { weight: this.cachedWeight, impedance: this.cachedImpedance };
   }
 
   isComplete(reading: ScaleReading): boolean {
-    // Weight-only device — complete as soon as we have a valid weight
+    // Weight is enough to resolve; the hold window waits for impedance.
     return reading.weight > 0;
   }
 
+  /** Resolve immediately once impedance has arrived (the rich reading). */
+  isFinal(reading: ScaleReading): boolean {
+    return reading.impedance > 0;
+  }
+
   computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {
-    // No impedance — use estimated body composition from BMI
-    return buildPayload(reading.weight, 0, {}, profile);
+    const comp: ScaleBodyComp = {};
+    // Recompute body fat from raw impedance (BIA) when available; otherwise
+    // buildPayload falls back to BMI estimation.
+    if (reading.impedance > 0) {
+      comp.fat = computeBiaFat(reading.weight, reading.impedance, profile);
+    }
+    return buildPayload(reading.weight, reading.impedance, comp, profile);
   }
 }

--- a/tests/scales/renpho.test.ts
+++ b/tests/scales/renpho.test.ts
@@ -1,149 +1,191 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { RenphoScaleAdapter } from '../../src/scales/renpho.js';
+import type { ConnectionContext } from '../../src/interfaces/scale-adapter.js';
+import { uuid16 } from '../../src/scales/body-comp-helpers.js';
 import {
   mockPeripheral,
   defaultProfile,
   assertPayloadRanges,
 } from '../helpers/scale-test-utils.js';
 
+const CHR_WEIGHT = uuid16(0x2a9d);
+const CHR_BODYCOMP = uuid16(0x2a9c);
+const CHR_UCP = uuid16(0x2a9f);
+const CHR_VENDOR_NOTIFY = uuid16(0xffe1);
+const CHR_VENDOR_WRITE = uuid16(0xffe2);
+const CHR_GENDER = uuid16(0x2a8c);
+const CHR_HEIGHT = uuid16(0x2a8e);
+const CHR_DOB = uuid16(0x2a85);
+const CHR_AGE = uuid16(0x2a80);
+const CHR_VENDOR_2AFF = uuid16(0x2aff);
+
+// Live frames decoded from the physical-device btsnoop capture.
+// Weight frame 1374: flags 0x4E, raw 0x076A = 1898 → 94.9 kg (×0.05).
+const WSS_FRAME = Buffer.from('4e6a07ea0707040c1a06aa00000000', 'hex');
+// Body-comp packet 2 (frame 1477): flags 0x020C, impedance 0x0D00 = 3328 → 332.8 Ω.
+const BCS_PACKET2 = Buffer.from('0c02f901f70144000dec00a500290091020600', 'hex');
+
 function makeAdapter() {
   return new RenphoScaleAdapter();
 }
 
+const ALL_CHARS = new Set([
+  CHR_WEIGHT,
+  CHR_BODYCOMP,
+  CHR_UCP,
+  CHR_VENDOR_NOTIFY,
+  CHR_VENDOR_WRITE,
+  CHR_GENDER,
+  CHR_HEIGHT,
+  CHR_DOB,
+  CHR_AGE,
+  CHR_VENDOR_2AFF,
+]);
+
+function makeCtx(over: Partial<ConnectionContext> = {}): ConnectionContext {
+  return {
+    profile: defaultProfile(),
+    deviceAddress: '',
+    availableChars: ALL_CHARS,
+    write: vi.fn().mockResolvedValue(undefined),
+    read: vi.fn().mockResolvedValue(Buffer.alloc(0)),
+    subscribe: vi.fn().mockResolvedValue(undefined),
+    ...over,
+  } as ConnectionContext;
+}
+
 describe('RenphoScaleAdapter', () => {
   describe('matches()', () => {
-    it('matches "renpho" name without QN service UUIDs', () => {
-      const adapter = makeAdapter();
-      const p = mockPeripheral('Renpho Scale', []);
-      expect(adapter.matches(p)).toBe(true);
+    it('matches a real ES-WBE28 advert (renpho + SIG WSS/BCS, no QN UUID)', () => {
+      expect(makeAdapter().matches(mockPeripheral('Renpho-Scale', ['181b', '181d']))).toBe(true);
     });
-
-    it('matches "renpho-scale" without QN UUIDs', () => {
-      const adapter = makeAdapter();
-      const p = mockPeripheral('renpho-scale', []);
-      expect(adapter.matches(p)).toBe(true);
+    it('matches case-insensitively without QN services', () => {
+      expect(makeAdapter().matches(mockPeripheral('RENPHO', []))).toBe(true);
     });
-
-    it('matches a real ES-WBE28 advert (renpho + SIG WSS/BCS, no QN UUID) (#191)', () => {
-      const adapter = makeAdapter();
-      const p = mockPeripheral('Renpho Body Scale', ['181b', '181d']);
-      expect(adapter.matches(p)).toBe(true);
-    });
-
-    it('rejects "renpho" with QN service UUID FFE0', () => {
-      const adapter = makeAdapter();
-      const p = mockPeripheral('Renpho Scale', ['ffe0']);
-      expect(adapter.matches(p)).toBe(false);
-    });
-
-    it('rejects "renpho" with QN service UUID FFF0', () => {
-      const adapter = makeAdapter();
-      const p = mockPeripheral('Renpho Scale', ['fff0']);
-      expect(adapter.matches(p)).toBe(false);
-    });
-
-    it('rejects "renpho" with full 128-bit QN UUID', () => {
-      const adapter = makeAdapter();
-      const p = mockPeripheral('Renpho Scale', ['0000ffe000001000800000805f9b34fb']);
-      expect(adapter.matches(p)).toBe(false);
-    });
-
-    it('does not match unrelated name', () => {
-      const adapter = makeAdapter();
-      const p = mockPeripheral('Yunmai ISM', []);
-      expect(adapter.matches(p)).toBe(false);
-    });
-
-    it('case-insensitive name match', () => {
-      const adapter = makeAdapter();
-      const p = mockPeripheral('RENPHO', []);
-      expect(adapter.matches(p)).toBe(true);
+    it.each(['ffe0', 'fff0', '0000ffe000001000800000805f9b34fb'])(
+      'rejects renpho advertising QN service %s',
+      (svc) => {
+        expect(makeAdapter().matches(mockPeripheral('Renpho Scale', [svc]))).toBe(false);
+      },
+    );
+    it('does not match an unrelated name', () => {
+      expect(makeAdapter().matches(mockPeripheral('Yunmai ISM', []))).toBe(false);
     });
   });
 
-  describe('parseNotification()', () => {
-    it('parses valid frame with marker 0x2E', () => {
-      const adapter = makeAdapter();
-      const buf = Buffer.alloc(3);
-      buf[0] = 0x2e; // valid marker
-      buf.writeUInt16LE(1600, 1); // 1600 / 20 = 80 kg
+  describe('onConnected()', () => {
+    it('replays handshake → consent → profile, then enables measurement notifs LAST', async () => {
+      const a = makeAdapter();
+      const ctx = makeCtx();
+      await a.onConnected(ctx);
 
-      const reading = adapter.parseNotification(buf);
-      expect(reading).not.toBeNull();
-      expect(reading!.weight).toBe(80);
-      expect(reading!.impedance).toBe(0); // no impedance
+      const write = ctx.write as ReturnType<typeof vi.fn>;
+      const subscribe = ctx.subscribe as ReturnType<typeof vi.fn>;
+
+      // Three vendor handshake writes to 0xFFE2 come first.
+      expect(write.mock.calls[0]).toEqual([CHR_VENDOR_WRITE, [0x10, 0x01, 0x00, 0x11], true]);
+      expect(write.mock.calls[1]).toEqual([CHR_VENDOR_WRITE, [0x03, 0x00, 0x01, 0x04], true]);
+      expect(write.mock.calls[2]).toEqual([CHR_VENDOR_WRITE, [0x19, 0x00, 0x19], true]);
+
+      // Consent: opcode 0x02, user 0xAA (170), code 9999 = 0x270F → LE 0F 27.
+      expect(write.mock.calls[3]).toEqual([CHR_UCP, [0x02, 0xaa, 0x0f, 0x27], true]);
+
+      // Profile writes follow (gender/height/dob/age/vendor).
+      const writtenChars = write.mock.calls.map((c) => c[0]);
+      expect(writtenChars).toContain(CHR_GENDER);
+      expect(writtenChars).toContain(CHR_HEIGHT);
+      expect(writtenChars).toContain(CHR_AGE);
+
+      // Measurement notifications are enabled ONLY after all init writes.
+      expect(subscribe).toHaveBeenCalledWith(CHR_WEIGHT);
+      expect(subscribe).toHaveBeenCalledWith(CHR_BODYCOMP);
+      expect(subscribe).not.toHaveBeenCalledBefore(write);
     });
 
-    it('returns null for wrong marker byte', () => {
-      const adapter = makeAdapter();
-      const buf = Buffer.alloc(3);
-      buf[0] = 0x10; // wrong marker
-      buf.writeUInt16LE(1600, 1);
-
-      expect(adapter.parseNotification(buf)).toBeNull();
+    it('throws a clear error when consent/vendor chars are missing', async () => {
+      const a = makeAdapter();
+      await expect(
+        a.onConnected(makeCtx({ availableChars: new Set([CHR_WEIGHT]) })),
+      ).rejects.toThrow(/discovery race/);
     });
 
-    it('returns null for too-short buffer', () => {
-      const adapter = makeAdapter();
-      expect(adapter.parseNotification(Buffer.alloc(2))).toBeNull();
-    });
-
-    it('returns null for zero weight', () => {
-      const adapter = makeAdapter();
-      const buf = Buffer.alloc(3);
-      buf[0] = 0x2e;
-      buf.writeUInt16LE(0, 1);
-
-      expect(adapter.parseNotification(buf)).toBeNull();
-    });
-
-    it('handles various weight values', () => {
-      const adapter = makeAdapter();
-      // 60 kg = 1200 raw
-      const buf = Buffer.alloc(3);
-      buf[0] = 0x2e;
-      buf.writeUInt16LE(1200, 1);
-
-      const reading = adapter.parseNotification(buf);
-      expect(reading).not.toBeNull();
-      expect(reading!.weight).toBe(60);
+    it('skips profile writes for characteristics the firmware lacks', async () => {
+      const a = makeAdapter();
+      // Only the essential consent/vendor chars present — profile chars absent.
+      const ctx = makeCtx({ availableChars: new Set([CHR_UCP, CHR_VENDOR_WRITE]) });
+      await a.onConnected(ctx);
+      const writtenChars = (ctx.write as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0]);
+      expect(writtenChars).not.toContain(CHR_GENDER);
+      // Handshake + consent still happened.
+      expect(writtenChars).toContain(CHR_VENDOR_WRITE);
+      expect(writtenChars).toContain(CHR_UCP);
     });
   });
 
-  describe('isComplete()', () => {
-    it('returns true when weight > 0', () => {
-      const adapter = makeAdapter();
-      expect(adapter.isComplete({ weight: 80, impedance: 0 })).toBe(true);
+  describe('parseCharNotification()', () => {
+    it('decodes a real SIG weight frame (flags byte, not a 0x2E marker)', () => {
+      const a = makeAdapter();
+      const reading = a.parseCharNotification(CHR_WEIGHT, WSS_FRAME);
+      expect(reading).not.toBeNull();
+      expect(reading!.weight).toBeCloseTo(94.9, 1);
     });
 
-    it('returns false when weight is 0', () => {
-      const adapter = makeAdapter();
-      expect(adapter.isComplete({ weight: 0, impedance: 0 })).toBe(false);
+    it('extracts impedance from a body-composition packet', () => {
+      const a = makeAdapter();
+      a.parseCharNotification(CHR_WEIGHT, WSS_FRAME);
+      const reading = a.parseCharNotification(CHR_BODYCOMP, BCS_PACKET2);
+      expect(reading).not.toBeNull();
+      expect(reading!.weight).toBeCloseTo(94.9, 1);
+      expect(reading!.impedance).toBeCloseTo(332.8, 1);
+    });
+
+    it('parses imperial (lb) weight frames to kg', () => {
+      const a = makeAdapter();
+      const buf = Buffer.alloc(3);
+      buf[0] = 0x01; // flags: imperial, no optional fields
+      buf.writeUInt16LE(2000, 1); // 2000 × 0.1 lb = 200 lb → ~90.72 kg
+      const reading = a.parseCharNotification(CHR_WEIGHT, buf);
+      expect(reading!.weight).toBeCloseTo(200 * 0.45359237, 1);
+    });
+
+    it('ignores User Control Point responses without emitting a reading', () => {
+      const a = makeAdapter();
+      expect(a.parseCharNotification(CHR_UCP, Buffer.from([0x20, 0x02, 0x01]))).toBeNull();
+      expect(a.parseCharNotification(CHR_UCP, Buffer.from([0x20, 0x02, 0x05]))).toBeNull();
+    });
+
+    it('does not throw on a truncated body-comp frame that over-claims via flags', () => {
+      const a = makeAdapter();
+      // flags 0x0300 claim body-water + impedance, but only fat% fits.
+      const truncated = Buffer.from([0x00, 0x03, 0x12, 0x01]);
+      expect(() => a.parseCharNotification(CHR_BODYCOMP, truncated)).not.toThrow();
+    });
+  });
+
+  describe('isComplete() / isFinal()', () => {
+    it('is complete once weight is positive', () => {
+      const a = makeAdapter();
+      expect(a.isComplete({ weight: 80, impedance: 0 })).toBe(true);
+      expect(a.isComplete({ weight: 0, impedance: 0 })).toBe(false);
+    });
+    it('is final only once impedance has arrived', () => {
+      const a = makeAdapter();
+      expect(a.isFinal({ weight: 80, impedance: 0 })).toBe(false);
+      expect(a.isFinal({ weight: 80, impedance: 332.8 })).toBe(true);
     });
   });
 
   describe('computeMetrics()', () => {
-    it('returns all BodyComposition fields using estimation (no impedance)', () => {
-      const adapter = makeAdapter();
+    it('uses impedance (BIA) for body fat when present', () => {
+      const a = makeAdapter();
       const profile = defaultProfile();
-      const payload = adapter.computeMetrics({ weight: 80, impedance: 0 }, profile);
-
-      expect(payload.weight).toBe(80);
-      expect(payload.impedance).toBe(0);
-      assertPayloadRanges(payload);
-    });
-
-    it('computes different results for different profiles', () => {
-      const adapter = makeAdapter();
-      const male = defaultProfile();
-      const female = defaultProfile({ gender: 'female', height: 165 });
-
-      const m = adapter.computeMetrics({ weight: 70, impedance: 0 }, male);
-      const f = adapter.computeMetrics({ weight: 70, impedance: 0 }, female);
-
-      expect(m.bodyFatPercent).not.toBe(f.bodyFatPercent);
-      assertPayloadRanges(m);
-      assertPayloadRanges(f);
+      const withImp = a.computeMetrics({ weight: 80, impedance: 500 }, profile);
+      const noImp = a.computeMetrics({ weight: 80, impedance: 0 }, profile);
+      assertPayloadRanges(withImp);
+      assertPayloadRanges(noImp);
+      expect(withImp.impedance).toBe(500);
+      // BIA-derived fat should differ from the BMI-only estimate.
+      expect(withImp.bodyFatPercent).not.toBe(noImp.bodyFatPercent);
     });
   });
 });


### PR DESCRIPTION
## Problem

The **Renpho ES-WBE28** ("Renpho-Scale", Elis 1 family) connects but never produces a reading — the log shows `Matched adapter: Renpho ES-WBE28` → `Subscribed to notifications. Step on the scale.` → (after the step-on timeout) `Scale disconnected before reading completed`.

Root cause: this scale speaks **standard Bluetooth SIG GATT** (Weight Scale `0x2A9D`, Body Composition `0x2A9C`, User Data `0x2A9F`) and stays completely **silent until a registered user consents** through the User Data Service. The previous adapter only:

- re-sent a single vendor `MAGIC0` write (`10 01 00 11`) to `0xFFE2` every 3s via the legacy `Unlockable` path, and
- subscribed to `0x2A9D`.

It never sent the rest of the vendor handshake, never sent UCP consent, and never wrote the user profile — so the scale never unlocked and eventually dropped the link.

A second latent bug: `parseNotification()` required `data[0] === 0x2E` as a frame marker, but real frames from this device begin with a standard SIG **flags** byte (e.g. `0x4E`), so every measurement would have been dropped even if the scale did stream.

## Fix

Rewrite the adapter to replay the app's init through the `onConnected` hook, modeled on the existing Beurer BF720 SIG-consent adapter:

1. Auto-subscribe the vendor (`0xFFE1`) + User Control Point (`0x2A9F`) channels.
2. Vendor handshake — three writes to `0xFFE2` (`10 01 00 11`, `03 00 01 04`, `19 00 19`).
3. UCP consent — `02 AA 0F 27` (user index 170, code 9999).
4. Profile writes (gender / height / DOB / age + vendor `0x2AFF`), each guarded by `availableChars` so a firmware variant missing one doesn't abort init.
5. Enable the weight + body-composition notifications **last** (order matters — the app enables these CCCDs only after consent).

Parsing now decodes standard SIG Weight Measurement + Body Composition frames (with RENPHO's documented `0.05 kg` resolution deviation) and extracts **impedance**. The link is held open briefly (`completionHoldMs`) so the multi-packet composition indications carrying impedance can land, and body fat is recomputed host-side from impedance (BIA) rather than trusting the scale's per-profile derived values.

The consent user index (170) and code (9999) are the returning-user values captured from the RENPHO app and are fixed for this device family.

## Testing

- Rewrote `tests/scales/renpho.test.ts` (17 tests): `matches()`, the full `onConnected` handshake ordering, consent-char-missing error, firmware-variant profile skipping, SIG weight/impedance decoding (using real captured frames → **94.9 kg** / **332.8 Ω**), imperial→kg, UCP-response handling, truncated-frame safety, and BIA `computeMetrics`.
- `npm test` (full scales suite: 617 passing), `npx tsc --noEmit`, `npm run lint`, `npm run format:check` all clean.

Verified against the physical device's protocol capture; the byte-level test fixtures come straight from that capture. I don't have a second ES-WBE28 to check consent-code portability, but the values match the app's registration for this model family.
