### PR TITLE
feat(scales): add Hutbit smart scale adapter

### DIFF
--- a/src/scales/hutbit.ts
+++ b/src/scales/hutbit.ts
@@ -1,0 +1,127 @@
+import type {
+  BleDeviceInfo,
+  CharacteristicBinding,
+  ConnectionContext,
+  ScaleAdapterCore,
+  GattWiring,
+  ScaleReading,
+  UserProfile,
+  BodyComposition,
+} from '../interfaces/scale-adapter.js';
+import { uuid16, buildPayload } from './body-comp-helpers.js';
+import { bleLog } from '../ble/types.js';
+import type { MatchDescriptor } from './match-descriptor.js';
+
+// ─── Hutbit Smart Scale (Lefu / Fitdays FFB0 "AC02" 8-byte protocol) ─────────
+
+const CHR_FFB1 = uuid16(0xffb1); // write (handshake, phone→scale)
+const CHR_FFB2 = uuid16(0xffb2); // notify (weight stream, scale→phone)
+
+/**
+ * Handshake replayed on FFB1 (write-without-response) after enabling FFB2
+ * notifications. Fixed 8-byte AC02 frames decoded from two Fitdays HCI snoops
+ * (#254). Unlike the Robi S9's 20-byte protocol, every frame is a fixed
+ * `AC 02 | D0 D1 D2 D3 | STATUS | CKSUM` with a plain additive checksum and NO
+ * app-identity token, so the frames are stable and safe to replay verbatim.
+ * `ac02fe060000ccd0` is the poll/keepalive the app repeats through the session.
+ */
+const HANDSHAKE: string[] = [
+  'ac02fa010000ccc7',
+  'ac02fb021fa5cc8d',
+  'ac02fde20101ccad',
+  'ac02fc010000ccc9',
+  'ac02fe060000ccd0',
+];
+
+const FRAME_LEN = 8;
+const FRAME_HEADER0 = 0xac;
+const FRAME_HEADER1 = 0x02;
+const STATUS_STABLE = 0xca; // final/stable reading (0xCE = measuring/unstable)
+const WEIGHT_DIV = 10; // weight = u16 BE / 10 → kg
+
+/** Additive checksum over D0..STATUS (bytes 2..6), matching the vendor frames. */
+function frameChecksum(data: Buffer): number {
+  return (data[2] + data[3] + data[4] + data[5] + data[6]) & 0xff;
+}
+
+/**
+ * Adapter for the Hutbit Smart Scale (model 218008 / WL292, Fitdays app, Lefu
+ * OEM). It shares service 0xFFB0 with the Robi S9 and openScale MGB families
+ * but speaks a simpler, fixed 8-byte "AC02" protocol: after enabling FFB2
+ * notifications the phone replays a short FFB1 handshake, then the scale streams
+ * `AC 02 [weight_u16_BE] 00 00 [STATUS] [CKSUM]` frames on FFB2, where
+ * STATUS 0xCE = measuring/unstable and 0xCA = stable/final. Weight = u16 / 10 kg.
+ *
+ * Decoded from two known-weight HCI snoops (#254): `ac0203490000ca16`
+ * = 0x0349 = 841 → 84.1 kg. The unit's bioimpedance is unreliable (it reported
+ * 0.4–0.7 % body fat), so it is treated as weight-only and body composition is
+ * derived via the shared BIA/BMI pipeline, same as the Robi S9 / Renpho adapters.
+ */
+export class HutbitAdapter implements ScaleAdapterCore, GattWiring {
+  readonly name = 'Hutbit';
+  readonly match: MatchDescriptor = {
+    priority: 35,
+    custom: true,
+    names: { includes: ['hutbit'] },
+    serviceUuids: ['ffb0'],
+  };
+  readonly charNotifyUuid = CHR_FFB2;
+  readonly charWriteUuid = CHR_FFB1;
+  readonly normalizesWeight = true;
+
+  readonly characteristics: CharacteristicBinding[] = [
+    { uuid: CHR_FFB1, type: 'write' },
+    { uuid: CHR_FFB2, type: 'notify' },
+  ];
+
+  private final = false;
+
+  matches(device: BleDeviceInfo): boolean {
+    // Advertised name is "Hutbit Scale"; match by name only. The nameless FFB0
+    // space is deliberately left to the Robi S9 (FFB3 result char) and the MGB
+    // fallback — the Hutbit exposes no unique post-discovery characteristic
+    // (FFB3 is present but unused), so claiming nameless FFB0 here would risk
+    // shadowing those adapters.
+    return (device.localName || '').toLowerCase().includes('hutbit');
+  }
+
+  async onConnected(ctx: ConnectionContext): Promise<void> {
+    this.final = false;
+    for (const hex of HANDSHAKE) {
+      await ctx.write(CHR_FFB1, Buffer.from(hex, 'hex'), true);
+      await new Promise((r) => setTimeout(r, 150));
+    }
+    bleLog.debug('Hutbit: handshake sent');
+  }
+
+  parseNotification(data: Buffer): ScaleReading | null {
+    // Fixed 8-byte AC02 weight frame: AC 02 [weight u16 BE] 00 00 [STATUS] [CKSUM]
+    if (data.length !== FRAME_LEN) return null;
+    if (data[0] !== FRAME_HEADER0 || data[1] !== FRAME_HEADER1) return null;
+    if (frameChecksum(data) !== data[7]) return null;
+
+    bleLog.debug(`Hutbit frame: ${data.toString('hex')}`);
+
+    // Only the stable (0xCA) frame is a final reading; 0xCE frames are the live
+    // settling stream and are treated as progress only.
+    if (data[6] !== STATUS_STABLE) return null;
+
+    const weight = data.readUInt16BE(2) / WEIGHT_DIV;
+    if (!(weight > 0) || !Number.isFinite(weight)) return null;
+
+    this.final = true;
+    // Weight-only: the sensor's bioimpedance is unreliable, so emit impedance 0
+    // and let the shared BIA/BMI pipeline derive body composition.
+    return { weight, impedance: 0 };
+  }
+
+  isComplete(reading: ScaleReading): boolean {
+    return reading.weight > 0 && this.final;
+  }
+
+  computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {
+    // Body composition via the shared BMI/BIA fallback; the vendor's own
+    // bioimpedance is unreliable and its body-comp frames are not decoded.
+    return buildPayload(reading.weight, reading.impedance, {}, profile);
+  }
+}

