### PR TITLE
fix(firmware): enable BLE CCCD notifications in start_notify

### DIFF
--- a/firmware/ble_bridge.py
+++ b/firmware/ble_bridge.py
@@ -572,10 +572,28 @@ class BleBridge:
         return {"chars": chars_info}
 
     async def start_notify(self, uuid_str, publish_fn):
-        """Start forwarding notifications from a characteristic via publish_fn."""
+        """Start forwarding notifications from a characteristic via publish_fn.
+
+        This also writes the CCCD (Client Characteristic Configuration
+        Descriptor) so the peripheral actually sends notifications. Without this
+        step aioble's char.notified() just waits forever on an empty queue and
+        times out with no data (#231)."""
         char = self._chars.get(uuid_str)
         if not char:
             return
+
+        # Enable notify/indicate on the peripheral. aioble's notified() only
+        # consumes events; it does not turn on the CCCD bit itself.
+        print(f"Subscribe: enabling CCCD for {uuid_str}")
+        try:
+            await char.subscribe(
+                notify=bool(char.properties & bluetooth.FLAG_NOTIFY),
+                indicate=bool(char.properties & bluetooth.FLAG_INDICATE),
+            )
+        except Exception as e:
+            print(f"Subscribe: CCCD enable failed for {uuid_str}: {type(e).__name__}: {e}")
+            raise
+        print(f"Subscribe: CCCD enabled for {uuid_str}")
 
         async def _notify_loop():
             try:

--- a/firmware/tests/test_connect_irq.py
+++ b/firmware/tests/test_connect_irq.py
@@ -9,6 +9,7 @@ times out.
 Run: python -m unittest discover -s firmware/tests
 """
 
+import asyncio
 import os
 import sys
 import types
@@ -97,6 +98,25 @@ class _FakeChar:
     def __init__(self, uuid, properties):
         self.uuid = uuid
         self.properties = properties
+
+
+class _SubscribableFakeChar:
+    """Models aioble's ClientCharacteristic subscribe/notified surface. Records
+    whether subscribe() was awaited and with which CCCD flags, and lets the
+    notify loop block until cancelled so tests can assert on the subscribe call
+    without the loop racing ahead (#231)."""
+
+    def __init__(self, uuid, properties):
+        self.uuid = uuid
+        self.properties = properties
+        self.subscribed = []  # list of (notify, indicate) tuples
+
+    async def subscribe(self, notify=True, indicate=False):
+        self.subscribed.append((notify, indicate))
+
+    async def notified(self, timeout_ms=None):
+        # Block forever; real firmware loops until cancelled/disconnected.
+        await asyncio.Event().wait()
 
 
 class _FakeService:
@@ -345,6 +365,54 @@ class TestConnectDiscoversCharsViaAsyncFor(unittest.IsolatedAsyncioTestCase):
                 "00002a9d00001000800000805f9b34fb",
             ],
         )
+
+
+class TestStartNotifySubscribesCccd(unittest.IsolatedAsyncioTestCase):
+    """start_notify() must write the CCCD via char.subscribe() before waiting
+    on char.notified(). Without this, the peripheral never sends notifications,
+    the loop times out with an empty error, and the QN handshake stalls (#231)."""
+
+    async def test_notify_characteristic_enables_cccd(self):
+        bridge = ble_bridge.BleBridge()
+        char = _SubscribableFakeChar(
+            "0000fff1-0000-1000-8000-00805f9b34fb", _bt.FLAG_NOTIFY
+        )
+        bridge._chars[char.uuid] = char
+        bridge._conn = _FakeConn()
+
+        async def publish_fn(_uuid, _data):
+            pass
+
+        await bridge.start_notify(char.uuid, publish_fn)
+        self.assertEqual(char.subscribed, [(True, False)])
+        # Clean up the background notify loop.
+        await bridge.disconnect()
+
+    async def test_indicate_characteristic_enables_cccd(self):
+        bridge = ble_bridge.BleBridge()
+        char = _SubscribableFakeChar(
+            "00002a9d-0000-1000-8000-00805f9b34fb", _bt.FLAG_INDICATE
+        )
+        bridge._chars[char.uuid] = char
+        bridge._conn = _FakeConn()
+
+        async def publish_fn(_uuid, _data):
+            pass
+
+        await bridge.start_notify(char.uuid, publish_fn)
+        self.assertEqual(char.subscribed, [(False, True)])
+        await bridge.disconnect()
+
+    async def test_missing_char_is_noop(self):
+        bridge = ble_bridge.BleBridge()
+        bridge._conn = _FakeConn()
+
+        async def publish_fn(_uuid, _data):
+            pass
+
+        # Should not raise or create a task.
+        await bridge.start_notify("0000dead-0000-1000-8000-00805f9b34fb", publish_fn)
+        self.assertEqual(bridge._notify_tasks, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Enables BLE notifications on the peripheral by writing the Client Characteristic Configuration Descriptor.

The latest retest logs in #231 showed:

```
Subscribe: notify enabled for 0000fff1...
Subscribe: notify enabled for 0000ae02...
Notify loop error (0000fff1...):
Notify loop error (0000ae02...):
```

The empty error message after the colon is `asyncio.TimeoutError()` from `char.notified()`. aioble's `notified()` only consumes events; it does not turn on the CCCD bit. Without that write, the scale never starts sending notifications, so the loop waits 10s and times out with no data.

This change adds `char.subscribe(notify=/indicate=)` in `BleBridge.start_notify()` based on the characteristic properties, and adds REPL debug logs so the CCCD step is visible in future logs. A regression test covers notify, indicate, and missing-characteristic paths.

All 93 firmware tests pass. The unrelated `tests/config/watch.test.ts` failure is pre-existing on `dev`.

Relates to #231