--- a/src/scales/index.ts
+++ b/src/scales/index.ts
@@ -21,6 +21,7 @@ import { DigooScaleAdapter } from './digoo.js';
 import { OneByoneAdapter, OneByoneNewAdapter } from './one-byone.js';
 import { ActiveEraAdapter } from './active-era.js';
 import { RobiS9Adapter } from './robi-s9.js';
+import { HutbitAdapter } from './hutbit.js';
 import { MgbAdapter } from './mgb.js';
 import { HoffenAdapter } from './hoffen.js';
 import { SenssunAdapter } from './senssun.js';
@@ -66,6 +67,9 @@ export const adapters: ScaleAdapter[] = [
   // Robi speaks a different protocol and is matched by name or its FFB3 result
   // characteristic, so it must win before the generic MGB FFB0 fallback (#228).
   new RobiS9Adapter(),
+  // Hutbit (Lefu/Fitdays FFB0 8-byte AC02 protocol): matches by its "Hutbit"
+  // name; sits before the generic MGB FFB0 fallback (#254).
+  new HutbitAdapter(),
   new MgbAdapter(),
   new HoffenAdapter(),
   // Generic standard GATT adapter last — matches by service UUID / brand names

--- a/tests/scales/hutbit.test.ts
+++ b/tests/scales/hutbit.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest';
+import { HutbitAdapter } from '../../src/scales/hutbit.js';
+import { adapters } from '../../src/scales/index.js';
+import { uuid16 } from '../../src/scales/body-comp-helpers.js';
+import type { ConnectionContext } from '../../src/interfaces/scale-adapter.js';
+import {
+  mockPeripheral,
+  defaultProfile,
+  expectMatches,
+  parseOk,
+  expectValidMetrics,
+} from '../helpers/scale-test-utils.js';
+
+function makeAdapter() {
+  return new HutbitAdapter();
+}
+
+describe('HutbitAdapter (#254)', () => {
+  describe('matches() and registry resolution', () => {
+    it('matches the advertised "Hutbit Scale" name (case-insensitive)', () => {
+      expectMatches(makeAdapter(), {
+        yes: ['Hutbit Scale', 'hutbit scale', 'HUTBIT'],
+        no: ['Robi S9', 'icomon', 'swan123', 'QN-Scale', ''],
+      });
+    });
+
+    it('resolves "Hutbit Scale" to the Hutbit adapter, not MGB/Robi', () => {
+      const matched = adapters.find((a) => a.matches(mockPeripheral('Hutbit Scale', ['ffb0'])));
+      expect(matched?.name).toBe('Hutbit');
+    });
+
+    it('does not claim a nameless FFB0 device (left to Robi/MGB)', () => {
+      const info = mockPeripheral('', [uuid16(0xffb0)], undefined, [
+        uuid16(0xffb1),
+        uuid16(0xffb2),
+      ]);
+      expect(makeAdapter().matches(info)).toBe(false);
+    });
+  });
+
+  describe('onConnected() handshake', () => {
+    it('replays the captured 8-byte FFB1 handshake in order', async () => {
+      const writes: Buffer[] = [];
+      const ctx = {
+        profile: defaultProfile(),
+        deviceAddress: 'AA',
+        availableChars: new Set<string>(),
+        write: vi.fn(async (_uuid: string, data: number[] | Buffer) => {
+          writes.push(Buffer.isBuffer(data) ? data : Buffer.from(data));
+        }),
+        read: vi.fn(),
+        subscribe: vi.fn(),
+      } as unknown as ConnectionContext;
+
+      await makeAdapter().onConnected(ctx);
+
+      expect(writes).toHaveLength(5);
+      expect(writes[0].toString('hex')).toBe('ac02fa010000ccc7');
+      expect(writes[4].toString('hex')).toBe('ac02fe060000ccd0');
+      // Every handshake frame is a valid 8-byte AC02 frame with a good checksum.
+      for (const w of writes) {
+        expect(w).toHaveLength(8);
+        expect(w[0]).toBe(0xac);
+        expect(w[1]).toBe(0x02);
+        expect((w[2] + w[3] + w[4] + w[5] + w[6]) & 0xff).toBe(w[7]);
+      }
+    });
+  });
+
+  describe('parseNotification()', () => {
+    it('decodes 84.1 kg from the real stable FFB2 frame (#254)', () => {
+      const adapter = makeAdapter();
+      // ac02 0349 0000 ca 16 → 0x0349 = 841 → 84.1 kg, STATUS 0xCA (stable)
+      const reading = parseOk(adapter, Buffer.from('ac0203490000ca16', 'hex'), {
+        weight: 84.1,
+        impedance: 0,
+      });
+      expect(adapter.isComplete(reading)).toBe(true);
+    });
+
+    it('ignores measuring (0xCE) frames as progress only', () => {
+      // ac02 0348 0000 ce 19 → valid checksum, but STATUS 0xCE = unstable
+      expect(makeAdapter().parseNotification(Buffer.from('ac0203480000ce19', 'hex'))).toBeNull();
+    });
+
+    it('rejects a frame with a bad checksum', () => {
+      expect(makeAdapter().parseNotification(Buffer.from('ac0203490000ca00', 'hex'))).toBeNull();
+    });
+
+    it('rejects wrong header / wrong length frames', () => {
+      const a = makeAdapter();
+      expect(a.parseNotification(Buffer.from('bb0203490000ca16', 'hex'))).toBeNull();
+      expect(a.parseNotification(Buffer.from('ac0203490000ca', 'hex'))).toBeNull();
+    });
+  });
+
+  describe('computeMetrics()', () => {
+    it('derives a valid body-composition payload (weight-only → BIA/BMI)', () => {
+      const adapter = makeAdapter();
+      const reading = parseOk(adapter, Buffer.from('ac0203490000ca16', 'hex'));
+      const payload = expectValidMetrics(adapter, reading);
+      expect(payload.weight).toBeCloseTo(84.1, 2);
+      expect(payload.impedance).toBe(0);
+    });
+  });
+});

--- a/tests/scales/registry-collision.test.ts
+++ b/tests/scales/registry-collision.test.ts
@@ -60,6 +60,7 @@ const FIXTURES: Record<string, BleDeviceInfo> = {
   '1byone Scale (new)': { localName: '1byone scale', serviceUuids: [] },
   'Active Era BS-06': { localName: 'AE BS-06', serviceUuids: [] },
   'Robi S9': { localName: 'Robi S9', serviceUuids: [] },
+  Hutbit: { localName: 'Hutbit Scale', serviceUuids: ['ffb0'] },
   'MGB (Swan/Icomon/YG)': { localName: 'icomon', serviceUuids: [] },
   'Hoffen BS-8107': { localName: 'hoffen bs-8107', serviceUuids: [] },
   // Generic fallback: a non-excluded name + bare Weight Scale Service (0x181D).


### PR DESCRIPTION
Closes #254.

Adds an adapter for the **Hutbit Smart Scale** (model **218008** / B/N **WL292**, Fitdays app, Lefu OEM), decoded from two Android Fitdays HCI snoops taken at known weights.

### Protocol (Lefu FFB0 "AC02")
Shares service `0xFFB0` with the Robi S9 / openScale MGB families but speaks a **simpler, fixed 8-byte protocol** — not the Robi's 20-byte one:

```
AC 02 | D0 D1 D2 D3 | STATUS | CKSUM
CKSUM = (D0 + D1 + D2 + D3 + STATUS) & 0xFF   // verified on every frame
```

- **Handshake** replayed on `FFB1` (write-no-response) after enabling `FFB2` notifications. Frames are fixed and carry **no app-identity token**, so they're safe to replay verbatim.
- **Weight** streamed on `FFB2` notify: `AC 02 [weight_u16_BE] 00 00 [STATUS] [CKSUM]`, `weight_kg = u16 / 10`. `STATUS 0xCE` = measuring/unstable, **`0xCA` = stable/final**.
- Ground truth: `ac0203490000ca16` → `0x0349` = 841 → **84.1 kg** ✓ (matched the Fitdays reading).
- `FFB3` is present but **unused**; the unit's bioimpedance is unreliable (0.4–0.7 % body fat), so this is **weight-only** → body composition is derived via the shared BIA/BMI pipeline, same as the Robi S9 / Renpho adapters.

### Changes
- `src/scales/hutbit.ts` — `HutbitAdapter` (`ScaleAdapterCore` + `GattWiring`), matches by the `Hutbit` name, `custom: true`, unique `priority: 35`, checksum-validated `FFB2` parse, weight-only → `impedance: 0`.
- `src/scales/index.ts` — registered before the generic MGB `FFB0` fallback.
- `tests/scales/hutbit.test.ts` — matches/registry-resolution, handshake order + checksum, weight decode from the real capture, measuring-frame + bad-checksum rejection, metrics range check.
- `tests/scales/registry-collision.test.ts` — added the required first-match fixture.

Matching is intentionally **name-only** — the nameless `FFB0` space is left to Robi S9 (FFB3 result char) and the MGB fallback to avoid shadowing them.

### Verification (local)
`npm test` (1830 tests), `npm run lint`, `npm run format:check`, `npx tsc --noEmit` — all green.

I still have the two raw `btsnoop_hci.log` captures (weigh-ins at known weights) and can attach them or adjust anything to your conventions — just say the word.