### PR TITLE
release: promote dev to main

### DIFF
--- a/ble-scale-sync-addon/DOCS.md
+++ b/ble-scale-sync-addon/DOCS.md
@@ -113,6 +113,12 @@ See the [full list](https://blescalesync.dev/guide/supported-scales).
 
 ## Troubleshooting
 
+### Add-on exits immediately with `DBusError: ... AccessDenied`
+
+The full error mentions `An AppArmor policy prevents this sender from sending this message`, names `member="Hello"`, and appears before any scanning starts.
+
+The Supervisor's default AppArmor profile does not allow the D-Bus calls this add-on makes to reach BlueZ. Newer add-on versions run unconfined instead, so updating to the latest version fixes it. If you still see this after updating, uninstall and reinstall the add-on so the Supervisor picks up the new manifest.
+
 ### Bluetooth adapter reset
 
 The add-on power-cycles the Bluetooth adapter on startup to ensure a clean state. This is enabled by default (**Reset Bluetooth adapter on startup**). If you have other HA Bluetooth integrations that lose connectivity when this add-on restarts, disable the option.

--- a/ble-scale-sync-addon/config.yaml
+++ b/ble-scale-sync-addon/config.yaml
@@ -22,6 +22,15 @@ host_dbus: true
 privileged:
   - NET_ADMIN
   - NET_RAW
+# The Supervisor's default AppArmor profile denies the D-Bus method calls this
+# add-on needs, so it dies on the very first `Hello` handshake to
+# org.freedesktop.DBus before any BLE scan starts. Running unconfined is what
+# the standalone Docker image already does. Confinement buys little here: the
+# add-on already runs as root with host_network, host_dbus, NET_ADMIN and
+# NET_RAW. A custom apparmor.txt would be the tidier fix, but a profile that
+# fails to parse breaks add-on install AND update for every user, and it cannot
+# be tested in CI. See issue #271.
+apparmor: false
 hassio_api: true
 map:
   - share:rw

--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -25,7 +25,7 @@ head:
 | **Push notifications**    | Ntfy                                                         | No               | No                 | App only         |
 | **Local file export**     | CSV and JSONL                                                | SQLite           | No                 | No               |
 | **Multi-user**            | Automatic weight matching                                    | Manual selection | Per-user sync      | Per-account      |
-| **Supported scales**      | 26 protocol adapters                                         | 20+ brands       | Via openScale      | 1 (own brand)    |
+| **Supported scales**      | 27 protocol adapters                                         | 20+ brands       | Via openScale      | 1 (own brand)    |
 | **Body composition**      | 10 metrics (BIA)                                             | Varies           | 4 metrics          | Varies           |
 | **Docker**                | Multi-arch images                                            | No               | No                 | No               |
 | **Open source**           | GPL-3.0                                                      | GPL-3.0          | GPL-3.0            | No               |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -62,7 +62,7 @@ Yes. Set `update_check: false` in `config.yaml`, or run with `CI=true` in the en
 
 ### Is my scale supported?
 
-Check the [supported scales](/guide/supported-scales) page for the full list of 26 adapters. Coverage includes Xiaomi, Renpho (Elis 1, FITINDEX, Sencor, QN Scale), Eufy, Yunmai, Beurer (incl. BF720 / BF105), Sanitas, Medisana, Soehnle, and many unbranded Asian scales that reuse the Renpho or QN protocol. Auto-detect matches most devices without any MAC pinning.
+Check the [supported scales](/guide/supported-scales) page for the full list of 27 adapters. Coverage includes Xiaomi, Renpho (Elis 1, FITINDEX, Sencor, QN Scale), Eufy, Yunmai, Beurer (incl. BF720 / BF105), Sanitas, Medisana, Soehnle, and many unbranded Asian scales that reuse the Renpho or QN protocol. Auto-detect matches most devices without any MAC pinning.
 
 ### My scale is not listed. Can I add it?
 

--- a/docs/guide/esphome-proxy.md
+++ b/docs/guide/esphome-proxy.md
@@ -9,7 +9,17 @@ head:
 
 # ESPHome Bluetooth Proxy
 
-If you already run an [ESPHome Bluetooth proxy](https://esphome.io/components/bluetooth_proxy.html) mesh for Home Assistant, BLE Scale Sync can reuse it as its BLE radio. No dedicated ESP32 with custom firmware, no MQTT broker plumbing: the server connects to the ESPHome Native API on port 6053 and subscribes to BLE advertisements directly.
+An [ESPHome Bluetooth proxy](https://esphome.io/components/bluetooth_proxy.html) can act as BLE Scale Sync's BLE radio. No dedicated ESP32 with custom firmware, no MQTT broker plumbing: the server connects to the ESPHome Native API on port 6053 and subscribes to BLE advertisements directly.
+
+::: danger The proxy node must not be adopted by Home Assistant
+A proxy node serves its BLE advertisement subscription to **one API client at a time**. If Home Assistant has already adopted the node, it holds that subscription, and BLE Scale Sync connects successfully but never receives a single advertisement, so the scale is never seen. The ESPHome device log shows:
+
+```
+Only one API subscription is allowed at a time
+```
+
+Use a **dedicated ESPHome bluetooth-proxy node that you flash but do not add to Home Assistant**, and point BLE Scale Sync at that node. Your existing Home Assistant proxy mesh keeps working untouched. See [#232](https://github.com/KristianP26/ble-scale-sync/issues/232), [#248](https://github.com/KristianP26/ble-scale-sync/issues/248) and [#252](https://github.com/KristianP26/ble-scale-sync/issues/252).
+:::
 
 ::: tip Broadcast and GATT supported
 The ESPHome proxy transport handles both broadcast scales (parsed straight from advertisements) and GATT scales (connected on demand through the proxy, then read and disconnected). Multiple proxies can be configured for a mesh: a GATT connect is routed to the proxy that most recently saw the scale, with the others as fallbacks. Implemented in [issue #116](https://github.com/KristianP26/ble-scale-sync/issues/116).
@@ -29,11 +39,13 @@ The ESPHome proxy sees the scale's BLE advertisement, wraps it in a Native API `
 ## Requirements
 
 - A running ESPHome device with `bluetooth_proxy:` enabled, on ESPHome **2023.5 or newer** (older firmware used a different BLE event layout that is not handled by this transport)
+- The proxy node **must not be adopted by Home Assistant** (see the warning above); dedicate one node to BLE Scale Sync
+- The proxy node should have **no `remote_receiver:` / RF or IR receiver** configured (see the IR/RF note below)
 - Network reachability between BLE Scale Sync and the ESPHome device on TCP port 6053
 - Either the ESPHome API encryption key (recommended) or the legacy API password, matching the device's `api:` config
 
 ::: tip When to pick this vs the ESP32 MQTT proxy
-Both transports support broadcast and GATT scales. If you already have ESPHome proxies in your home, start here: zero new hardware. The [ESP32 MQTT proxy](/guide/esp32-proxy) additionally offers a display/beep feedback UI.
+Both transports support broadcast and GATT scales. Pick this one if you are comfortable flashing a spare ESP32 with stock ESPHome and want no custom firmware. The [ESP32 MQTT proxy](/guide/esp32-proxy) additionally offers a display/beep feedback UI. Either way the node is dedicated to BLE Scale Sync.
 :::
 
 ## Configuring BLE Scale Sync
@@ -95,6 +107,35 @@ volumes:
 ```
 
 ## Troubleshooting
+
+### Connects fine but never sees the scale ("Only one API subscription is allowed at a time")
+
+The proxy is already adopted by Home Assistant, which holds the node's single BLE
+advertisement subscription. BLE Scale Sync connects to the Native API and logs
+`ESPHome proxy connected` plus `ReadingWatcher started`, but no advertisement ever
+arrives, so no scale is matched.
+
+Flash a spare ESP32 as a bluetooth proxy and **do not add it to Home Assistant**,
+then point `esphome_proxy.host` at it. Board or RAM is not the cause: this happens
+on an Atom Echo and on an ESP32-S3 alike.
+
+### Proxy connection drops every few minutes (IR or RF receiver on the node)
+
+If the node also has a `remote_receiver:` (IR/RF) component, every received IR or RF
+signal, including stray ambient IR, makes ESPHome emit an API message that the
+Native API client library does not recognise. Older builds of BLE Scale Sync tore the
+proxy connection down on each one, and any weigh-in during the reconnect window was
+lost. You would see repeating pairs of:
+
+```
+ESPHome proxy <host>:6053 error: Failed find or parsed message type for Id: 137
+ESPHome proxy <host>:6053 error: Cannot set properties of undefined (setting 'length')
+```
+
+Unknown message ids are now ignored and the connection is kept alive, so this is
+handled. Even so, keep the IR/RF receiver on a different node than the one serving
+BLE Scale Sync: a dedicated bluetooth-proxy node should run `bluetooth_proxy:` and
+little else. Reported in [#252](https://github.com/KristianP26/ble-scale-sync/issues/252).
 
 ### Timed out connecting to ESPHome proxy
 

--- a/docs/guide/home-assistant-addon.md
+++ b/docs/guide/home-assistant-addon.md
@@ -31,7 +31,7 @@ The badge above uses [My Home Assistant](https://www.home-assistant.io/integrati
    :::
 
 ::: tip
-The add-on requires `host_network`, `host_dbus`, and the `NET_ADMIN` / `NET_RAW` capabilities to access the host Bluetooth adapter through BlueZ. The Supervisor grants these automatically.
+The add-on requires `host_network`, `host_dbus`, and the `NET_ADMIN` / `NET_RAW` capabilities to access the host Bluetooth adapter through BlueZ. The Supervisor grants these automatically. The add-on also declares `apparmor: false`, because the Supervisor's default AppArmor profile blocks the D-Bus handshake that BlueZ needs. See [#271](https://github.com/KristianP26/ble-scale-sync/issues/271).
 :::
 
 ## Quick start
@@ -174,8 +174,11 @@ User-supplied files live under `/share/ble-scale-sync/`:
    ```bash
    docker run --rm -it --network host --cap-add NET_ADMIN --cap-add NET_RAW \
      --group-add 112 -v /var/run/dbus:/var/run/dbus:ro \
+     --security-opt apparmor=unconfined \
      ghcr.io/kristianp26/ble-scale-sync:latest scan
    ```
+
+   On hosts whose Docker applies a restrictive default AppArmor policy, dropping `--security-opt apparmor=unconfined` makes this command exit with `DBusError` and `AccessDenied`. See [Troubleshooting](/troubleshooting#docker-issues).
 
 3. If the scale is visible, paste its MAC into the **Scale MAC address** field.
 4. If multiple Bluetooth adapters are attached, set **BLE adapter** to the one facing the scale (`hci1`, etc.).

--- a/docs/guide/supported-scales.md
+++ b/docs/guide/supported-scales.md
@@ -1,15 +1,15 @@
 ---
 title: Supported Scales
-description: All 25 BLE smart scale brands supported by BLE Scale Sync.
+description: All 26 BLE smart scale brands supported by BLE Scale Sync.
 head:
   - - meta
     - name: keywords
-      content: xiaomi mi scale, renpho scale bluetooth, eufy smart scale, yunmai scale, beurer bf scale, sanitas scale, medisana bs scale, silvercrest scale, 1byone scale, etekcity scale, inevifit scale, arboleaf scale, lepulse scale, fitdays scale, senssun scale, supported ble scales
+      content: koogeek scale, xiaomi mi scale, renpho scale bluetooth, eufy smart scale, yunmai scale, beurer bf scale, sanitas scale, medisana bs scale, silvercrest scale, 1byone scale, etekcity scale, inevifit scale, arboleaf scale, lepulse scale, fitdays scale, senssun scale, supported ble scales
 ---
 
 # Supported Scales
 
-BLE Scale Sync ships **26 protocol adapters** out of the box, covering Xiaomi, Renpho (incl. FITINDEX, Sencor, QN-Scale), Eufy (incl. P2 Pro T9149), Yunmai, Beurer, Sanitas, Medisana, and more, plus a generic Bluetooth SIG adapter that works with any spec-compliant BCS/WSS scale. Each adapter typically supports several models or rebrands sold under different names, so the real device coverage is much wider than the adapter count. All adapters provide weight + impedance for full [body composition](/body-composition) calculation.
+BLE Scale Sync ships **27 protocol adapters** out of the box, covering Xiaomi, Renpho (incl. FITINDEX, Sencor, QN-Scale), Eufy (incl. P2 Pro T9149), Yunmai, Beurer, Sanitas, Medisana, and more, plus a generic Bluetooth SIG adapter that works with any spec-compliant BCS/WSS scale. Each adapter typically supports several models or rebrands sold under different names, so the real device coverage is much wider than the adapter count. All adapters provide weight + impedance for full [body composition](/body-composition) calculation.
 
 ## Scale List
 
@@ -38,6 +38,7 @@ BLE Scale Sync ships **26 protocol adapters** out of the box, covering Xiaomi, R
 | **Hoffen** BS-8107                                                    |                                                                                                                                                                                                                                                   |
 | **Hesley** (YunChen)                                                  |                                                                                                                                                                                                                                                   |
 | **Inlife** (FatScale)                                                 |                                                                                                                                                                                                                                                   |
+| **Koogeek** S1 | Vendor FFF0 protocol. Body composition is estimated from weight and impedance, because the vendor computed it in a cloud service that no longer exists. See Known Limitations |
 | **Exingtech** Y1 (vscale)                                             |                                                                                                                                                                                                                                                   |
 | Any **standard BT SIG** scale (BCS/WSS)                               | Catch-all for standard-compliant scales                                                                                                                                                                                                           |
 
@@ -69,6 +70,7 @@ We recommend setting `scale_mac` in `config.yaml`. It prevents the app from acci
 | **Soehnle**, **Sanitas** SBF72/73, **Beurer** BF915   | Create user slot 1 in the manufacturer's phone app first                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | **Standard GATT**                                     | Select user 1 on the scale before measuring                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | **Senssun** Model B                                   | Not supported yet (only Model A with service 0xFFF0)                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| **Koogeek** S1 | The measurement protocol is implemented and verified, but this hardware's GATT connect and service discovery are unreliable on BlueZ and on ESP32 NimBLE, and succeed only occasionally on macOS CoreBluetooth. That is a trait of the device rather than of the adapter. Retry, or use whichever transport works best for your unit |
 | **Renpho ES-CS20M / Elis 1** (some hardware variants) | Some units use broadcast-only firmware that does not allow GATT connections. The same model name can ship with different internal hardware. If your ES-CS20M or Elis 1 is broadcast-only, ble-scale-sync reads weight directly from BLE advertisements. Body composition is estimated from BMI (Deurenberg formula) instead of impedance, since impedance is not available in broadcast mode. Run `npm run diagnose` to check whether your unit is connectable or broadcast-only. |
 
 ## Don't See Your Scale?

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -130,6 +130,27 @@ The original Pi Zero W has an ARMv6 CPU, which is **not supported**. The `esbuil
 
 ## Docker Issues
 
+### Container exits at startup with `DBusError` and `AccessDenied`
+
+The log names `An AppArmor policy prevents this sender from sending this message`, mentions `member="Hello"`, and the container exits before any scanning begins.
+
+The host's D-Bus daemon asks the kernel whether the container may talk to `org.freedesktop.DBus`. Docker's `docker-default` AppArmor profile carries no D-Bus rules, and that mediation is deny by default, so the handshake never completes. Ubuntu 24.04 hits this most often because its AppArmor 4.x stack tightened the defaults. Bind-mounting the D-Bus socket is not enough on those hosts. Run the container unconfined:
+
+```bash
+docker run --security-opt apparmor=unconfined ...
+```
+
+Or in `docker-compose.yml`:
+
+```yaml
+services:
+  ble-scale-sync:
+    security_opt:
+      - apparmor=unconfined
+```
+
+The Home Assistant add-on sets the equivalent option in its manifest, so it needs no action. Reported in [#271](https://github.com/KristianP26/ble-scale-sync/issues/271).
+
 ### Container can't find BLE adapter
 
 Make sure you're passing all required flags. See [Getting Started](/guide/getting-started#docker) for the full command. The most common mistake is forgetting `--network host` or the D-Bus volume mount.

--- a/firmware/ble_bridge.py
+++ b/firmware/ble_bridge.py
@@ -572,10 +572,28 @@ class BleBridge:
         return {"chars": chars_info}
 
     async def start_notify(self, uuid_str, publish_fn):
-        """Start forwarding notifications from a characteristic via publish_fn."""
+        """Start forwarding notifications from a characteristic via publish_fn.
+
+        This also writes the CCCD (Client Characteristic Configuration
+        Descriptor) so the peripheral actually sends notifications. Without this
+        step aioble's char.notified() just waits forever on an empty queue and
+        times out with no data (#231)."""
         char = self._chars.get(uuid_str)
         if not char:
             return
+
+        # Enable notify/indicate on the peripheral. aioble's notified() only
+        # consumes events; it does not turn on the CCCD bit itself.
+        print(f"Subscribe: enabling CCCD for {uuid_str}")
+        try:
+            await char.subscribe(
+                notify=bool(char.properties & bluetooth.FLAG_NOTIFY),
+                indicate=bool(char.properties & bluetooth.FLAG_INDICATE),
+            )
+        except Exception as e:
+            print(f"Subscribe: CCCD enable failed for {uuid_str}: {type(e).__name__}: {e}")
+            raise
+        print(f"Subscribe: CCCD enabled for {uuid_str}")
 
         async def _notify_loop():
             try:

--- a/firmware/tests/test_connect_irq.py
+++ b/firmware/tests/test_connect_irq.py
@@ -9,6 +9,7 @@ times out.
 Run: python -m unittest discover -s firmware/tests
 """
 
+import asyncio
 import os
 import sys
 import types
@@ -97,6 +98,25 @@ class _FakeChar:
     def __init__(self, uuid, properties):
         self.uuid = uuid
         self.properties = properties
+
+
+class _SubscribableFakeChar:
+    """Models aioble's ClientCharacteristic subscribe/notified surface. Records
+    whether subscribe() was awaited and with which CCCD flags, and lets the
+    notify loop block until cancelled so tests can assert on the subscribe call
+    without the loop racing ahead (#231)."""
+
+    def __init__(self, uuid, properties):
+        self.uuid = uuid
+        self.properties = properties
+        self.subscribed = []  # list of (notify, indicate) tuples
+
+    async def subscribe(self, notify=True, indicate=False):
+        self.subscribed.append((notify, indicate))
+
+    async def notified(self, timeout_ms=None):
+        # Block forever; real firmware loops until cancelled/disconnected.
+        await asyncio.Event().wait()
 
 
 class _FakeService:
@@ -345,6 +365,54 @@ class TestConnectDiscoversCharsViaAsyncFor(unittest.IsolatedAsyncioTestCase):
                 "00002a9d00001000800000805f9b34fb",
             ],
         )
+
+
+class TestStartNotifySubscribesCccd(unittest.IsolatedAsyncioTestCase):
+    """start_notify() must write the CCCD via char.subscribe() before waiting
+    on char.notified(). Without this, the peripheral never sends notifications,
+    the loop times out with an empty error, and the QN handshake stalls (#231)."""
+
+    async def test_notify_characteristic_enables_cccd(self):
+        bridge = ble_bridge.BleBridge()
+        char = _SubscribableFakeChar(
+            "0000fff1-0000-1000-8000-00805f9b34fb", _bt.FLAG_NOTIFY
+        )
+        bridge._chars[char.uuid] = char
+        bridge._conn = _FakeConn()
+
+        async def publish_fn(_uuid, _data):
+            pass
+
+        await bridge.start_notify(char.uuid, publish_fn)
+        self.assertEqual(char.subscribed, [(True, False)])
+        # Clean up the background notify loop.
+        await bridge.disconnect()
+
+    async def test_indicate_characteristic_enables_cccd(self):
+        bridge = ble_bridge.BleBridge()
+        char = _SubscribableFakeChar(
+            "00002a9d-0000-1000-8000-00805f9b34fb", _bt.FLAG_INDICATE
+        )
+        bridge._chars[char.uuid] = char
+        bridge._conn = _FakeConn()
+
+        async def publish_fn(_uuid, _data):
+            pass
+
+        await bridge.start_notify(char.uuid, publish_fn)
+        self.assertEqual(char.subscribed, [(False, True)])
+        await bridge.disconnect()
+
+    async def test_missing_char_is_noop(self):
+        bridge = ble_bridge.BleBridge()
+        bridge._conn = _FakeConn()
+
+        async def publish_fn(_uuid, _data):
+            pass
+
+        # Should not raise or create a task.
+        await bridge.start_notify("0000dead-0000-1000-8000-00805f9b34fb", publish_fn)
+        self.assertEqual(bridge._notify_tasks, [])
 
 
 if __name__ == "__main__":

--- a/src/ble/handler-esphome-proxy/client.ts
+++ b/src/ble/handler-esphome-proxy/client.ts
@@ -1,9 +1,92 @@
+import { createRequire } from 'node:module';
 import type { EsphomeProxyConfig } from '../../config/schema.js';
 import { bleLog, errMsg } from '../types.js';
+
+const nodeRequire = createRequire(import.meta.url);
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 export const CONNECT_TIMEOUT_MS = 30_000;
+
+// ─── Unknown-message patch (#252) ────────────────────────────────────────────
+
+/**
+ * Inert stand-in returned for API messages this library version cannot decode.
+ * `connection.js` reads `message.constructor.type` and calls `message.toObject()`
+ * on every frame, so the placeholder must satisfy both. `mapMessageByType()`
+ * passes an unrecognised type straight through, and nothing listens for
+ * `message.UnknownEsphomeMessage`, so the frame is effectively ignored.
+ */
+class UnknownEsphomeMessage {
+  static type = 'UnknownEsphomeMessage';
+  toObject(): Record<string, never> {
+    return {};
+  }
+}
+
+/** Set before the attempt so a failing patch is not retried on every reconnect. */
+let patchAttempted = false;
+
+/**
+ * Repair `FrameHelper.buildMessage` in `@2colors/esphome-native-api` (1.3.6).
+ *
+ * The shipped implementation does `pb[id_to_type[messageId]].deserializeBinary()`,
+ * which throws for an id it does not know, and then runs
+ * `if (typeof id_to_type[messageId] !== undefined) this.end();`. `typeof` always
+ * yields a string, so that guard is always true and the proxy connection is torn
+ * down for UNKNOWN ids as well. Newer ESPHome firmware emits id 137
+ * (InfraredRFReceiveEvent) on every IR/RF event, so any proxy node with a
+ * `remote_receiver` dropped the connection constantly and lost in-flight
+ * readings. `buildMessage` also returned undefined, which the frame helpers then
+ * dereferenced ("Cannot set properties of undefined (setting 'length')").
+ *
+ * Clients are expected to ignore unrecognised message types, so we skip them and
+ * keep the link up, while preserving the original teardown for a KNOWN type that
+ * fails to parse (there the stream really is desynced).
+ *
+ * Patching the prototype covers both NoiseFrameHelper and PlaintextFrameHelper.
+ * `createRequire` resolves the same module instance the dynamically imported
+ * Client uses (Node shares the CJS require cache with ESM interop). If a future
+ * release moves these internals the feature check and try/catch fall back to the
+ * library default, which is the current behaviour, so this cannot regress.
+ */
+function patchUnknownMessageHandling(): void {
+  if (patchAttempted) return;
+  patchAttempted = true;
+  try {
+    const FrameHelper = nodeRequire('@2colors/esphome-native-api/lib/utils/frameHelper.js');
+    const { id_to_type, pb } = nodeRequire('@2colors/esphome-native-api/lib/utils/messages.js');
+    if (typeof FrameHelper?.prototype?.buildMessage !== 'function') {
+      bleLog.warn(
+        'ESPHome unknown-message patch skipped: buildMessage not found (library internals changed).',
+      );
+      return;
+    }
+    FrameHelper.prototype.buildMessage = function (
+      this: { emit: (event: string, err: Error) => void; end: () => void },
+      messageId: number,
+      bytes: Uint8Array,
+    ): unknown {
+      const type = id_to_type[messageId];
+      if (type === undefined || !pb[type]) {
+        // Unknown id (e.g. 137 InfraredRFReceiveEvent): ignore, keep the link up.
+        return new UnknownEsphomeMessage();
+      }
+      try {
+        return pb[type].deserializeBinary(bytes);
+      } catch {
+        this.emit('error', new Error(`Failed to parse ESPHome message ${type} (id ${messageId}).`));
+        this.end();
+        return undefined;
+      }
+    };
+  } catch (e: unknown) {
+    bleLog.warn(`ESPHome unknown-message patch failed, using library default: ${errMsg(e)}`);
+  }
+}
+
+/** Exposed for the regression test that guards the patched library internals. */
+export const _internals = { patchUnknownMessageHandling };
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -66,6 +149,9 @@ export interface EsphomeConnection {
 // ─── Client factory ──────────────────────────────────────────────────────────
 
 export async function createEsphomeClient(config: EsphomeProxyConfig): Promise<EsphomeClient> {
+  // Must run before the Client (and its FrameHelper) is constructed. #252
+  patchUnknownMessageHandling();
+
   const mod = (await import('@2colors/esphome-native-api')) as unknown as {
     Client: new (options: Record<string, unknown>) => EsphomeClient;
   };

--- a/src/ble/handler-esphome-proxy/watcher.ts
+++ b/src/ble/handler-esphome-proxy/watcher.ts
@@ -130,7 +130,7 @@ export class ReadingWatcher implements Watcher {
     // Broadcast yielded nothing usable. If the adapter has a GATT path, connect
     // on demand through the proxy pool. (decision is 'gatt' or 'none'.)
     if (decision.kind === 'gatt') {
-      this.readViaGatt(adapter, address, addrLc);
+      this.readViaGatt(adapter, info, address, addrLc);
     }
   }
 
@@ -144,7 +144,12 @@ export class ReadingWatcher implements Watcher {
     this.queue.push(raw);
   }
 
-  private readViaGatt(adapter: ScaleAdapter, address: string, addrLc: string): void {
+  private readViaGatt(
+    adapter: ScaleAdapter,
+    info: BleDeviceInfo,
+    address: string,
+    addrLc: string,
+  ): void {
     if (this.gattInFlight.has(addrLc)) return;
     if (!this.pool) return;
     const pool = this.pool;
@@ -152,12 +157,33 @@ export class ReadingWatcher implements Watcher {
     bleLog.info(`Matched: ${adapter.name} (${address}); opening GATT via ESPHome proxy`);
     void (async () => {
       let session: Awaited<ReturnType<typeof pool.connectGatt>> | null = null;
+      // Adapter that actually drives the read; may be re-resolved below once the
+      // characteristics are known. Kept in the outer scope so a failure warning
+      // names the adapter that ran, not the pre-discovery guess.
+      let gattAdapter = adapter;
       try {
         session = await pool.connectGatt(address);
+        // Re-resolve char-aware now that GATT discovery is complete, mirroring
+        // the node-ble post-discovery pass (#177). The advertisement-time match
+        // keyed only on name + advertised service UUIDs, which lets a generic-
+        // service adapter (e.g. Inlife on the bare fff0 vendor service) win over
+        // the correct char-specific one. On a Eufy P1 "T9147" (fff1 + fff4, no
+        // fff2) Inlife matched then failed writing fff2; with the discovered
+        // chars, Inlife rejects (no fff2) and 1byone (Eufy) wins on fff4 (#251).
+        gattAdapter =
+          resolveAdapter(
+            { ...info, characteristicUuids: [...session.charMap.keys()] },
+            this.adapters,
+          ) ?? adapter;
+        if (gattAdapter.name !== adapter.name) {
+          bleLog.info(
+            `Re-resolved adapter after GATT discovery: ${adapter.name} -> ${gattAdapter.name} (${address})`,
+          );
+        }
         const raw = await waitForRawReading(
           session.charMap,
           session.device,
-          adapter,
+          gattAdapter,
           this.profile ?? { height: 170, age: 30, gender: 'male', isAthlete: false },
           address.replace(/[:-]/g, '').toUpperCase(),
           undefined,
@@ -166,7 +192,7 @@ export class ReadingWatcher implements Watcher {
         );
         this.pushDeduped(address, raw, raw.reading.weight);
       } catch (e) {
-        this.warnGattFailure(adapter.name, address, errMsg(e));
+        this.warnGattFailure(gattAdapter.name, address, errMsg(e));
       } finally {
         if (session) await session.close();
         this.gattInFlight.delete(addrLc);

--- a/src/ble/handler-mqtt-proxy/watcher.ts
+++ b/src/ble/handler-mqtt-proxy/watcher.ts
@@ -429,26 +429,32 @@ export class ReadingWatcher implements Watcher {
     try {
       client = await getOrCreatePersistentClient(this.config);
 
-      // Match the address to an adapter
+      // Match the address to an adapter. The ESP32 already discovered the GATT
+      // characteristics, so populate them and resolve char-aware FIRST, exactly
+      // like the node-ble post-discovery re-resolution (#177). This lets a
+      // structural matcher win over a generic-notify-char collision: e.g. a
+      // QN-family Elis 1 exposes ae01/ae02 (a positive QN signature) plus the
+      // generic fff1/fff2 pair; without the structural pass the higher-priority
+      // Eufy P2 adapter stole it via its fff2 notify char and then failed on the
+      // missing fff4 (#258).
       const info = toBleDeviceInfo({ address: data.address, name: '', rssi: 0, services: [] });
-      // For autonomous connect, we match by scanning the chars for known notify UUIDs
-      // Order by descriptor priority (mirrors resolveAdapter) then apply the
-      // per-adapter OR of matches() and a charNotify match. A stable sort keeps
-      // the input order for ties, so behavior matches the prior array-order find.
-      const adapter = [...this.adapters]
-        .sort((a, b) => (b.match?.priority ?? 0) - (a.match?.priority ?? 0))
-        .find((a) => {
-          // Try matching by device info first
-          if (a.matches(info)) return true;
-          // Also match by charNotifyUuid: the ESP32 already connected, so the
-          // adapter may match only by its GATT characteristic.
-          // Normalize both sides (case + 16-bit vs 128-bit) to avoid silent mismatches.
-          if (a.charNotifyUuid) {
-            const normalized = normalizeUuid(a.charNotifyUuid);
-            return data.chars.some((c) => normalizeUuid(c.uuid) === normalized);
-          }
-          return false;
-        });
+      info.characteristicUuids = data.chars.map((c) => c.uuid.toLowerCase());
+      let adapter = resolveAdapter(info, this.adapters);
+      if (!adapter) {
+        // No structural match: fall back to a priority-ordered notify-char scan
+        // so name/notify-only adapters still resolve when nothing matches by
+        // descriptor. A stable sort keeps input order for ties.
+        adapter = [...this.adapters]
+          .sort((a, b) => (b.match?.priority ?? 0) - (a.match?.priority ?? 0))
+          .find((a) => {
+            if (a.charNotifyUuid) {
+              // Normalize both sides (case + 16-bit vs 128-bit) to avoid silent mismatches.
+              const normalized = normalizeUuid(a.charNotifyUuid);
+              return data.chars.some((c) => normalizeUuid(c.uuid) === normalized);
+            }
+            return false;
+          });
+      }
 
       if (!adapter) {
         bleLog.warn(

--- a/src/ble/handler-node-ble/scan.ts
+++ b/src/ble/handler-node-ble/scan.ts
@@ -248,7 +248,16 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
       // the first service-only match. BlueZ can export characteristics late
       // ([bluez/bluez#1489]), so retry the enumeration within the existing
       // discovery budget until an adapter is recognized. #177
-      const gatt = await device.gatt();
+      // Wrap device.gatt() in the same timeout as the standard path below: if
+      // the peripheral drops the connection mid-discovery, node-ble waits on the
+      // D-Bus ServicesResolved property forever, freezing the event loop after
+      // connect but before the scan cycle fails, so the consecutive-failure
+      // watchdog never trips (#273).
+      const gatt = await withTimeout(
+        device.gatt(),
+        GATT_DISCOVERY_TIMEOUT_MS,
+        'GATT server acquisition timed out',
+      );
       const serviceUuids = await gatt.services();
       bleLog.debug(`Services: [${serviceUuids.join(', ')}]`);
 

--- a/src/ble/shared.ts
+++ b/src/ble/shared.ts
@@ -388,7 +388,7 @@ export function waitForRawReading(
         const ack = adapter.buildAck(data);
         if (ack) {
           const ackBuf = Buffer.isBuffer(ack) ? ack : Buffer.from(ack);
-          void ackWriteChar.write(ackBuf, true).catch((e: unknown) => {
+          void ackWriteChar.write(ackBuf, adapter.ackWithResponse ?? true).catch((e: unknown) => {
             if (!resolved) bleLog.debug(`ACK write error: ${errMsg(e)}`);
           });
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -184,13 +184,15 @@ async function main(): Promise<void> {
   }
   log.info(`Adapters: ${adapters.map((a) => a.name).join(', ')}\n`);
 
-  // Inject per-device broadcast secrets (e.g. the Xiaomi S800 MiBeacon bind key)
-  // into adapters that decrypt them. Optional + no-op for adapters without
-  // configure(). Re-applied on config reload below so a hot-edited key takes effect.
-  const applyAdapterBindKey = (bindKey: string | undefined): void => {
-    for (const a of adapters) a.configure?.({ bindKey });
+  // Inject runtime config into adapters that read it: the Xiaomi S800 MiBeacon
+  // bind key, and the configured display unit that the QN 0x13 command echoes to
+  // the scale (#269). Optional + no-op for adapters without configure().
+  // Re-applied on config reload below so a hot-edited key or unit takes effect.
+  const applyAdapterConfig = (bindKey: string | undefined): void => {
+    const weightUnit = ctx.config.scale.weight_unit;
+    for (const a of adapters) a.configure?.({ bindKey, weightUnit });
   };
-  applyAdapterBindKey(ctx.config.ble?.bind_key ?? undefined);
+  applyAdapterConfig(ctx.config.ble?.bind_key ?? undefined);
 
   let singleUserExporters: Exporter[] | undefined;
   if (!ctx.dryRun) {
@@ -247,7 +249,7 @@ async function main(): Promise<void> {
 
   const onReload = async (): Promise<void> => {
     await reloadAppConfig(ctx, displaySnapshotRef);
-    applyAdapterBindKey(ctx.config.ble?.bind_key ?? undefined);
+    applyAdapterConfig(ctx.config.ble?.bind_key ?? undefined);
     if (ctx.config.users.length === 1) {
       singleUserExporters = ctx.dryRun ? undefined : buildSingleUserExporters(ctx);
     }

--- a/src/interfaces/scale-adapter.ts
+++ b/src/interfaces/scale-adapter.ts
@@ -1,4 +1,5 @@
 import type { MatchDescriptor } from '../scales/match-descriptor.js';
+import type { WeightUnit } from '../config/schema.js';
 export type { MatchDescriptor };
 
 export type Gender = 'male' | 'female';
@@ -129,6 +130,13 @@ export interface ConnectionContext {
 export interface AdapterRuntimeConfig {
   /** MiBeacon bind key (32 hex chars) for broadcast-encrypted scales (Xiaomi S800). */
   bindKey?: string;
+  /**
+   * Configured display unit (`scale.weight_unit`). Adapters whose protocol tells
+   * the scale which unit to show (e.g. the QN 0x13 config command) honour this so
+   * a read does not flip the scale's display (#269). Optional and ignored by
+   * adapters that do not write a unit.
+   */
+  weightUnit?: WeightUnit;
 }
 
 /**

--- a/src/interfaces/scale-adapter.ts
+++ b/src/interfaces/scale-adapter.ts
@@ -282,6 +282,15 @@ export interface AckProtocol {
    * characteristic after each notification. Return null to write nothing.
    */
   buildAck(data: Buffer): Buffer | number[] | null;
+
+  /**
+   * Whether the ACK is written with a response. Defaults to true, which keeps
+   * the Beurer/Sanitas behaviour. Vendor OEM write characteristics in the
+   * 0xFFF0 and 0xFFB0 families are often write-without-response only, and there
+   * a with-response write is rejected by BlueZ, so the ACK never lands and the
+   * scale never starts streaming. Those adapters set this false.
+   */
+  readonly ackWithResponse?: boolean;
 }
 
 /**

--- a/src/scales/beurer-bf720.ts
+++ b/src/scales/beurer-bf720.ts
@@ -54,7 +54,7 @@ interface CachedComp {
 }
 
 /**
- * Adapter for Beurer SIG-standard BLE scales (BF720, BF105).
+ * Adapter for Beurer SIG-standard BLE scales (BF720, BF105, BF500).
  *
  * These speak pure Bluetooth SIG GATT: Weight Scale (0x181D / 0x2A9D), Body
  * Composition (0x181B / 0x2A9C) and User Data (0x181C / 0x2A9F) services. Body
@@ -74,7 +74,7 @@ export class BeurerBf720Adapter implements ScaleAdapterCore, GattWiring, MultiCh
   readonly match: MatchDescriptor = {
     priority: 220,
     custom: true,
-    names: { includes: ['bf720', 'bf105'] },
+    names: { includes: ['bf720', 'bf105', 'bf500'] },
     serviceUuids: ['181d', '181b'],
     manufacturerId: 0x0611,
   };
@@ -100,12 +100,22 @@ export class BeurerBf720Adapter implements ScaleAdapterCore, GattWiring, MultiCh
 
   matches(device: BleDeviceInfo): boolean {
     const name = (device.localName || '').toLowerCase();
-    if (name.includes('bf720') || name.includes('bf105')) return true;
+    // BF500 speaks the same SIG consent+bond protocol as the BF720 (verified
+    // against an HCI snoop in #83: consent write 02/userIndex/pinLE, weight on
+    // 0x2A9D, native body composition on 0x2A9C). On Linux auto-discovery the
+    // advertised service UUIDs and manufacturer data are often absent, so the
+    // name is what routes it here instead of falling to Standard GATT, which
+    // sends a code-0 consent on an unbonded link and reads nothing.
+    if (name.includes('bf720') || name.includes('bf105') || name.includes('bf500')) return true;
     if (device.manufacturerData?.id !== BEURER_COMPANY_ID) return false;
     // A bare company id is too weak: this adapter is ordered ahead of the
     // name-based Beurer/Sanitas adapters, so require a SIG WSS/BCS service
     // (advertised or, on the connect path, discovered) before claiming it.
-    const isSig = (u: string) => u === SVC_WEIGHT_SCALE || u === SVC_BODY_COMPOSITION;
+    // Accept both short (advertised) and full (discovered) UUID forms.
+    const isSig = (u: string) => {
+      const n = u.toLowerCase().replace(/-/g, '');
+      return n === SVC_WEIGHT_SCALE || n === SVC_BODY_COMPOSITION || n === '181d' || n === '181b';
+    };
     return (
       (device.serviceUuids ?? []).some(isSig) ||
       (device.serviceData ?? []).some((sd) => isSig(sd.uuid))
@@ -125,7 +135,7 @@ export class BeurerBf720Adapter implements ScaleAdapterCore, GattWiring, MultiCh
     const pin = ctx.scaleAuth?.pin;
     if (pin == null) {
       throw new Error(
-        'Beurer BF720/BF105 needs a consent PIN. Set `users[].beurer_pin` in config.yaml ' +
+        'Beurer BF720/BF105/BF500 needs a consent PIN. Set `users[].beurer_pin` in config.yaml ' +
           '(the code the scale was paired with in the Beurer / openScale app, or shown on ' +
           "the scale's control unit).",
       );

--- a/src/scales/hutbit.ts
+++ b/src/scales/hutbit.ts
@@ -1,0 +1,127 @@
+import type {
+  BleDeviceInfo,
+  CharacteristicBinding,
+  ConnectionContext,
+  ScaleAdapterCore,
+  GattWiring,
+  ScaleReading,
+  UserProfile,
+  BodyComposition,
+} from '../interfaces/scale-adapter.js';
+import { uuid16, buildPayload } from './body-comp-helpers.js';
+import { bleLog } from '../ble/types.js';
+import type { MatchDescriptor } from './match-descriptor.js';
+
+// ─── Hutbit Smart Scale (Lefu / Fitdays FFB0 "AC02" 8-byte protocol) ─────────
+
+const CHR_FFB1 = uuid16(0xffb1); // write (handshake, phone→scale)
+const CHR_FFB2 = uuid16(0xffb2); // notify (weight stream, scale→phone)
+
+/**
+ * Handshake replayed on FFB1 (write-without-response) after enabling FFB2
+ * notifications. Fixed 8-byte AC02 frames decoded from two Fitdays HCI snoops
+ * (#254). Unlike the Robi S9's 20-byte protocol, every frame is a fixed
+ * `AC 02 | D0 D1 D2 D3 | STATUS | CKSUM` with a plain additive checksum and NO
+ * app-identity token, so the frames are stable and safe to replay verbatim.
+ * `ac02fe060000ccd0` is the poll/keepalive the app repeats through the session.
+ */
+const HANDSHAKE: string[] = [
+  'ac02fa010000ccc7',
+  'ac02fb021fa5cc8d',
+  'ac02fde20101ccad',
+  'ac02fc010000ccc9',
+  'ac02fe060000ccd0',
+];
+
+const FRAME_LEN = 8;
+const FRAME_HEADER0 = 0xac;
+const FRAME_HEADER1 = 0x02;
+const STATUS_STABLE = 0xca; // final/stable reading (0xCE = measuring/unstable)
+const WEIGHT_DIV = 10; // weight = u16 BE / 10 → kg
+
+/** Additive checksum over D0..STATUS (bytes 2..6), matching the vendor frames. */
+function frameChecksum(data: Buffer): number {
+  return (data[2] + data[3] + data[4] + data[5] + data[6]) & 0xff;
+}
+
+/**
+ * Adapter for the Hutbit Smart Scale (model 218008 / WL292, Fitdays app, Lefu
+ * OEM). It shares service 0xFFB0 with the Robi S9 and openScale MGB families
+ * but speaks a simpler, fixed 8-byte "AC02" protocol: after enabling FFB2
+ * notifications the phone replays a short FFB1 handshake, then the scale streams
+ * `AC 02 [weight_u16_BE] 00 00 [STATUS] [CKSUM]` frames on FFB2, where
+ * STATUS 0xCE = measuring/unstable and 0xCA = stable/final. Weight = u16 / 10 kg.
+ *
+ * Decoded from two known-weight HCI snoops (#254): `ac0203490000ca16`
+ * = 0x0349 = 841 → 84.1 kg. The unit's bioimpedance is unreliable (it reported
+ * 0.4–0.7 % body fat), so it is treated as weight-only and body composition is
+ * derived via the shared BIA/BMI pipeline, same as the Robi S9 / Renpho adapters.
+ */
+export class HutbitAdapter implements ScaleAdapterCore, GattWiring {
+  readonly name = 'Hutbit';
+  readonly match: MatchDescriptor = {
+    priority: 35,
+    custom: true,
+    names: { includes: ['hutbit'] },
+    serviceUuids: ['ffb0'],
+  };
+  readonly charNotifyUuid = CHR_FFB2;
+  readonly charWriteUuid = CHR_FFB1;
+  readonly normalizesWeight = true;
+
+  readonly characteristics: CharacteristicBinding[] = [
+    { uuid: CHR_FFB1, type: 'write' },
+    { uuid: CHR_FFB2, type: 'notify' },
+  ];
+
+  private final = false;
+
+  matches(device: BleDeviceInfo): boolean {
+    // Advertised name is "Hutbit Scale"; match by name only. The nameless FFB0
+    // space is deliberately left to the Robi S9 (FFB3 result char) and the MGB
+    // fallback — the Hutbit exposes no unique post-discovery characteristic
+    // (FFB3 is present but unused), so claiming nameless FFB0 here would risk
+    // shadowing those adapters.
+    return (device.localName || '').toLowerCase().includes('hutbit');
+  }
+
+  async onConnected(ctx: ConnectionContext): Promise<void> {
+    this.final = false;
+    for (const hex of HANDSHAKE) {
+      await ctx.write(CHR_FFB1, Buffer.from(hex, 'hex'), true);
+      await new Promise((r) => setTimeout(r, 150));
+    }
+    bleLog.debug('Hutbit: handshake sent');
+  }
+
+  parseNotification(data: Buffer): ScaleReading | null {
+    // Fixed 8-byte AC02 weight frame: AC 02 [weight u16 BE] 00 00 [STATUS] [CKSUM]
+    if (data.length !== FRAME_LEN) return null;
+    if (data[0] !== FRAME_HEADER0 || data[1] !== FRAME_HEADER1) return null;
+    if (frameChecksum(data) !== data[7]) return null;
+
+    bleLog.debug(`Hutbit frame: ${data.toString('hex')}`);
+
+    // Only the stable (0xCA) frame is a final reading; 0xCE frames are the live
+    // settling stream and are treated as progress only.
+    if (data[6] !== STATUS_STABLE) return null;
+
+    const weight = data.readUInt16BE(2) / WEIGHT_DIV;
+    if (!(weight > 0) || !Number.isFinite(weight)) return null;
+
+    this.final = true;
+    // Weight-only: the sensor's bioimpedance is unreliable, so emit impedance 0
+    // and let the shared BIA/BMI pipeline derive body composition.
+    return { weight, impedance: 0 };
+  }
+
+  isComplete(reading: ScaleReading): boolean {
+    return reading.weight > 0 && this.final;
+  }
+
+  computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {
+    // Body composition via the shared BMI/BIA fallback; the vendor's own
+    // bioimpedance is unreliable and its body-comp frames are not decoded.
+    return buildPayload(reading.weight, reading.impedance, {}, profile);
+  }
+}

--- a/src/scales/hutbit.ts
+++ b/src/scales/hutbit.ts
@@ -54,7 +54,7 @@ function frameChecksum(data: Buffer): number {
  *
  * Decoded from two known-weight HCI snoops (#254): `ac0203490000ca16`
  * = 0x0349 = 841 → 84.1 kg. The unit's bioimpedance is unreliable (it reported
- * 0.4–0.7 % body fat), so it is treated as weight-only and body composition is
+ * 0.4 to 0.7 % body fat), so it is treated as weight-only and body composition is
  * derived via the shared BIA/BMI pipeline, same as the Robi S9 / Renpho adapters.
  */
 export class HutbitAdapter implements ScaleAdapterCore, GattWiring {
@@ -88,7 +88,11 @@ export class HutbitAdapter implements ScaleAdapterCore, GattWiring {
   async onConnected(ctx: ConnectionContext): Promise<void> {
     this.final = false;
     for (const hex of HANDSHAKE) {
-      await ctx.write(CHR_FFB1, Buffer.from(hex, 'hex'), true);
+      // Write without response: FFB1 is the Lefu/Fitdays FFB0 handshake char and
+      // the family writes no-response. A char that advertises only
+      // WRITE_NO_RESPONSE rejects a with-response write, so this is the safe mode
+      // and matches the documented protocol above (#268 review).
+      await ctx.write(CHR_FFB1, Buffer.from(hex, 'hex'), false);
       await new Promise((r) => setTimeout(r, 150));
     }
     bleLog.debug('Hutbit: handshake sent');

--- a/src/scales/index.ts
+++ b/src/scales/index.ts
@@ -16,6 +16,7 @@ import { EsCs20mAdapter } from './es-cs20m.js';
 import { ExingtechY1Adapter } from './exingtech-y1.js';
 import { ExcelvanCF369Adapter } from './excelvan-cf369.js';
 import { HesleyScaleAdapter } from './hesley.js';
+import { KoogeekS1Adapter } from './koogeek-s1.js';
 import { InlifeScaleAdapter } from './inlife.js';
 import { DigooScaleAdapter } from './digoo.js';
 import { OneByoneAdapter, OneByoneNewAdapter } from './one-byone.js';
@@ -57,6 +58,9 @@ export const adapters: ScaleAdapter[] = [
   new ExingtechY1Adapter(),
   new ExcelvanCF369Adapter(),
   new HesleyScaleAdapter(),
+  // Koogeek-S1 outranks Inlife because a Koogeek advertises the bare 0xFFF0
+  // service, which Inlife's pre-connect fallback would otherwise claim (#270).
+  new KoogeekS1Adapter(),
   new InlifeScaleAdapter(),
   new DigooScaleAdapter(),
   new OneByoneAdapter(),

--- a/src/scales/index.ts
+++ b/src/scales/index.ts
@@ -22,6 +22,7 @@ import { DigooScaleAdapter } from './digoo.js';
 import { OneByoneAdapter, OneByoneNewAdapter } from './one-byone.js';
 import { ActiveEraAdapter } from './active-era.js';
 import { RobiS9Adapter } from './robi-s9.js';
+import { HutbitAdapter } from './hutbit.js';
 import { MgbAdapter } from './mgb.js';
 import { HoffenAdapter } from './hoffen.js';
 import { SenssunAdapter } from './senssun.js';
@@ -70,6 +71,9 @@ export const adapters: ScaleAdapter[] = [
   // Robi speaks a different protocol and is matched by name or its FFB3 result
   // characteristic, so it must win before the generic MGB FFB0 fallback (#228).
   new RobiS9Adapter(),
+  // Hutbit (Lefu/Fitdays FFB0 8-byte AC02 protocol): matches by its "Hutbit"
+  // name; sits before the generic MGB FFB0 fallback (#254).
+  new HutbitAdapter(),
   new MgbAdapter(),
   new HoffenAdapter(),
   // Generic standard GATT adapter last — matches by service UUID / brand names

--- a/src/scales/inlife.ts
+++ b/src/scales/inlife.ts
@@ -13,6 +13,8 @@ import type { MatchDescriptor } from './match-descriptor.js';
 const SVC_UUID = uuid16(0xfff0);
 const CHR_NOTIFY = uuid16(0xfff1);
 const CHR_WRITE = uuid16(0xfff2);
+/** 1byone/Eufy write char, present on that family, never on a real Inlife. */
+const CHR_ONEBYONE = uuid16(0xfff4);
 
 const KNOWN_NAMES = ['000fatscale01', '000fatscale02', '042fatscale01'];
 
@@ -55,7 +57,10 @@ export class InlifeScaleAdapter implements ScaleAdapterCore, GattWiring {
       // 1byone/Eufy family, so require Inlife's own write characteristic
       // 0xFFF2 rather than the bare service UUID. Prevents the #177 collision
       // where a nameless T9146 (0xFFF1 + 0xFFF4, no 0xFFF2) fell to Inlife.
-      return chars.includes(CHR_WRITE);
+      // Also reject any device carrying the 1byone/Eufy write char 0xFFF4:
+      // a real Inlife never exposes it, and some Eufy variants (T9147, #251)
+      // expose fff2 AND fff4, which would otherwise still hit Inlife here.
+      return chars.includes(CHR_WRITE) && !chars.includes(CHR_ONEBYONE);
     }
 
     // Pre-connect (no characteristics yet): keep the legacy advertised-service

--- a/src/scales/koogeek-s1.ts
+++ b/src/scales/koogeek-s1.ts
@@ -1,0 +1,180 @@
+import type {
+  BleDeviceInfo,
+  ScaleAdapterCore,
+  GattWiring,
+  AckProtocol,
+  HoldForComposition,
+  ScaleReading,
+  UserProfile,
+  BodyComposition,
+} from '../interfaces/scale-adapter.js';
+import { uuid16, buildPayload, computeBiaFat, xorChecksum } from './body-comp-helpers.js';
+import type { MatchDescriptor } from './match-descriptor.js';
+
+const CHR_NOTIFY = uuid16(0xfff4);
+const CHR_WRITE = uuid16(0xfff3);
+
+/** Frame header shared by both directions. */
+const MAGIC = [0x55, 0xaa, 0x55, 0xaa];
+
+/** Inbound command bytes, read from data[4]. */
+const CMD_INIT = 0x01;
+const CMD_LIVE = 0x02;
+const CMD_STABLE = 0x03;
+const CMD_QUERY = 0x07;
+
+/** Outbound reply command bytes. */
+const CMD_ACK_INIT = 0x81;
+const CMD_ACK_QUERY = 0x87;
+
+const MIN_FRAME_LEN = 6; // magic(4) + command(1) + checksum(1)
+const DATA_FRAME_LEN = 14;
+const MAX_WEIGHT_KG = 300;
+
+/** Wait this long for an impedance-bearing stable frame before settling for weight only. */
+const COMPOSITION_HOLD_MS = 2000;
+
+/**
+ * Adapter for the Koogeek-S1 body-composition scale (issue #270).
+ *
+ * The protocol was reverse-engineered from the vendor's Smart Health app and
+ * validated against real hardware by the reporter:
+ *
+ *   - Vendor service 0xFFF0, notify 0xFFF4, write 0xFFF3.
+ *   - Frames are `55 AA 55 AA <cmd> [<0x01> outbound] <payload...> <XOR>`,
+ *     where the trailing byte is the XOR of every preceding byte.
+ *   - Once notifications are enabled the scale repeats a command 0x01 init
+ *     frame and streams no weight at all until the client answers it with the
+ *     command 0x81 acknowledgement. A command 0x07 query must be answered with
+ *     command 0x87 echoing data[6]. Both replies are per-frame, so they live in
+ *     buildAck and no onConnected handshake is needed.
+ *   - Data frames are 14 bytes: command 0x02 is a live reading, 0x03 is the
+ *     stable one. Weight is data[9..10] big endian tenths of a kg, impedance is
+ *     data[11..12] big endian ohms.
+ *
+ * The vendor computed body composition in a cloud service that no longer
+ * exists, so metrics come from the project's generic BIA path.
+ *
+ * Known limitation: this hardware's GATT connect and service discovery are
+ * unreliable on BlueZ and on ESP32 NimBLE, and connect only occasionally on
+ * macOS CoreBluetooth. That is a link-layer trait of the device, not something
+ * an adapter can influence.
+ */
+export class KoogeekS1Adapter
+  implements ScaleAdapterCore, GattWiring, AckProtocol, HoldForComposition
+{
+  readonly name = 'Koogeek-S1';
+  readonly match: MatchDescriptor = {
+    priority: 95,
+    custom: true,
+    names: { includes: ['koogeek-s1'] },
+  };
+  readonly charNotifyUuid = CHR_NOTIFY;
+  readonly charWriteUuid = CHR_WRITE;
+  readonly normalizesWeight = true;
+  /**
+   * 0xFFF3 is a vendor OEM command characteristic. Every other adapter in the
+   * 0xFFF0 family writes without a response, so we do the same.
+   *
+   * This is inferred from the family rather than measured, and it only takes
+   * effect on the native and ESPHome transports. The ESP32 MQTT proxy discards
+   * the flag (see handler-mqtt-proxy/gatt.ts) and lets its firmware choose.
+   */
+  readonly ackWithResponse = false;
+
+  /** True when the frame just parsed was the stable (command 0x03) reading. */
+  private stable = false;
+
+  /**
+   * Matches on the advertised name only.
+   *
+   * A structural fallback keyed on the 0xFFF1 to 0xFFF6 characteristic set was
+   * considered, so that the ESP32 proxy's autonomous connect path (which
+   * resolves from characteristics alone, with no name and no services) could
+   * identify a Koogeek. It was rejected. The Eufy P2 uses 0xFFF1, 0xFFF2 and
+   * 0xFFF4 on the same 0xFFF0 service, and its own matcher returns false for a
+   * nameless device, so priority could not protect it: if a Eufy's GATT table
+   * happens to also expose the unused 0xFFF3, 0xFFF5 and 0xFFF6, a structural
+   * Koogeek match would claim it and break a scale that works today (#251,
+   * #258). Nothing in the project records whether it does.
+   *
+   * The cost is that a Koogeek cannot be auto-detected over the ESP32 proxy's
+   * autonomous connect, which is no worse than before this adapter existed. The
+   * native and ESPHome paths both preserve the advertised name.
+   */
+  matches(device: BleDeviceInfo): boolean {
+    return (device.localName || '').toLowerCase().includes('koogeek-s1');
+  }
+
+  /**
+   * A well-formed frame carries the magic header and a valid trailing XOR.
+   * buildAck runs on every inbound frame, including frames from a device that
+   * was matched by mistake, so this must be fully defensive.
+   */
+  private isValidFrame(data: Buffer): boolean {
+    if (data.length < MIN_FRAME_LEN) return false;
+    for (let i = 0; i < MAGIC.length; i++) {
+      if (data[i] !== MAGIC[i]) return false;
+    }
+    return xorChecksum(data, 0, data.length - 1) === data[data.length - 1];
+  }
+
+  /** Assemble an outbound frame and append its XOR checksum. */
+  private buildFrame(cmd: number, payload: number[]): number[] {
+    const body = [...MAGIC, cmd, 0x01, ...payload];
+    body.push(xorChecksum(body, 0, body.length));
+    return body;
+  }
+
+  /**
+   * The scale gates its weight stream on these replies:
+   *   command 0x01 (init)  answered with 55 AA 55 AA 81 01 01 81
+   *   command 0x07 (query) answered with 55 AA 55 AA 87 01 <data[6]> <XOR>
+   * Data frames need no acknowledgement.
+   */
+  buildAck(data: Buffer): number[] | null {
+    if (!this.isValidFrame(data)) return null;
+    const cmd = data[4];
+    if (cmd === CMD_INIT) return this.buildFrame(CMD_ACK_INIT, [0x01]);
+    if (cmd === CMD_QUERY && data.length >= 7) return this.buildFrame(CMD_ACK_QUERY, [data[6]]);
+    return null;
+  }
+
+  parseNotification(data: Buffer): ScaleReading | null {
+    this.stable = false;
+    if (!this.isValidFrame(data)) return null;
+
+    const cmd = data[4];
+    if (cmd !== CMD_LIVE && cmd !== CMD_STABLE) return null;
+    if (data.length < DATA_FRAME_LEN) return null;
+
+    const weight = ((data[9] << 8) | data[10]) / 10;
+    if (!Number.isFinite(weight) || weight <= 0 || weight > MAX_WEIGHT_KG) return null;
+
+    const impedance = (data[11] << 8) | data[12];
+    this.stable = cmd === CMD_STABLE;
+    return { weight, impedance };
+  }
+
+  /**
+   * Only a stable frame finishes the read. Impedance is deliberately not
+   * required: a stable frame measured through socks reports zero, and gating on
+   * it would spin until the read timeout rather than record the weight.
+   */
+  isComplete(reading: ScaleReading): boolean {
+    return this.stable && reading.weight > 0;
+  }
+
+  /** Prefer a stable frame carrying impedance, but never wait forever for one. */
+  readonly completionHoldMs = COMPOSITION_HOLD_MS;
+
+  isFinal(reading: ScaleReading): boolean {
+    return reading.impedance > 0;
+  }
+
+  computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {
+    const fat =
+      reading.impedance > 0 ? computeBiaFat(reading.weight, reading.impedance, profile) : undefined;
+    return buildPayload(reading.weight, reading.impedance, { fat }, profile);
+  }
+}

--- a/src/scales/mi-scale-2.ts
+++ b/src/scales/mi-scale-2.ts
@@ -64,6 +64,17 @@ export class MiScale2Adapter implements ScaleAdapterCore, GattWiring, Unlockable
     if (device.manufacturerData?.id === 0x0611) return false;
     if (name.includes('BF720') || name.includes('BF105')) return false;
     if (KNOWN_PREFIXES.some((p) => name.startsWith(p.toUpperCase()))) return true;
+
+    // Post-discovery: 0x181B is the generic SIG Body Composition Service that
+    // standard BCS/WSS scales also expose (e.g. Beurer BF950, #255), so once the
+    // characteristics are known require the Mi vendor history characteristic
+    // rather than the bare service. This stops Mi (priority 210) from stealing
+    // those devices from Standard GATT in the MAC-pinned re-resolution path.
+    const chars = device.characteristicUuids;
+    if (chars && chars.length > 0) {
+      return chars.map((u) => u.toLowerCase()).includes(CHR_MI_HISTORY);
+    }
+
     // ESPHome / MQTT proxy advertisements may omit the BLE local name. The scale
     // always includes 0x181B as a service-data UUID (AD type 0x16), which lands in
     // serviceData rather than serviceUuids, so check both.

--- a/src/scales/one-byone.ts
+++ b/src/scales/one-byone.ts
@@ -26,6 +26,7 @@ export class OneByoneAdapter implements ScaleAdapterCore, GattWiring {
   readonly name = '1byone (Eufy)';
   readonly match: MatchDescriptor = {
     priority: 70,
+    custom: true,
     names: { includes: ['t9146', 't9147', 't9120', 'health scale'] },
     charUuids: ['fff4'],
   };
@@ -34,7 +35,19 @@ export class OneByoneAdapter implements ScaleAdapterCore, GattWiring {
   readonly normalizesWeight = true;
 
   matches(device: BleDeviceInfo): boolean {
-    return matchesDescriptor(device, this.match);
+    // Name match is unambiguous (T914x / Health Scale); keep it.
+    const name = (device.localName || '').toLowerCase();
+    if (this.match.names?.includes?.some((n) => name.includes(n))) return true;
+
+    const chars = (device.characteristicUuids ?? []).map((u) => u.toLowerCase());
+    if (chars.length === 0) return false;
+    // Post-discovery: 0xFFF4 identifies the 1byone family, but the Eufy P2 also
+    // exposes 0xFFF4 alongside 0xFFF2 + its auth char. A real 1byone C1/P1 uses
+    // fff1 + fff4 and never fff2, so require fff4 WITHOUT fff2. This stops a
+    // nameless Eufy P2 reaching an mqtt-proxy autonomous connect from being
+    // driven with the wrong 1byone protocol (it falls through to its own
+    // adapter via the notify-char fallback instead).
+    return chars.includes(uuid16(0xfff4)) && !chars.includes(uuid16(0xfff2));
   }
 
   /**

--- a/src/scales/qn-scale.ts
+++ b/src/scales/qn-scale.ts
@@ -367,10 +367,22 @@ export class QnScaleAdapter implements ScaleAdapterCore, GattWiring, BroadcastSo
       return true;
     }
 
-    // Fallback: match by QN vendor service UUID, but only for unnamed devices.
-    // Named devices (e.g. "eufy T9149") should match their own specific adapter
-    // rather than being caught by the generic FFF0/FFE0 UUID check.
-    if (!name && hasQnVendor) return true;
+    // QN Type-1 structural signature: notify 0xFFE1 + write 0xFFE3. The ESP32
+    // autonomous-connect path resolves an adapter from characteristics alone
+    // (no advertised name, no service UUIDs), so a Type-1 QN otherwise falls
+    // through to the proxy's notify-only fallback and is mis-picked as Yunmai
+    // on the shared 0xFFE4 char, then hangs on the missing 0xFFE9 (#272). 0xFFE3
+    // as a write char is unique to QN; 0xFFE1 alone is shared with Beurer, so
+    // require BOTH. Compare short and dashless-128-bit forms like hasAe00 above.
+    const hasQnType1Chars =
+      chars.some((u) => u === 'ffe1' || u === CHR_NOTIFY_T1) &&
+      chars.some((u) => u === 'ffe3' || u === CHR_WRITE_T1);
+
+    // Fallback: match by QN vendor service UUID or the Type-1 char pair, but
+    // only for unnamed devices. Named devices (e.g. "eufy T9149") should match
+    // their own specific adapter rather than being caught by these generic
+    // structural checks.
+    if (!name && (hasQnVendor || hasQnType1Chars)) return true;
 
     return false;
   }

--- a/src/scales/qn-scale.ts
+++ b/src/scales/qn-scale.ts
@@ -8,10 +8,12 @@ import type {
   ScaleReading,
   UserProfile,
   BodyComposition,
+  AdapterRuntimeConfig,
 } from '../interfaces/scale-adapter.js';
 import { uuid16 } from './body-comp-helpers.js';
 import { bleLog } from '../ble/types.js';
 import type { MatchDescriptor } from './match-descriptor.js';
+import type { WeightUnit } from '../config/schema.js';
 
 /** Format bytes as hex string for debug logging. */
 const hex = (data: number[] | Buffer): string =>
@@ -143,6 +145,13 @@ export class QnScaleAdapter implements ScaleAdapterCore, GattWiring, BroadcastSo
   /** Protocol type byte captured from the scale's 0x12 frame, echoed in config commands. */
   private seenProtocolType = 0x00;
 
+  /**
+   * Configured display unit. The 0x13 config command tells the scale which unit
+   * to show, so hardcoding kg flipped a user's lbs display on every read (#269).
+   * Injected via configure() from scale.weight_unit; defaults to kg.
+   */
+  private displayUnit: WeightUnit = 'kg';
+
   /** Whether the AE00 service is available (newer firmware). */
   private hasAe00 = false;
 
@@ -182,6 +191,16 @@ export class QnScaleAdapter implements ScaleAdapterCore, GattWiring, BroadcastSo
 
   /** Timer handle for the pending stored-data re-query. */
   private storedRetryTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /** Receive the configured display unit from the composition root (#269). */
+  configure(opts: AdapterRuntimeConfig): void {
+    if (opts.weightUnit) this.displayUnit = opts.weightUnit;
+  }
+
+  /** 0x13 config unit flag: 0x01 kg, 0x02 lb (openScale QNHandler). */
+  private unitFlag(): number {
+    return this.displayUnit === 'lbs' ? 0x02 : 0x01;
+  }
 
   /** Write to FFF2 (write char), fall back to FFE3 (Type 1). */
   private async writeCmd(data: number[]): Promise<void> {
@@ -257,10 +276,12 @@ export class QnScaleAdapter implements ScaleAdapterCore, GattWiring, BroadcastSo
       // Older firmware: send legacy unlock variants on FFF2.
       // These work with Renpho, Sencor, and generic QN-Scale devices
       // that don't use the notification-driven handshake.
-      const unlocks = [
-        [0x13, 0x09, 0x00, 0x01, 0x01, 0x02],
-        [0x13, 0x09, 0x00, 0x01, 0x10, 0x00, 0x00, 0x00, 0x2d],
-      ];
+      // The second unlock is the 0x10 config variant whose byte[3] is the unit
+      // flag; honour the configured unit and recompute its checksum (#269). The
+      // first unlock is a different 0x01 subcommand and is left as-is.
+      const config = [0x13, 0x09, 0x00, this.unitFlag(), 0x10, 0x00, 0x00, 0x00, 0x00];
+      config[8] = config.reduce((a, b) => a + b, 0) & 0xff;
+      const unlocks = [[0x13, 0x09, 0x00, 0x01, 0x01, 0x02], config];
       for (const cmd of unlocks) {
         await this.writeCmd(cmd);
       }
@@ -604,9 +625,10 @@ export class QnScaleAdapter implements ScaleAdapterCore, GattWiring, BroadcastSo
     await wait(200);
 
     // Step 3: 0x13 config
-    // byte[3] = unit flag: 0x01 (kg) or 0x02 (lb) per openScale QNHandler.
+    // byte[3] = unit flag: 0x01 (kg) or 0x02 (lb) per openScale QNHandler. Honour
+    // the configured unit so a read does not flip the scale's display (#269).
     // The Renpho app uses 0x08 which also works but switches the scale display to lb.
-    const cmd = [0x13, 0x09, this.seenProtocolType, 0x01, 0x10, 0x00, 0x00, 0x00, 0x00];
+    const cmd = [0x13, 0x09, this.seenProtocolType, this.unitFlag(), 0x10, 0x00, 0x00, 0x00, 0x00];
     cmd[8] = cmd.reduce((a, b) => a + b, 0) & 0xff;
     await this.writeCmd(cmd);
   }

--- a/src/scales/renpho.ts
+++ b/src/scales/renpho.ts
@@ -1,43 +1,98 @@
 import type {
   BleDeviceInfo,
+  CharacteristicBinding,
+  ConnectionContext,
   ScaleAdapterCore,
   GattWiring,
-  Unlockable,
+  MultiCharNotify,
+  HoldForComposition,
   ScaleReading,
   UserProfile,
   BodyComposition,
 } from '../interfaces/scale-adapter.js';
-import { uuid16, buildPayload } from './body-comp-helpers.js';
+import { uuid16, buildPayload, computeBiaFat, type ScaleBodyComp } from './body-comp-helpers.js';
+import { bleLog } from '../ble/types.js';
 import type { MatchDescriptor } from './match-descriptor.js';
 
 /**
- * Ported from openScale's RenphoHandler.kt
+ * Handler for RENPHO ES-WBE28 / "Renpho-Scale" (Elis 1 family).
  *
- * Handler for RENPHO ES-WBE28 — a newer Renpho model that uses standard BLE
- * services (Body Composition 0x181B, User Data 0x181C, Weight Scale 0x181D,
- * Current Time 0x1805) but with vendor-specific payload encoding.
+ * Reverse-engineered from an Android btsnoop HCI capture of the physical device
+ * and verified against it. Despite openScale's older RenphoHandler.kt treating
+ * this as a proprietary weight-only device, the ES-WBE28 speaks pure Bluetooth
+ * SIG GATT:
  *
- * Weight is published on the Weight Measurement characteristic (0x2A9D) in a
- * proprietary format: data[0] must equal 0x2E, weight = LE uint16 at [1-2] / 20.0.
+ *   Weight Scale       0x181D → Weight Measurement       0x2A9D (notify)
+ *   Body Composition   0x181B → Body Comp. Measurement    0x2A9C (indicate)
+ *   User Data          0x181C → User Control Point        0x2A9F (consent)
  *
- * Vendor handshake:
- *   MAGIC0 [0x10, 0x01, 0x00, 0x11] → written to 0xFFE2
- *   MAGIC1 [0x03, 0x00, 0x01, 0x04] → written to 0xFFE2
- *   MAGIC_UCP [0x02, 0xAA, 0x0F, 0x27] → written to 0x2A9F (consent user 0xAA, code 9999)
+ * The scale stays completely SILENT until a registered user "consents" through
+ * the User Data Service. Merely subscribing to 0x2A9D and poking the vendor
+ * channel (the previous implementation) never unlocks it, so the scale connects
+ * and then disconnects without ever streaming. We must replay the app's init:
  *
- * Mutual exclusion with QnScaleAdapter:
- *   RenphoHandler claims "renpho-scale" devices that do NOT advertise 0xFFE0/0xFFF0.
- *   Devices WITH 0xFFE0/0xFFF0 are handled by QnScaleAdapter (QNHandler.kt).
+ *   1. Subscribe to the vendor (0xFFE1) + User Control Point (0x2A9F) channels.
+ *   2. Vendor handshake — three writes to 0xFFE2 (opaque config query).
+ *   3. UCP consent — write 02 AA 0F 27 to 0x2A9F (user 0xAA=170, code 9999).
+ *   4. Profile writes (gender/height/DOB/age + vendor 0x2AFF) to satisfy the
+ *      scale's on-device maths.
+ *   5. Enable the weight + body-composition notifications LAST (order matters —
+ *      the app enables these CCCDs only after consent + profile).
+ *
+ * The consent user index (170) and code (9999) are the returning-user values
+ * captured from the RENPHO app's own registration; they are fixed for this
+ * device family. Body composition is recomputed on the host from raw impedance
+ * (BIA) rather than trusting the scale's per-profile derived numbers, which are
+ * only correct for the single profile the scale was registered with.
+ *
+ * Mutual exclusion with QnScaleAdapter: RenphoScaleAdapter claims "renpho"
+ * devices that do NOT advertise the QN vendor services (0xFFE0 / 0xFFF0).
  */
 
-const CHR_WEIGHT = uuid16(0x2a9d); // notify — proprietary weight encoding
-const CHR_CUSTOM0 = uuid16(0xffe2); // write  — vendor magic commands
+// Standard SIG characteristics.
+const CHR_WEIGHT = uuid16(0x2a9d); // notify   — Weight Measurement
+const CHR_BODYCOMP = uuid16(0x2a9c); // indicate — Body Composition Measurement
+const CHR_UCP = uuid16(0x2a9f); // User Control Point (consent + response)
 
-// QN vendor service UUIDs (used for exclusion)
+// Vendor 0xFFE0 service used for the opaque config handshake.
+const CHR_VENDOR_NOTIFY = uuid16(0xffe1);
+const CHR_VENDOR_WRITE = uuid16(0xffe2);
+
+// User Data Service profile characteristics.
+const CHR_GENDER = uuid16(0x2a8c);
+const CHR_AGE = uuid16(0x2a80);
+const CHR_DOB = uuid16(0x2a85);
+const CHR_HEIGHT = uuid16(0x2a8e);
+const CHR_VENDOR_2AFF = uuid16(0x2aff);
+
+// QN vendor service UUIDs (used for exclusion).
 const SVC_QN_T1 = 'ffe0';
 const SVC_QN_T2 = 'fff0';
 
-export class RenphoScaleAdapter implements ScaleAdapterCore, GattWiring, Unlockable {
+// Vendor handshake, replayed verbatim from the app capture (writes to 0xFFE2).
+const HANDSHAKE: number[][] = [
+  [0x10, 0x01, 0x00, 0x11],
+  [0x03, 0x00, 0x01, 0x04],
+  [0x19, 0x00, 0x19],
+];
+
+// User Control Point consent (returning-user values captured from the app).
+const UCP_CONSENT = 0x02;
+const UCP_RESPONSE = 0x20;
+const UCP_RESULT_SUCCESS = 0x01;
+const CONSENT_USER_INDEX = 0xaa; // 170
+const CONSENT_CODE = 9999; // 0x270F → wire bytes 0F 27 (LE)
+
+// RENPHO deviates from the SIG standard: mass fields use a 0.05 kg resolution
+// (10× the spec's 0.005), confirmed against the physical scale and internally
+// consistent with fat% and fat-free mass (raw 1900 → 95.0 kg).
+const KG_PER_UNIT = 0.05;
+const LB_PER_UNIT = 0.1;
+const LB_TO_KG = 0.45359237;
+
+export class RenphoScaleAdapter
+  implements ScaleAdapterCore, GattWiring, MultiCharNotify, HoldForComposition
+{
   readonly name = 'Renpho ES-WBE28';
   readonly match: MatchDescriptor = {
     priority: 240,
@@ -45,22 +100,35 @@ export class RenphoScaleAdapter implements ScaleAdapterCore, GattWiring, Unlocka
     names: { includes: ['renpho'] },
     serviceUuids: ['181b', '181d'],
   };
+  // Legacy single-char fallback (unused in multi-char mode).
   readonly charNotifyUuid = CHR_WEIGHT;
-  readonly charWriteUuid = CHR_CUSTOM0;
+  readonly charWriteUuid = CHR_VENDOR_WRITE;
   readonly normalizesWeight = true;
-  /** MAGIC0 — kicks the device into measurement mode. */
-  readonly unlockCommand = [0x10, 0x01, 0x00, 0x11];
-  readonly unlockIntervalMs = 3000;
+
+  // Only the channels that must be live BEFORE the handshake are auto-subscribed
+  // here. The weight + body-composition CCCDs are enabled LAST, inside
+  // onConnected(), to mirror the app's ordering.
+  readonly characteristics: CharacteristicBinding[] = [
+    { uuid: CHR_VENDOR_NOTIFY, type: 'notify' },
+    { uuid: CHR_UCP, type: 'notify' },
+    { uuid: CHR_VENDOR_WRITE, type: 'write' },
+  ];
+
+  // Hold the link open briefly after the weight settles so the multi-packet
+  // body-composition indications (carrying impedance) can land.
+  readonly completionHoldMs = 8000;
+
+  private cachedWeight = 0;
+  private cachedImpedance = 0;
 
   /**
-   * Match "renpho-scale" (or "renpho") devices that do NOT advertise QN vendor
-   * service UUIDs (0xFFE0 / 0xFFF0). Those are handled by QnScaleAdapter.
+   * Match "renpho" devices that do NOT advertise QN vendor service UUIDs
+   * (0xFFE0 / 0xFFF0). Those are handled by QnScaleAdapter.
    */
   matches(device: BleDeviceInfo): boolean {
     const name = (device.localName || '').toLowerCase();
     if (!name.includes('renpho')) return false;
 
-    // Reject QN-protocol devices (mutual exclusion from RenphoHandler.kt)
     const uuids = (device.serviceUuids || []).map((u) => u.toLowerCase());
     const hasQn = uuids.some(
       (u) => u === SVC_QN_T1 || u === SVC_QN_T2 || u === uuid16(0xffe0) || u === uuid16(0xfff0),
@@ -68,35 +136,178 @@ export class RenphoScaleAdapter implements ScaleAdapterCore, GattWiring, Unlocka
     return !hasQn;
   }
 
-  /**
-   * Parse a Renpho ES-WBE28 weight notification on 0x2A9D.
-   *
-   * Proprietary layout (from RenphoHandler.kt):
-   *   [0]    0x2E — valid frame marker
-   *   [1]    weight low byte  (LE)
-   *   [2]    weight high byte (LE)
-   *   weight_kg = ((data[2] << 8) | data[1]) / 20.0
-   */
+  async onConnected(ctx: ConnectionContext): Promise<void> {
+    // Reset per-connection state (adapter instance is shared across sessions).
+    this.cachedWeight = 0;
+    this.cachedImpedance = 0;
+
+    const required = [CHR_UCP, CHR_VENDOR_WRITE];
+    const missing = required.filter((u) => !ctx.availableChars.has(u));
+    if (missing.length > 0) {
+      throw new Error(
+        `Renpho ES-WBE28: required characteristics not discovered (${missing.join(', ')}). ` +
+          'Likely a transient GATT discovery race. Try again.',
+      );
+    }
+
+    // 1. Vendor handshake — three opaque config writes to 0xFFE2.
+    for (const cmd of HANDSHAKE) {
+      await ctx.write(CHR_VENDOR_WRITE, cmd, true);
+    }
+
+    // 2. User Control Point consent (opcode, user index, code LE).
+    await ctx.write(
+      CHR_UCP,
+      [UCP_CONSENT, CONSENT_USER_INDEX & 0xff, CONSENT_CODE & 0xff, (CONSENT_CODE >> 8) & 0xff],
+      true,
+    );
+
+    // 3. Profile writes — only unlock measurements / feed the scale's ignored
+    //    on-device maths. Guarded by availableChars so a firmware variant
+    //    missing one does not abort the whole init.
+    for (const [uuid, payload] of this.buildProfileWrites(ctx.profile)) {
+      if (ctx.availableChars.has(uuid)) await ctx.write(uuid, payload, true);
+    }
+
+    // 4. Enable measurement notifications LAST, as the app does.
+    await ctx.subscribe(CHR_WEIGHT);
+    await ctx.subscribe(CHR_BODYCOMP);
+    bleLog.debug('Renpho ES-WBE28: consent + profile sent, measurement notifications enabled');
+  }
+
+  /** Ordered (characteristic, bytes) profile writes mirroring the app. */
+  private buildProfileWrites(profile: UserProfile): Array<[string, number[]]> {
+    const gender = profile.gender === 'female' ? 1 : 0;
+    const age = Math.max(1, Math.round(profile.age));
+    const heightCm = Math.max(1, Math.round(profile.height));
+    const birthYear = new Date().getFullYear() - age;
+    return [
+      [CHR_GENDER, [gender]],
+      [CHR_HEIGHT, [heightCm & 0xff, (heightCm >> 8) & 0xff]],
+      [CHR_DOB, [birthYear & 0xff, (birthYear >> 8) & 0xff, 1, 1]],
+      [CHR_AGE, [age & 0xff]],
+      [CHR_VENDOR_2AFF, [0x04, 0x00]],
+    ];
+  }
+
+  parseCharNotification(charUuid: string, data: Buffer): ScaleReading | null {
+    if (charUuid === CHR_UCP) {
+      this.handleUcpResponse(data);
+      return null;
+    }
+    if (charUuid === CHR_VENDOR_NOTIFY) {
+      return null; // opaque handshake acks — nothing to decode
+    }
+    if (charUuid === CHR_WEIGHT) {
+      this.parseWeightMeasurement(data);
+      return this.buildReading();
+    }
+    if (charUuid === CHR_BODYCOMP) {
+      this.parseBodyComposition(data);
+      return this.buildReading();
+    }
+    return null;
+  }
+
+  /** Legacy single-char path: weight measurement frames only. */
   parseNotification(data: Buffer): ScaleReading | null {
-    if (data.length < 3) return null;
-    if (data[0] !== 0x2e) return null;
+    this.parseWeightMeasurement(data);
+    return this.buildReading();
+  }
 
+  private handleUcpResponse(data: Buffer): void {
+    if (data.length < 3 || data[0] !== UCP_RESPONSE) return;
+    if (data[2] === UCP_RESULT_SUCCESS) {
+      bleLog.debug('Renpho ES-WBE28: consent accepted, awaiting measurement');
+    } else {
+      bleLog.warn(
+        `Renpho ES-WBE28: User Control Point result 0x${data[2].toString(16)} ` +
+          '(consent not accepted). The scale may need re-registering in the RENPHO app.',
+      );
+    }
+  }
+
+  /**
+   * Decode a 0x2A9D Weight Measurement notification. Standard SIG layout with
+   * RENPHO's 0.05 kg resolution deviation. data[0] is a FLAGS byte (bit0 = unit,
+   * bit1 = timestamp, ...), NOT a fixed frame marker.
+   */
+  private parseWeightMeasurement(data: Buffer): void {
+    if (data.length < 3) return;
+    const flags = data[0];
+    const imperial = (flags & 0x01) !== 0;
     const raw = data.readUInt16LE(1);
-    const weight = raw / 20.0;
+    let weight = raw * (imperial ? LB_PER_UNIT : KG_PER_UNIT);
+    if (imperial) weight *= LB_TO_KG;
+    if (weight > 0 && Number.isFinite(weight)) this.cachedWeight = weight;
+  }
 
-    if (weight <= 0 || !Number.isFinite(weight)) return null;
+  /**
+   * Decode a 0x2A9C Body Composition Measurement packet, extracting impedance
+   * (the profile-independent field we need for host-side BIA). RENPHO splits the
+   * measurement across two indications and its per-packet flags can advertise
+   * fields that don't actually fit; so we walk fields in SIG bit-order and stop
+   * the moment the buffer is exhausted. We keep the FIRST impedance seen.
+   */
+  private parseBodyComposition(data: Buffer): void {
+    if (data.length < 4) return;
+    const flags = data.readUInt16LE(0);
+    const imperial = (flags & 0x0001) !== 0;
+    const step = imperial ? LB_PER_UNIT : KG_PER_UNIT;
+    const n = data.length;
 
-    // No impedance available from this device
-    return { weight, impedance: 0 };
+    // (flag, size, field). null flag = always present. Order is the SIG bit order.
+    const plan: Array<[number | null, number, 'impedance' | 'weight' | null]> = [
+      [null, 2, null], // body fat % (mandatory) — ignored; we recompute from impedance
+      [0x0002, 7, null], // timestamp
+      [0x0004, 1, null], // user id
+      [0x0008, 2, null], // basal metabolism
+      [0x0010, 2, null], // muscle %
+      [0x0020, 2, null], // muscle mass
+      [0x0040, 2, null], // fat free mass
+      [0x0080, 2, null], // soft lean mass
+      [0x0100, 2, null], // body water mass
+      [0x0200, 2, 'impedance'], // impedance ×0.1 Ω
+      [0x0400, 2, 'weight'], // weight ×step
+      [0x0800, 2, null], // height
+    ];
+
+    let off = 2;
+    for (const [flag, size, field] of plan) {
+      if (flag !== null && !(flags & flag)) continue;
+      if (off + size > n) break; // belongs to a later packet
+      if (field === 'impedance' && this.cachedImpedance <= 0) {
+        this.cachedImpedance = data.readUInt16LE(off) * 0.1;
+      } else if (field === 'weight' && this.cachedWeight <= 0) {
+        const w = data.readUInt16LE(off) * step;
+        if (w > 0 && Number.isFinite(w)) this.cachedWeight = w;
+      }
+      off += size;
+    }
+  }
+
+  private buildReading(): ScaleReading | null {
+    if (this.cachedWeight <= 0) return null;
+    return { weight: this.cachedWeight, impedance: this.cachedImpedance };
   }
 
   isComplete(reading: ScaleReading): boolean {
-    // Weight-only device — complete as soon as we have a valid weight
+    // Weight is enough to resolve; the hold window waits for impedance.
     return reading.weight > 0;
   }
 
+  /** Resolve immediately once impedance has arrived (the rich reading). */
+  isFinal(reading: ScaleReading): boolean {
+    return reading.impedance > 0;
+  }
+
   computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {
-    // No impedance — use estimated body composition from BMI
-    return buildPayload(reading.weight, 0, {}, profile);
+    const comp: ScaleBodyComp = {};
+    // Recompute body fat from raw impedance (BIA) when available; otherwise
+    // buildPayload falls back to BMI estimation.
+    if (reading.impedance > 0) {
+      comp.fat = computeBiaFat(reading.weight, reading.impedance, profile);
+    }
+    return buildPayload(reading.weight, reading.impedance, comp, profile);
   }
 }

--- a/src/scales/renpho.ts
+++ b/src/scales/renpho.ts
@@ -141,18 +141,22 @@ export class RenphoScaleAdapter
     this.cachedWeight = 0;
     this.cachedImpedance = 0;
 
-    const required = [CHR_UCP, CHR_VENDOR_WRITE];
-    const missing = required.filter((u) => !ctx.availableChars.has(u));
-    if (missing.length > 0) {
+    // Consent on the SIG User Control Point is what unlocks the stream, so it is
+    // the only hard requirement. The vendor 0xFFE2 service is not advertised (the
+    // matcher rejects devices that advertise 0xFFE0), so a firmware variant may
+    // not expose it; guard its writes rather than hard-requiring it (#267 review).
+    if (!ctx.availableChars.has(CHR_UCP)) {
       throw new Error(
-        `Renpho ES-WBE28: required characteristics not discovered (${missing.join(', ')}). ` +
+        `Renpho ES-WBE28: User Control Point (${CHR_UCP}) not discovered. ` +
           'Likely a transient GATT discovery race. Try again.',
       );
     }
 
-    // 1. Vendor handshake — three opaque config writes to 0xFFE2.
-    for (const cmd of HANDSHAKE) {
-      await ctx.write(CHR_VENDOR_WRITE, cmd, true);
+    // 1. Vendor handshake — three opaque config writes to 0xFFE2, when present.
+    if (ctx.availableChars.has(CHR_VENDOR_WRITE)) {
+      for (const cmd of HANDSHAKE) {
+        await ctx.write(CHR_VENDOR_WRITE, cmd, true);
+      }
     }
 
     // 2. User Control Point consent (opcode, user index, code LE).

--- a/src/scales/yunmai.ts
+++ b/src/scales/yunmai.ts
@@ -3,6 +3,7 @@ import type {
   ScaleAdapterCore,
   GattWiring,
   Unlockable,
+  HoldForComposition,
   ScaleReading,
   UserProfile,
   BodyComposition,
@@ -30,7 +31,9 @@ const RESP_MEASURED = 0x02;
  *
  * Body-composition formulas ported from openScale's YunmaiLib.
  */
-export class YunmaiScaleAdapter implements ScaleAdapterCore, GattWiring, Unlockable {
+export class YunmaiScaleAdapter
+  implements ScaleAdapterCore, GattWiring, Unlockable, HoldForComposition
+{
   readonly name = 'Yunmai';
   readonly match: MatchDescriptor = {
     priority: 190,
@@ -100,10 +103,28 @@ export class YunmaiScaleAdapter implements ScaleAdapterCore, GattWiring, Unlocka
   }
 
   isComplete(reading: ScaleReading): boolean {
-    if (reading.weight <= 0) return false;
-    // Mini/SE: wait for impedance data for full body composition
-    if (this.isMini) return reading.impedance > 0;
-    return true;
+    return reading.weight > 0;
+  }
+
+  /**
+   * Mini/SE variants embed impedance in the same final frame as the weight, so a
+   * complete reading either already carries impedance or never will. Hold the
+   * link briefly after the first weight-only final frame to prefer a frame that
+   * carries impedance, then resolve weight-only rather than hanging until the
+   * overall read timeout. Some SE units (e.g. YUNMAI-ISSE) have no working
+   * bioimpedance sensor and stream weight forever with impedance 0 (#257).
+   * Standard weight-only variants set no hold and resolve immediately.
+   */
+  get completionHoldMs(): number | undefined {
+    return this.isMini ? 4000 : undefined;
+  }
+
+  /**
+   * A reading carrying impedance is the rich/final one, so resolve without waiting
+   * out the hold window. Only consulted for Mini/SE (completionHoldMs set).
+   */
+  isFinal(reading: ScaleReading): boolean {
+    return reading.impedance > 0;
   }
 
   computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {

--- a/tests/ble/esphome-proxy/frame-patch.test.ts
+++ b/tests/ble/esphome-proxy/frame-patch.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'node:module';
+import { _internals } from '../../../src/ble/handler-esphome-proxy/client.js';
+
+const nodeRequire = createRequire(import.meta.url);
+
+/**
+ * Regression guard for #252.
+ *
+ * `@2colors/esphome-native-api` 1.3.6 tears the proxy connection down whenever the
+ * ESPHome node sends an API message id it does not know (id 137,
+ * InfraredRFReceiveEvent, fires on every IR/RF event). We repair
+ * `FrameHelper.prototype.buildMessage` at runtime. This suite deliberately does NOT
+ * mock the library: it asserts against the real prototype, so a future upgrade that
+ * moves these internals fails here instead of silently reintroducing the bug.
+ */
+describe('ESPHome unknown-message patch (#252)', () => {
+  // Applying the patch mutates the real FrameHelper prototype for this process.
+  // That is exactly the production behaviour, and no other suite drives the real
+  // frame helper (they mock the package root).
+  _internals.patchUnknownMessageHandling();
+
+  const FrameHelper = nodeRequire('@2colors/esphome-native-api/lib/utils/frameHelper.js');
+  const { id_to_type, pb } = nodeRequire('@2colors/esphome-native-api/lib/utils/messages.js');
+
+  /** Stand-in for the frame-helper instance `buildMessage` is invoked on. */
+  function fakeHelper() {
+    return { emit: vi.fn(), end: vi.fn() };
+  }
+
+  it('library internals still have the expected shape', () => {
+    expect(typeof FrameHelper?.prototype?.buildMessage).toBe('function');
+    expect(id_to_type[1]).toBe('HelloRequest');
+    // The IR/RF event this library version cannot decode.
+    expect(id_to_type[137]).toBeUndefined();
+  });
+
+  it('ignores an unknown message id without ending the connection', () => {
+    const self = fakeHelper();
+    const msg = FrameHelper.prototype.buildMessage.call(self, 137, Buffer.alloc(0)) as {
+      constructor: { type: string };
+      toObject: () => unknown;
+    };
+
+    expect(msg).toBeDefined();
+    expect(msg.constructor.type).toBe('UnknownEsphomeMessage');
+    expect(msg.toObject()).toEqual({});
+    // The whole point: the connection must survive an unknown id.
+    expect(self.end).not.toHaveBeenCalled();
+    expect(self.emit).not.toHaveBeenCalled();
+  });
+
+  it('the placeholder survives the frame helper setting .length on it', () => {
+    const self = fakeHelper();
+    const msg = FrameHelper.prototype.buildMessage.call(self, 137, Buffer.alloc(0)) as {
+      length?: number;
+    };
+    // noise/plaintext deserialize() both assign message.length before returning.
+    msg.length = 42;
+    expect(msg.length).toBe(42);
+  });
+
+  it('still decodes a known message id', () => {
+    const self = fakeHelper();
+    const hello = new pb.HelloRequest();
+    const bytes = hello.serializeBinary();
+
+    const msg = FrameHelper.prototype.buildMessage.call(self, 1, bytes) as {
+      constructor: { type: string };
+    };
+
+    expect(msg.constructor.type).toBe('HelloRequest');
+    expect(self.end).not.toHaveBeenCalled();
+  });
+
+  it('ends the connection for a known id whose payload cannot be parsed', () => {
+    const self = fakeHelper();
+    const type = id_to_type[1];
+    const spy = vi.spyOn(pb[type], 'deserializeBinary').mockImplementation(() => {
+      throw new Error('corrupt frame');
+    });
+
+    try {
+      const msg = FrameHelper.prototype.buildMessage.call(self, 1, Buffer.alloc(4));
+      // Original library semantics for a desynced stream: surface + tear down.
+      expect(msg).toBeUndefined();
+      expect(self.end).toHaveBeenCalledTimes(1);
+      expect(self.emit).toHaveBeenCalledWith('error', expect.any(Error));
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/tests/ble/shared.test.ts
+++ b/tests/ble/shared.test.ts
@@ -7,6 +7,8 @@ import {
 } from '../../src/ble/shared.js';
 import type { BleChar, BleDevice } from '../../src/ble/shared.js';
 import { normalizeUuid, bleLog } from '../../src/ble/types.js';
+import { KoogeekS1Adapter } from '../../src/scales/koogeek-s1.js';
+import { uuid16, xorChecksum } from '../../src/scales/body-comp-helpers.js';
 import type {
   ScaleAdapter,
   ScaleReading,
@@ -871,6 +873,37 @@ describe('waitForRawReading() history collection', () => {
 // ─── per-frame ACK + completion hold ────────────────────────────────────────
 
 describe('waitForRawReading() — per-frame ACK + completion hold', () => {
+  /** #270: run one notify frame through an ACK adapter and report the write call. */
+  async function ackWriteCall(ackWithResponse?: boolean) {
+    const notifyChar = createMockChar();
+    const writeChar = createMockChar();
+    const device = createMockDevice();
+    const { charMap } = createCharMap([
+      [NOTIFY_UUID, notifyChar],
+      [WRITE_UUID, writeChar],
+    ]);
+
+    const adapter = createLegacyAdapter({
+      buildAck: vi.fn(() => [0x01]),
+      parseNotification: vi.fn(() => null),
+      ...(ackWithResponse === undefined ? {} : { ackWithResponse }),
+    });
+
+    void waitForRawReading(charMap, device, adapter, PROFILE, '');
+    await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
+    notifyChar.triggerData(Buffer.from([0xe7]));
+    await vi.waitFor(() => expect(writeChar.write).toHaveBeenCalled());
+    return writeChar.write.mock.calls.at(-1);
+  }
+
+  it('writes the ACK with a response by default (Beurer/Sanitas behaviour)', async () => {
+    expect((await ackWriteCall(undefined))?.[1]).toBe(true);
+  });
+
+  it('writes the ACK without a response when the adapter opts out (#270)', async () => {
+    expect((await ackWriteCall(false))?.[1]).toBe(false);
+  });
+
   it('writes the buildAck result back for every notify frame', async () => {
     const notifyChar = createMockChar();
     const writeChar = createMockChar();
@@ -1276,5 +1309,102 @@ describe('waitForReading() — adapter with no unlock wiring (#244)', () => {
     expect(result).toEqual(SAMPLE_BODY_COMP);
     // No legacy unlock write was issued.
     expect(writeChar.writtenData.length).toBe(0);
+  });
+});
+
+// ─── Koogeek-S1 end to end through the real adapter (#270) ──────────────────
+
+describe('waitForRawReading() with the real KoogeekS1Adapter (#270)', () => {
+  const KOOGEEK_NOTIFY = uuid16(0xfff4);
+  const KOOGEEK_WRITE = uuid16(0xfff3);
+
+  /** A stable (command 0x03) frame with the given weight tenths and impedance. */
+  function stableFrame(weightTenths: number, impedance: number): Buffer {
+    const body = [
+      0x55,
+      0xaa,
+      0x55,
+      0xaa,
+      0x03,
+      0x01,
+      0,
+      0,
+      0,
+      (weightTenths >> 8) & 0xff,
+      weightTenths & 0xff,
+      (impedance >> 8) & 0xff,
+      impedance & 0xff,
+    ];
+    return Buffer.from([...body, xorChecksum(body, 0, body.length)]);
+  }
+
+  function koogeekHarness() {
+    const notifyChar = createMockChar();
+    const writeChar = createMockChar();
+    const device = createMockDevice();
+    const { charMap } = createCharMap([
+      [KOOGEEK_NOTIFY, notifyChar],
+      [KOOGEEK_WRITE, writeChar],
+    ]);
+    return { notifyChar, writeChar, device, charMap, adapter: new KoogeekS1Adapter() };
+  }
+
+  it('answers the init frame on fff3 without a response, and never resolves on it', async () => {
+    const { notifyChar, writeChar, device, charMap, adapter } = koogeekHarness();
+    const promise = waitForRawReading(charMap, device, adapter, PROFILE, '');
+    await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
+
+    notifyChar.triggerData(Buffer.from('55aa55aa010d010101162601735500000000001a', 'hex'));
+    await vi.waitFor(() => expect(writeChar.write).toHaveBeenCalled());
+
+    const [data, withResponse] = writeChar.write.mock.calls.at(-1)!;
+    expect([...(data as Buffer)]).toEqual([0x55, 0xaa, 0x55, 0xaa, 0x81, 0x01, 0x01, 0x81]);
+    expect(withResponse).toBe(false);
+
+    const pending = await Promise.race([
+      promise.then(() => 'resolved'),
+      new Promise((r) => setTimeout(() => r('pending'), 50)),
+    ]);
+    expect(pending).toBe('pending');
+
+    notifyChar.triggerData(stableFrame(783, 470));
+    expect((await promise).reading).toEqual({ weight: 78.3, impedance: 470 });
+  });
+
+  it('resolves immediately on a stable frame carrying impedance', async () => {
+    const { notifyChar, device, charMap, adapter } = koogeekHarness();
+    const promise = waitForRawReading(charMap, device, adapter, PROFILE, '');
+    await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
+
+    notifyChar.triggerData(stableFrame(783, 470));
+    expect((await promise).reading).toEqual({ weight: 78.3, impedance: 470 });
+  });
+
+  it('holds, then resolves weight-only when a stable frame reports no impedance', async () => {
+    vi.useFakeTimers();
+    try {
+      const { notifyChar, device, charMap, adapter } = koogeekHarness();
+      const promise = waitForRawReading(charMap, device, adapter, PROFILE, '');
+      await vi.advanceTimersByTimeAsync(1);
+      expect(notifyChar.subscribeCalled).toBe(true);
+
+      // Measured through socks: stable, but no impedance. Must not hang.
+      notifyChar.triggerData(stableFrame(800, 0));
+      await vi.advanceTimersByTimeAsync(2000);
+
+      expect((await promise).reading).toEqual({ weight: 80, impedance: 0 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('prefers a later impedance-bearing stable frame inside the hold window', async () => {
+    const { notifyChar, device, charMap, adapter } = koogeekHarness();
+    const promise = waitForRawReading(charMap, device, adapter, PROFILE, '');
+    await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
+
+    notifyChar.triggerData(stableFrame(800, 0));
+    notifyChar.triggerData(stableFrame(783, 470));
+    expect((await promise).reading).toEqual({ weight: 78.3, impedance: 470 });
   });
 });

--- a/tests/scales/beurer-bf720.test.ts
+++ b/tests/scales/beurer-bf720.test.ts
@@ -42,8 +42,22 @@ describe('BeurerBf720Adapter', () => {
   });
 
   describe('matches()', () => {
-    it.each(['BF720', 'beurer bf105', 'My BF720 Scale'])('matches name "%s"', (name) => {
+    it.each(['BF720', 'beurer bf105', 'My BF720 Scale', 'BF500'])('matches name "%s"', (name) => {
       expect(makeAdapter().matches(mockPeripheral(name))).toBe(true);
+    });
+
+    // #83: BF500 speaks the same SIG consent+bond protocol; it must route here
+    // (priority 220) rather than to Standard GATT (priority 0), which sends a
+    // code-0 consent on an unbonded link and reads nothing. Also accept the
+    // short-form advertised service UUID via the company-id path.
+    it('matches BF500 by name and by short-form 0x181d + Beurer company id (#83)', () => {
+      expect(makeAdapter().matches(mockPeripheral('BF500'))).toBe(true);
+      const viaShortForm: BleDeviceInfo = {
+        localName: '',
+        serviceUuids: ['181d'],
+        manufacturerData: { id: 0x0611, data: Buffer.alloc(0) },
+      };
+      expect(makeAdapter().matches(viaShortForm)).toBe(true);
     });
 
     // #168 review: a bare Beurer company id 0x0611 is too weak on its own.

--- a/tests/scales/false-match-resolution.test.ts
+++ b/tests/scales/false-match-resolution.test.ts
@@ -88,4 +88,20 @@ describe('false-match resolution (#255 / #258 / #251)', () => {
     };
     expect(resolveAdapter(inlife, adapters)?.name).toBe('Inlife');
   });
+
+  it('#272: QN Type-1 (ffe1/ffe3, nameless ESP32 payload) resolves to QN Scale, not Yunmai', () => {
+    // Renpho ES-CM20 over the ESP32 autonomous connect: no advertised name, no
+    // service UUIDs, only the Type-1 char set. Yunmai's notify char 0xFFE4 is
+    // present, so the proxy's notify-only fallback used to mis-pick Yunmai and
+    // then hang on the missing write char 0xFFE9. The FFE1+FFE3 structural
+    // signature must resolve to QN before any fallback runs.
+    const info: BleDeviceInfo = {
+      localName: '',
+      serviceUuids: [],
+      characteristicUuids: [0xffe1, 0xffe2, 0xffe3, 0xffe4, 0xffe5].map(uuid16),
+    };
+    const resolved = resolveAdapter(info, adapters);
+    expect(resolved?.name).toBe('QN Scale');
+    expect(resolved?.name).not.toBe('Yunmai');
+  });
 });

--- a/tests/scales/false-match-resolution.test.ts
+++ b/tests/scales/false-match-resolution.test.ts
@@ -47,4 +47,45 @@ describe('false-match resolution (#255 / #258 / #251)', () => {
     expect(resolved?.name).toBe('1byone (Eufy)');
     expect(resolved?.name).not.toBe('Inlife');
   });
+
+  const KOOGEEK_CHARS = [0xfff1, 0xfff2, 0xfff3, 0xfff4, 0xfff5, 0xfff6].map(uuid16);
+
+  it('#270: a named Koogeek-S1 resolves to Koogeek-S1, not Inlife', () => {
+    const info: BleDeviceInfo = {
+      localName: 'Koogeek-S1',
+      serviceUuids: [uuid16(0xfff0)],
+      characteristicUuids: KOOGEEK_CHARS,
+    };
+    const resolved = resolveAdapter(info, adapters);
+    expect(resolved?.name).toBe('Koogeek-S1');
+    expect(resolved?.name).not.toBe('Inlife');
+  });
+
+  it('#270: Koogeek never claims a nameless device carrying its characteristics', () => {
+    // Koogeek matches on name only. A structural match would claim a nameless
+    // Eufy P2 on the ESP32 autonomous path, because Eufy's own matcher returns
+    // false without a name and priority therefore cannot protect it.
+    const info: BleDeviceInfo = {
+      localName: '',
+      serviceUuids: [],
+      characteristicUuids: KOOGEEK_CHARS,
+    };
+    expect(resolveAdapter(info, adapters)?.name).not.toBe('Koogeek-S1');
+  });
+
+  it('#270: Koogeek does not steal a nameless 1byone or a nameless Inlife', () => {
+    const oneByone: BleDeviceInfo = {
+      localName: '',
+      serviceUuids: [],
+      characteristicUuids: [uuid16(0xfff1), uuid16(0xfff4)],
+    };
+    expect(resolveAdapter(oneByone, adapters)?.name).toBe('1byone (Eufy)');
+
+    const inlife: BleDeviceInfo = {
+      localName: '',
+      serviceUuids: [],
+      characteristicUuids: [uuid16(0xfff1), uuid16(0xfff2)],
+    };
+    expect(resolveAdapter(inlife, adapters)?.name).toBe('Inlife');
+  });
 });

--- a/tests/scales/false-match-resolution.test.ts
+++ b/tests/scales/false-match-resolution.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { adapters } from '../../src/scales/index.js';
+import { resolveAdapter } from '../../src/scales/resolve.js';
+import { uuid16 } from '../../src/scales/body-comp-helpers.js';
+import type { BleDeviceInfo } from '../../src/interfaces/scale-adapter.js';
+
+/**
+ * Post-discovery adapter resolution guards for the FFF0 / 0x181B false-match
+ * class (#255, #258, #251). Unlike the array-order collision guard, these use
+ * the real `resolveAdapter` precedence authority and populate
+ * `characteristicUuids`, reproducing the exact info the fixed proxy /
+ * MAC-pinned paths now build after GATT discovery.
+ */
+describe('false-match resolution (#255 / #258 / #251)', () => {
+  it('#255: Beurer BF950 (bare 0x181B, no Mi vendor char) resolves to Standard GATT, not Xiaomi', () => {
+    const info: BleDeviceInfo = {
+      localName: 'BF950',
+      serviceUuids: [uuid16(0x181b), uuid16(0x181d)],
+      // Standard BCS/WSS characteristics plus proprietary faa1/faa2, but
+      // crucially NOT the Mi vendor history char 00002a2f...af100700.
+      characteristicUuids: [uuid16(0x2a9d), uuid16(0x2a2f), uuid16(0xfaa1), uuid16(0xfaa2)],
+    };
+    const resolved = resolveAdapter(info, adapters);
+    expect(resolved?.name).toBe('Standard GATT (BCS/WSS)');
+    expect(resolved?.name).not.toBe('Xiaomi Mi Scale 2');
+  });
+
+  it('#258: QN-family Elis 1 (ae01/ae02 + generic fff1/fff2) resolves to QN Scale, not Eufy P2', () => {
+    // Autonomous mqtt-proxy connect: no advertised name, chars only.
+    const info: BleDeviceInfo = {
+      localName: '',
+      serviceUuids: [],
+      characteristicUuids: [uuid16(0xae01), uuid16(0xae02), uuid16(0xfff1), uuid16(0xfff2)],
+    };
+    const resolved = resolveAdapter(info, adapters);
+    expect(resolved?.name).toBe('QN Scale');
+    expect(resolved?.name).not.toBe('Eufy Smart Scale P2/P2 Pro');
+  });
+
+  it('#251: Eufy P1 "T9147" (fff1 + fff4, no fff2) resolves to 1byone (Eufy), not Inlife', () => {
+    const info: BleDeviceInfo = {
+      localName: 'eufy T9147',
+      serviceUuids: [uuid16(0xfff0)],
+      characteristicUuids: [uuid16(0xfff1), uuid16(0xfff4)],
+    };
+    const resolved = resolveAdapter(info, adapters);
+    expect(resolved?.name).toBe('1byone (Eufy)');
+    expect(resolved?.name).not.toBe('Inlife');
+  });
+});

--- a/tests/scales/hutbit.test.ts
+++ b/tests/scales/hutbit.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest';
+import { HutbitAdapter } from '../../src/scales/hutbit.js';
+import { adapters } from '../../src/scales/index.js';
+import { uuid16 } from '../../src/scales/body-comp-helpers.js';
+import type { ConnectionContext } from '../../src/interfaces/scale-adapter.js';
+import {
+  mockPeripheral,
+  defaultProfile,
+  expectMatches,
+  parseOk,
+  expectValidMetrics,
+} from '../helpers/scale-test-utils.js';
+
+function makeAdapter() {
+  return new HutbitAdapter();
+}
+
+describe('HutbitAdapter (#254)', () => {
+  describe('matches() and registry resolution', () => {
+    it('matches the advertised "Hutbit Scale" name (case-insensitive)', () => {
+      expectMatches(makeAdapter(), {
+        yes: ['Hutbit Scale', 'hutbit scale', 'HUTBIT'],
+        no: ['Robi S9', 'icomon', 'swan123', 'QN-Scale', ''],
+      });
+    });
+
+    it('resolves "Hutbit Scale" to the Hutbit adapter, not MGB/Robi', () => {
+      const matched = adapters.find((a) => a.matches(mockPeripheral('Hutbit Scale', ['ffb0'])));
+      expect(matched?.name).toBe('Hutbit');
+    });
+
+    it('does not claim a nameless FFB0 device (left to Robi/MGB)', () => {
+      const info = mockPeripheral('', [uuid16(0xffb0)], undefined, [
+        uuid16(0xffb1),
+        uuid16(0xffb2),
+      ]);
+      expect(makeAdapter().matches(info)).toBe(false);
+    });
+  });
+
+  describe('onConnected() handshake', () => {
+    it('replays the captured 8-byte FFB1 handshake in order', async () => {
+      const writes: Buffer[] = [];
+      const ctx = {
+        profile: defaultProfile(),
+        deviceAddress: 'AA',
+        availableChars: new Set<string>(),
+        write: vi.fn(async (_uuid: string, data: number[] | Buffer) => {
+          writes.push(Buffer.isBuffer(data) ? data : Buffer.from(data));
+        }),
+        read: vi.fn(),
+        subscribe: vi.fn(),
+      } as unknown as ConnectionContext;
+
+      await makeAdapter().onConnected(ctx);
+
+      expect(writes).toHaveLength(5);
+      expect(writes[0].toString('hex')).toBe('ac02fa010000ccc7');
+      expect(writes[4].toString('hex')).toBe('ac02fe060000ccd0');
+      // Every handshake frame is a valid 8-byte AC02 frame with a good checksum.
+      for (const w of writes) {
+        expect(w).toHaveLength(8);
+        expect(w[0]).toBe(0xac);
+        expect(w[1]).toBe(0x02);
+        expect((w[2] + w[3] + w[4] + w[5] + w[6]) & 0xff).toBe(w[7]);
+      }
+    });
+  });
+
+  describe('parseNotification()', () => {
+    it('decodes 84.1 kg from the real stable FFB2 frame (#254)', () => {
+      const adapter = makeAdapter();
+      // ac02 0349 0000 ca 16 → 0x0349 = 841 → 84.1 kg, STATUS 0xCA (stable)
+      const reading = parseOk(adapter, Buffer.from('ac0203490000ca16', 'hex'), {
+        weight: 84.1,
+        impedance: 0,
+      });
+      expect(adapter.isComplete(reading)).toBe(true);
+    });
+
+    it('ignores measuring (0xCE) frames as progress only', () => {
+      // ac02 0348 0000 ce 19 → valid checksum, but STATUS 0xCE = unstable
+      expect(makeAdapter().parseNotification(Buffer.from('ac0203480000ce19', 'hex'))).toBeNull();
+    });
+
+    it('rejects a frame with a bad checksum', () => {
+      expect(makeAdapter().parseNotification(Buffer.from('ac0203490000ca00', 'hex'))).toBeNull();
+    });
+
+    it('rejects wrong header / wrong length frames', () => {
+      const a = makeAdapter();
+      expect(a.parseNotification(Buffer.from('bb0203490000ca16', 'hex'))).toBeNull();
+      expect(a.parseNotification(Buffer.from('ac0203490000ca', 'hex'))).toBeNull();
+    });
+  });
+
+  describe('computeMetrics()', () => {
+    it('derives a valid body-composition payload (weight-only → BIA/BMI)', () => {
+      const adapter = makeAdapter();
+      const reading = parseOk(adapter, Buffer.from('ac0203490000ca16', 'hex'));
+      const payload = expectValidMetrics(adapter, reading);
+      expect(payload.weight).toBeCloseTo(84.1, 2);
+      expect(payload.impedance).toBe(0);
+    });
+  });
+});

--- a/tests/scales/inlife.test.ts
+++ b/tests/scales/inlife.test.ts
@@ -55,6 +55,18 @@ describe('InlifeScaleAdapter', () => {
       ]);
       expect(adapter.matches(info)).toBe(false);
     });
+
+    it('rejects a device exposing both 0xFFF2 and the 1byone 0xFFF4 char (#251)', () => {
+      const adapter = makeAdapter();
+      // Some Eufy variants (T9147) expose fff2 AND fff4; the fff4 presence
+      // means it is not a real Inlife, so it must fall to 1byone (Eufy).
+      const info = mockPeripheral('', [uuid16(0xfff0)], undefined, [
+        uuid16(0xfff1),
+        uuid16(0xfff2),
+        uuid16(0xfff4),
+      ]);
+      expect(adapter.matches(info)).toBe(false);
+    });
   });
 
   describe('parseNotification()', () => {

--- a/tests/scales/koogeek-s1.test.ts
+++ b/tests/scales/koogeek-s1.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { KoogeekS1Adapter } from '../../src/scales/koogeek-s1.js';
+import { uuid16, xorChecksum } from '../../src/scales/body-comp-helpers.js';
+import {
+  mockPeripheral,
+  defaultProfile,
+  assertPayloadRanges,
+} from '../helpers/scale-test-utils.js';
+
+/** Append the trailing XOR checksum to a synthetic frame body. */
+function withChecksum(bytes: number[]): Buffer {
+  return Buffer.from([...bytes, xorChecksum(bytes, 0, bytes.length)]);
+}
+
+const ALL_CHARS = ['fff1', 'fff2', 'fff3', 'fff4', 'fff5', 'fff6'].map((u) =>
+  uuid16(parseInt(u, 16)),
+);
+
+// Real frames captured by the reporter in issue #270.
+const INIT_FRAME = Buffer.from('55aa55aa010d010101162601735500000000001a', 'hex');
+const STABLE_FRAME = Buffer.from('55aa55aa0307010000030f01d6de', 'hex'); // 78.3 kg, 470 ohm
+
+describe('KoogeekS1Adapter (#270)', () => {
+  describe('matches()', () => {
+    it('matches the advertised name regardless of case', () => {
+      const adapter = new KoogeekS1Adapter();
+      expect(adapter.matches(mockPeripheral('Koogeek-S1', ['fff0']))).toBe(true);
+      expect(adapter.matches(mockPeripheral('koogeek-s1'))).toBe(true);
+    });
+
+    it('never matches a nameless device, even one carrying every Koogeek characteristic', () => {
+      // A structural match would claim a nameless Eufy P2, whose own matcher
+      // returns false without a name, so priority could not protect it.
+      const adapter = new KoogeekS1Adapter();
+      expect(adapter.matches(mockPeripheral('', [], undefined, ALL_CHARS))).toBe(false);
+    });
+
+    it('does not steal a 1byone (fff4 without fff2) or an Inlife (fff2 without fff4)', () => {
+      const adapter = new KoogeekS1Adapter();
+      const oneByone = [uuid16(0xfff1), uuid16(0xfff4)];
+      const inlife = [uuid16(0xfff1), uuid16(0xfff2)];
+      expect(adapter.matches(mockPeripheral('', [], undefined, oneByone))).toBe(false);
+      expect(adapter.matches(mockPeripheral('', [], undefined, inlife))).toBe(false);
+    });
+
+    it('does not match unrelated devices', () => {
+      const adapter = new KoogeekS1Adapter();
+      expect(adapter.matches(mockPeripheral('000fatscale01', ['fff0']))).toBe(false);
+      expect(adapter.matches(mockPeripheral('Random Scale'))).toBe(false);
+    });
+  });
+
+  describe('buildAck()', () => {
+    it('answers the real init frame with 55 AA 55 AA 81 01 01 81', () => {
+      const adapter = new KoogeekS1Adapter();
+      const ack = adapter.buildAck(INIT_FRAME);
+      expect(ack).toEqual([0x55, 0xaa, 0x55, 0xaa, 0x81, 0x01, 0x01, 0x81]);
+    });
+
+    it('answers a command 0x07 query by echoing data[6]', () => {
+      const adapter = new KoogeekS1Adapter();
+      const query = withChecksum([0x55, 0xaa, 0x55, 0xaa, 0x07, 0x01, 0x2a]);
+      const ack = adapter.buildAck(query) as number[];
+      expect(ack.slice(0, 7)).toEqual([0x55, 0xaa, 0x55, 0xaa, 0x87, 0x01, 0x2a]);
+      expect(ack[7]).toBe(xorChecksum(ack.slice(0, 7), 0, 7));
+    });
+
+    it('does not acknowledge data frames, foreign frames, or bad checksums', () => {
+      const adapter = new KoogeekS1Adapter();
+      expect(adapter.buildAck(STABLE_FRAME)).toBeNull();
+      expect(adapter.buildAck(Buffer.from([0x01, 0x02, 0x03, 0x04]))).toBeNull();
+      expect(adapter.buildAck(Buffer.from([0x55, 0xaa, 0x55, 0xaa, 0x01, 0x01, 0x01, 0x00]))).toBe(
+        null,
+      );
+    });
+
+    it('writes the acknowledgement without a response', () => {
+      expect(new KoogeekS1Adapter().ackWithResponse).toBe(false);
+    });
+  });
+
+  describe('parseNotification()', () => {
+    it('parses the real stable frame as 78.3 kg and 470 ohm', () => {
+      const adapter = new KoogeekS1Adapter();
+      const reading = adapter.parseNotification(STABLE_FRAME);
+      expect(reading).not.toBeNull();
+      expect(reading!.weight).toBeCloseTo(78.3, 2);
+      expect(reading!.impedance).toBe(470);
+      expect(adapter.isComplete(reading!)).toBe(true);
+      expect(adapter.isFinal(reading!)).toBe(true);
+    });
+
+    it('parses a live frame but never completes on it', () => {
+      const adapter = new KoogeekS1Adapter();
+      const live = withChecksum([
+        0x55, 0xaa, 0x55, 0xaa, 0x02, 0x01, 0, 0, 0, 0x03, 0x20, 0x01, 0xf4,
+      ]);
+      const reading = adapter.parseNotification(live);
+      expect(reading!.weight).toBeCloseTo(80.0, 2);
+      expect(reading!.impedance).toBe(500);
+      expect(adapter.isComplete(reading!)).toBe(false);
+    });
+
+    it('rejects the init frame, foreign frames, and a corrupted checksum', () => {
+      const adapter = new KoogeekS1Adapter();
+      expect(adapter.parseNotification(INIT_FRAME)).toBeNull();
+      expect(adapter.parseNotification(Buffer.from([0x02, 0xd2, 0x00]))).toBeNull();
+      const corrupted = Buffer.from(STABLE_FRAME);
+      corrupted[corrupted.length - 1] ^= 0xff;
+      expect(adapter.parseNotification(corrupted)).toBeNull();
+    });
+
+    it('rejects an out of range weight', () => {
+      const adapter = new KoogeekS1Adapter();
+      const huge = withChecksum([
+        0x55, 0xaa, 0x55, 0xaa, 0x03, 0x01, 0, 0, 0, 0xff, 0xff, 0x01, 0xf4,
+      ]);
+      expect(adapter.parseNotification(huge)).toBeNull();
+    });
+
+    it('clears the stable flag when a live frame follows a stable one', () => {
+      const adapter = new KoogeekS1Adapter();
+      const stable = adapter.parseNotification(STABLE_FRAME)!;
+      expect(adapter.isComplete(stable)).toBe(true);
+      const live = withChecksum([
+        0x55, 0xaa, 0x55, 0xaa, 0x02, 0x01, 0, 0, 0, 0x03, 0x20, 0x01, 0xf4,
+      ]);
+      const after = adapter.parseNotification(live)!;
+      expect(adapter.isComplete(after)).toBe(false);
+    });
+  });
+
+  describe('isComplete() / isFinal()', () => {
+    it('completes a stable weight even when impedance is zero, but not as final', () => {
+      // Standing in socks: the scale reports a stable weight with no impedance.
+      // Gating completion on impedance would hang the read until timeout.
+      const adapter = new KoogeekS1Adapter();
+      const noImp = withChecksum([0x55, 0xaa, 0x55, 0xaa, 0x03, 0x01, 0, 0, 0, 0x03, 0x20, 0, 0]);
+      const reading = adapter.parseNotification(noImp)!;
+      expect(reading.impedance).toBe(0);
+      expect(adapter.isComplete(reading)).toBe(true);
+      expect(adapter.isFinal(reading)).toBe(false);
+    });
+  });
+
+  describe('computeMetrics()', () => {
+    it('produces an in-range payload through the BIA path', () => {
+      const adapter = new KoogeekS1Adapter();
+      const reading = adapter.parseNotification(STABLE_FRAME)!;
+      const payload = adapter.computeMetrics(reading, defaultProfile());
+      expect(payload.weight).toBeCloseTo(78.3, 2);
+      expect(payload.impedance).toBe(470);
+      assertPayloadRanges(payload);
+    });
+
+    it('falls back to the BMI estimate when impedance is missing', () => {
+      const adapter = new KoogeekS1Adapter();
+      const payload = adapter.computeMetrics({ weight: 78.3, impedance: 0 }, defaultProfile());
+      expect(payload.impedance).toBe(0);
+      assertPayloadRanges(payload);
+    });
+  });
+});

--- a/tests/scales/mi-scale-2.test.ts
+++ b/tests/scales/mi-scale-2.test.ts
@@ -110,6 +110,26 @@ describe('MiScale2Adapter', () => {
         adapter.matches(mockPeripheral('Beurer BF105', ['0000181b00001000800000805f9b34fb'])),
       ).toBe(false);
     });
+
+    it('matches post-discovery when the Mi vendor history char is present', () => {
+      const adapter = makeAdapter();
+      const info = mockPeripheral('', ['0000181b00001000800000805f9b34fb'], undefined, [
+        '00002a2f0000351221180009af100700',
+      ]);
+      expect(adapter.matches(info)).toBe(true);
+    });
+
+    it('does not steal a standard BCS scale (Beurer BF950) that lacks the Mi vendor char (#255)', () => {
+      const adapter = makeAdapter();
+      // BF950 exposes the generic 0x181B service but only standard/proprietary
+      // characteristics, never the Mi vendor history char.
+      const info = mockPeripheral('BF950', ['0000181b00001000800000805f9b34fb'], undefined, [
+        '00002a9d00001000800000805f9b34fb',
+        '00002a2f00001000800000805f9b34fb',
+        '0000faa100001000800000805f9b34fb',
+      ]);
+      expect(adapter.matches(info)).toBe(false);
+    });
   });
 
   describe('parseNotification()', () => {

--- a/tests/scales/one-byone.test.ts
+++ b/tests/scales/one-byone.test.ts
@@ -56,6 +56,18 @@ describe('OneByoneAdapter', () => {
       const adapter = makeAdapter();
       expect(adapter.matches(mockPeripheral('', [uuid16(0xfff0)]))).toBe(false);
     });
+
+    it('rejects a nameless device exposing 0xFFF4 alongside 0xFFF2 (Eufy P2, review of #251/#258)', () => {
+      const adapter = makeAdapter();
+      // Eufy P2 exposes fff1 + fff2 + fff4; a real 1byone never has fff2, so the
+      // nameless P2 must fall through to its own adapter, not be grabbed here.
+      const info = mockPeripheral('', [uuid16(0xfff0)], undefined, [
+        uuid16(0xfff1),
+        uuid16(0xfff2),
+        uuid16(0xfff4),
+      ]);
+      expect(adapter.matches(info)).toBe(false);
+    });
   });
 
   describe('onConnected()', () => {

--- a/tests/scales/qn-scale.test.ts
+++ b/tests/scales/qn-scale.test.ts
@@ -119,6 +119,43 @@ describe('QnScaleAdapter', () => {
       expect(adapter.matches(p)).toBe(true);
     });
 
+    // #272: the ESP32 autonomous-connect path resolves from characteristics
+    // alone (no name, no service UUIDs). A Type-1 QN exposes notify 0xFFE1 +
+    // write 0xFFE3; without a structural match it is mis-picked as Yunmai on the
+    // shared 0xFFE4 char and hangs. The FFE1+FFE3 pair is QN-unique.
+    it('matches unnamed device by Type-1 char pair FFE1+FFE3 (ESP32 autonomous)', () => {
+      const adapter = makeAdapter();
+      const p = mockPeripheral('', [], undefined, ['ffe1', 'ffe2', 'ffe3', 'ffe4', 'ffe5']);
+      expect(adapter.matches(p)).toBe(true);
+    });
+
+    it('matches unnamed device by Type-1 char pair in 128-bit form', () => {
+      const adapter = makeAdapter();
+      const p = mockPeripheral('', [], undefined, [
+        '0000ffe100001000800000805f9b34fb',
+        '0000ffe300001000800000805f9b34fb',
+      ]);
+      expect(adapter.matches(p)).toBe(true);
+    });
+
+    it('does not match unnamed device with FFE1 notify char but no FFE3 write', () => {
+      const adapter = makeAdapter();
+      const p = mockPeripheral('', [], undefined, ['ffe1', 'ffe2']);
+      expect(adapter.matches(p)).toBe(false);
+    });
+
+    it('does not match unnamed device with only the Yunmai notify char FFE4', () => {
+      const adapter = makeAdapter();
+      const p = mockPeripheral('', [], undefined, ['ffe4', 'ffe5']);
+      expect(adapter.matches(p)).toBe(false);
+    });
+
+    it('does not claim a named non-QN device that happens to expose FFE1+FFE3', () => {
+      const adapter = makeAdapter();
+      const p = mockPeripheral('yunmai', [], undefined, ['ffe1', 'ffe3', 'ffe4']);
+      expect(adapter.matches(p)).toBe(false);
+    });
+
     it('matches AABB broadcast header with company ID 0xFFFF', () => {
       const adapter = makeAdapter();
       expect(adapter.matches(mockBroadcastDevice(makeBroadcast(70, true)))).toBe(true);

--- a/tests/scales/qn-scale.test.ts
+++ b/tests/scales/qn-scale.test.ts
@@ -464,6 +464,80 @@ describe('QnScaleAdapter', () => {
       }
     });
 
+    // #269: the 0x13 config command tells the scale which unit to display.
+    // Hardcoding kg flipped a user's lbs scale on every read. byte[3] is the unit
+    // flag (0x01 kg, 0x02 lb) and must follow the configured weight_unit.
+    async function captureConfigWrite(adapter: QnScaleAdapter): Promise<number[][]> {
+      vi.useFakeTimers();
+      try {
+        const writes: number[][] = [];
+        const ctx = {
+          write: async (_uuid: string, data: Buffer | number[]) => {
+            writes.push([...data]);
+          },
+          read: async () => Buffer.alloc(0),
+          subscribe: async () => {},
+          profile: defaultProfile,
+          deviceAddress: '',
+          availableChars: new Set<string>(),
+        } as unknown as ConnectionContext;
+        await adapter.onConnected(ctx);
+        const info = Buffer.alloc(11);
+        info[0] = 0x12;
+        info[2] = 0xff;
+        info[10] = 0;
+        adapter.parseNotification(info);
+        await vi.advanceTimersByTimeAsync(1000);
+        return writes;
+      } finally {
+        vi.useRealTimers();
+      }
+    }
+
+    it('sends the kg unit flag (0x01) in the 0x13 config by default', async () => {
+      const adapter = makeAdapter();
+      const writes = await captureConfigWrite(adapter);
+      const config = writes.find((w) => w[0] === 0x13 && w[4] === 0x10);
+      expect(config).toBeDefined();
+      expect(config![3]).toBe(0x01);
+      // Checksum is the low byte of the sum of the preceding bytes.
+      expect(config![8]).toBe(config!.slice(0, 8).reduce((a, b) => a + b, 0) & 0xff);
+    });
+
+    it('sends the lb unit flag (0x02) when weight_unit is lbs (#269)', async () => {
+      const adapter = makeAdapter();
+      adapter.configure({ weightUnit: 'lbs' });
+      const writes = await captureConfigWrite(adapter);
+      const config = writes.find((w) => w[0] === 0x13 && w[4] === 0x10);
+      expect(config).toBeDefined();
+      expect(config![3]).toBe(0x02);
+      expect(config![8]).toBe(config!.slice(0, 8).reduce((a, b) => a + b, 0) & 0xff);
+    });
+
+    it('honours the unit flag on the older-firmware unlock path too (#269)', async () => {
+      // No AE00 (subscribe rejects) so onConnected sends the legacy unlocks.
+      const adapter = makeAdapter();
+      adapter.configure({ weightUnit: 'lbs' });
+      const writes: number[][] = [];
+      const ctx = {
+        write: async (_uuid: string, data: Buffer | number[]) => {
+          writes.push([...data]);
+        },
+        read: async () => Buffer.alloc(0),
+        subscribe: async () => {
+          throw new Error('no AE02');
+        },
+        profile: defaultProfile,
+        deviceAddress: '',
+        availableChars: new Set<string>(),
+      } as unknown as ConnectionContext;
+      await adapter.onConnected(ctx);
+      const config = writes.find((w) => w[0] === 0x13 && w[4] === 0x10);
+      expect(config).toBeDefined();
+      expect(config![3]).toBe(0x02);
+      expect(config![8]).toBe(config!.slice(0, 8).reduce((a, b) => a + b, 0) & 0xff);
+    });
+
     it('0x12 frame captures protocol type', () => {
       const adapter = makeAdapter();
       const infoBuf = Buffer.alloc(11);

--- a/tests/scales/registry-collision.test.ts
+++ b/tests/scales/registry-collision.test.ts
@@ -47,6 +47,9 @@ const FIXTURES: Record<string, BleDeviceInfo> = {
   'Exingtech Y1': { localName: 'vscale', serviceUuids: [] },
   'Excelvan CF369': { localName: 'electronic scale', serviceUuids: [] },
   Hesley: { localName: 'yunchen', serviceUuids: [] },
+  // #270: a Koogeek advertises the bare 0xFFF0 service, so its name must beat
+  // Inlife's pre-connect service fallback.
+  'Koogeek-S1': { localName: 'Koogeek-S1', serviceUuids: [uuid16(0xfff0)] },
   // #177: real Inlife resolves by its exact known name.
   Inlife: { localName: '000fatscale01', serviceUuids: [uuid16(0xfff0)] },
   Digoo: { localName: 'mengii', serviceUuids: [] },

--- a/tests/scales/registry-collision.test.ts
+++ b/tests/scales/registry-collision.test.ts
@@ -63,6 +63,7 @@ const FIXTURES: Record<string, BleDeviceInfo> = {
   '1byone Scale (new)': { localName: '1byone scale', serviceUuids: [] },
   'Active Era BS-06': { localName: 'AE BS-06', serviceUuids: [] },
   'Robi S9': { localName: 'Robi S9', serviceUuids: [] },
+  Hutbit: { localName: 'Hutbit Scale', serviceUuids: ['ffb0'] },
   'MGB (Swan/Icomon/YG)': { localName: 'icomon', serviceUuids: [] },
   'Hoffen BS-8107': { localName: 'hoffen bs-8107', serviceUuids: [] },
   // Generic fallback: a non-excluded name + bare Weight Scale Service (0x181D).

--- a/tests/scales/renpho.test.ts
+++ b/tests/scales/renpho.test.ts
@@ -1,149 +1,191 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { RenphoScaleAdapter } from '../../src/scales/renpho.js';
+import type { ConnectionContext } from '../../src/interfaces/scale-adapter.js';
+import { uuid16 } from '../../src/scales/body-comp-helpers.js';
 import {
   mockPeripheral,
   defaultProfile,
   assertPayloadRanges,
 } from '../helpers/scale-test-utils.js';
 
+const CHR_WEIGHT = uuid16(0x2a9d);
+const CHR_BODYCOMP = uuid16(0x2a9c);
+const CHR_UCP = uuid16(0x2a9f);
+const CHR_VENDOR_NOTIFY = uuid16(0xffe1);
+const CHR_VENDOR_WRITE = uuid16(0xffe2);
+const CHR_GENDER = uuid16(0x2a8c);
+const CHR_HEIGHT = uuid16(0x2a8e);
+const CHR_DOB = uuid16(0x2a85);
+const CHR_AGE = uuid16(0x2a80);
+const CHR_VENDOR_2AFF = uuid16(0x2aff);
+
+// Live frames decoded from the physical-device btsnoop capture.
+// Weight frame 1374: flags 0x4E, raw 0x076A = 1898 → 94.9 kg (×0.05).
+const WSS_FRAME = Buffer.from('4e6a07ea0707040c1a06aa00000000', 'hex');
+// Body-comp packet 2 (frame 1477): flags 0x020C, impedance 0x0D00 = 3328 → 332.8 Ω.
+const BCS_PACKET2 = Buffer.from('0c02f901f70144000dec00a500290091020600', 'hex');
+
 function makeAdapter() {
   return new RenphoScaleAdapter();
 }
 
+const ALL_CHARS = new Set([
+  CHR_WEIGHT,
+  CHR_BODYCOMP,
+  CHR_UCP,
+  CHR_VENDOR_NOTIFY,
+  CHR_VENDOR_WRITE,
+  CHR_GENDER,
+  CHR_HEIGHT,
+  CHR_DOB,
+  CHR_AGE,
+  CHR_VENDOR_2AFF,
+]);
+
+function makeCtx(over: Partial<ConnectionContext> = {}): ConnectionContext {
+  return {
+    profile: defaultProfile(),
+    deviceAddress: '',
+    availableChars: ALL_CHARS,
+    write: vi.fn().mockResolvedValue(undefined),
+    read: vi.fn().mockResolvedValue(Buffer.alloc(0)),
+    subscribe: vi.fn().mockResolvedValue(undefined),
+    ...over,
+  } as ConnectionContext;
+}
+
 describe('RenphoScaleAdapter', () => {
   describe('matches()', () => {
-    it('matches "renpho" name without QN service UUIDs', () => {
-      const adapter = makeAdapter();
-      const p = mockPeripheral('Renpho Scale', []);
-      expect(adapter.matches(p)).toBe(true);
+    it('matches a real ES-WBE28 advert (renpho + SIG WSS/BCS, no QN UUID)', () => {
+      expect(makeAdapter().matches(mockPeripheral('Renpho-Scale', ['181b', '181d']))).toBe(true);
     });
-
-    it('matches "renpho-scale" without QN UUIDs', () => {
-      const adapter = makeAdapter();
-      const p = mockPeripheral('renpho-scale', []);
-      expect(adapter.matches(p)).toBe(true);
+    it('matches case-insensitively without QN services', () => {
+      expect(makeAdapter().matches(mockPeripheral('RENPHO', []))).toBe(true);
     });
-
-    it('matches a real ES-WBE28 advert (renpho + SIG WSS/BCS, no QN UUID) (#191)', () => {
-      const adapter = makeAdapter();
-      const p = mockPeripheral('Renpho Body Scale', ['181b', '181d']);
-      expect(adapter.matches(p)).toBe(true);
-    });
-
-    it('rejects "renpho" with QN service UUID FFE0', () => {
-      const adapter = makeAdapter();
-      const p = mockPeripheral('Renpho Scale', ['ffe0']);
-      expect(adapter.matches(p)).toBe(false);
-    });
-
-    it('rejects "renpho" with QN service UUID FFF0', () => {
-      const adapter = makeAdapter();
-      const p = mockPeripheral('Renpho Scale', ['fff0']);
-      expect(adapter.matches(p)).toBe(false);
-    });
-
-    it('rejects "renpho" with full 128-bit QN UUID', () => {
-      const adapter = makeAdapter();
-      const p = mockPeripheral('Renpho Scale', ['0000ffe000001000800000805f9b34fb']);
-      expect(adapter.matches(p)).toBe(false);
-    });
-
-    it('does not match unrelated name', () => {
-      const adapter = makeAdapter();
-      const p = mockPeripheral('Yunmai ISM', []);
-      expect(adapter.matches(p)).toBe(false);
-    });
-
-    it('case-insensitive name match', () => {
-      const adapter = makeAdapter();
-      const p = mockPeripheral('RENPHO', []);
-      expect(adapter.matches(p)).toBe(true);
+    it.each(['ffe0', 'fff0', '0000ffe000001000800000805f9b34fb'])(
+      'rejects renpho advertising QN service %s',
+      (svc) => {
+        expect(makeAdapter().matches(mockPeripheral('Renpho Scale', [svc]))).toBe(false);
+      },
+    );
+    it('does not match an unrelated name', () => {
+      expect(makeAdapter().matches(mockPeripheral('Yunmai ISM', []))).toBe(false);
     });
   });
 
-  describe('parseNotification()', () => {
-    it('parses valid frame with marker 0x2E', () => {
-      const adapter = makeAdapter();
-      const buf = Buffer.alloc(3);
-      buf[0] = 0x2e; // valid marker
-      buf.writeUInt16LE(1600, 1); // 1600 / 20 = 80 kg
+  describe('onConnected()', () => {
+    it('replays handshake → consent → profile, then enables measurement notifs LAST', async () => {
+      const a = makeAdapter();
+      const ctx = makeCtx();
+      await a.onConnected(ctx);
 
-      const reading = adapter.parseNotification(buf);
-      expect(reading).not.toBeNull();
-      expect(reading!.weight).toBe(80);
-      expect(reading!.impedance).toBe(0); // no impedance
+      const write = ctx.write as ReturnType<typeof vi.fn>;
+      const subscribe = ctx.subscribe as ReturnType<typeof vi.fn>;
+
+      // Three vendor handshake writes to 0xFFE2 come first.
+      expect(write.mock.calls[0]).toEqual([CHR_VENDOR_WRITE, [0x10, 0x01, 0x00, 0x11], true]);
+      expect(write.mock.calls[1]).toEqual([CHR_VENDOR_WRITE, [0x03, 0x00, 0x01, 0x04], true]);
+      expect(write.mock.calls[2]).toEqual([CHR_VENDOR_WRITE, [0x19, 0x00, 0x19], true]);
+
+      // Consent: opcode 0x02, user 0xAA (170), code 9999 = 0x270F → LE 0F 27.
+      expect(write.mock.calls[3]).toEqual([CHR_UCP, [0x02, 0xaa, 0x0f, 0x27], true]);
+
+      // Profile writes follow (gender/height/dob/age/vendor).
+      const writtenChars = write.mock.calls.map((c) => c[0]);
+      expect(writtenChars).toContain(CHR_GENDER);
+      expect(writtenChars).toContain(CHR_HEIGHT);
+      expect(writtenChars).toContain(CHR_AGE);
+
+      // Measurement notifications are enabled ONLY after all init writes.
+      expect(subscribe).toHaveBeenCalledWith(CHR_WEIGHT);
+      expect(subscribe).toHaveBeenCalledWith(CHR_BODYCOMP);
+      expect(subscribe).not.toHaveBeenCalledBefore(write);
     });
 
-    it('returns null for wrong marker byte', () => {
-      const adapter = makeAdapter();
-      const buf = Buffer.alloc(3);
-      buf[0] = 0x10; // wrong marker
-      buf.writeUInt16LE(1600, 1);
-
-      expect(adapter.parseNotification(buf)).toBeNull();
+    it('throws a clear error when consent/vendor chars are missing', async () => {
+      const a = makeAdapter();
+      await expect(
+        a.onConnected(makeCtx({ availableChars: new Set([CHR_WEIGHT]) })),
+      ).rejects.toThrow(/discovery race/);
     });
 
-    it('returns null for too-short buffer', () => {
-      const adapter = makeAdapter();
-      expect(adapter.parseNotification(Buffer.alloc(2))).toBeNull();
-    });
-
-    it('returns null for zero weight', () => {
-      const adapter = makeAdapter();
-      const buf = Buffer.alloc(3);
-      buf[0] = 0x2e;
-      buf.writeUInt16LE(0, 1);
-
-      expect(adapter.parseNotification(buf)).toBeNull();
-    });
-
-    it('handles various weight values', () => {
-      const adapter = makeAdapter();
-      // 60 kg = 1200 raw
-      const buf = Buffer.alloc(3);
-      buf[0] = 0x2e;
-      buf.writeUInt16LE(1200, 1);
-
-      const reading = adapter.parseNotification(buf);
-      expect(reading).not.toBeNull();
-      expect(reading!.weight).toBe(60);
+    it('skips profile writes for characteristics the firmware lacks', async () => {
+      const a = makeAdapter();
+      // Only the essential consent/vendor chars present — profile chars absent.
+      const ctx = makeCtx({ availableChars: new Set([CHR_UCP, CHR_VENDOR_WRITE]) });
+      await a.onConnected(ctx);
+      const writtenChars = (ctx.write as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0]);
+      expect(writtenChars).not.toContain(CHR_GENDER);
+      // Handshake + consent still happened.
+      expect(writtenChars).toContain(CHR_VENDOR_WRITE);
+      expect(writtenChars).toContain(CHR_UCP);
     });
   });
 
-  describe('isComplete()', () => {
-    it('returns true when weight > 0', () => {
-      const adapter = makeAdapter();
-      expect(adapter.isComplete({ weight: 80, impedance: 0 })).toBe(true);
+  describe('parseCharNotification()', () => {
+    it('decodes a real SIG weight frame (flags byte, not a 0x2E marker)', () => {
+      const a = makeAdapter();
+      const reading = a.parseCharNotification(CHR_WEIGHT, WSS_FRAME);
+      expect(reading).not.toBeNull();
+      expect(reading!.weight).toBeCloseTo(94.9, 1);
     });
 
-    it('returns false when weight is 0', () => {
-      const adapter = makeAdapter();
-      expect(adapter.isComplete({ weight: 0, impedance: 0 })).toBe(false);
+    it('extracts impedance from a body-composition packet', () => {
+      const a = makeAdapter();
+      a.parseCharNotification(CHR_WEIGHT, WSS_FRAME);
+      const reading = a.parseCharNotification(CHR_BODYCOMP, BCS_PACKET2);
+      expect(reading).not.toBeNull();
+      expect(reading!.weight).toBeCloseTo(94.9, 1);
+      expect(reading!.impedance).toBeCloseTo(332.8, 1);
+    });
+
+    it('parses imperial (lb) weight frames to kg', () => {
+      const a = makeAdapter();
+      const buf = Buffer.alloc(3);
+      buf[0] = 0x01; // flags: imperial, no optional fields
+      buf.writeUInt16LE(2000, 1); // 2000 × 0.1 lb = 200 lb → ~90.72 kg
+      const reading = a.parseCharNotification(CHR_WEIGHT, buf);
+      expect(reading!.weight).toBeCloseTo(200 * 0.45359237, 1);
+    });
+
+    it('ignores User Control Point responses without emitting a reading', () => {
+      const a = makeAdapter();
+      expect(a.parseCharNotification(CHR_UCP, Buffer.from([0x20, 0x02, 0x01]))).toBeNull();
+      expect(a.parseCharNotification(CHR_UCP, Buffer.from([0x20, 0x02, 0x05]))).toBeNull();
+    });
+
+    it('does not throw on a truncated body-comp frame that over-claims via flags', () => {
+      const a = makeAdapter();
+      // flags 0x0300 claim body-water + impedance, but only fat% fits.
+      const truncated = Buffer.from([0x00, 0x03, 0x12, 0x01]);
+      expect(() => a.parseCharNotification(CHR_BODYCOMP, truncated)).not.toThrow();
+    });
+  });
+
+  describe('isComplete() / isFinal()', () => {
+    it('is complete once weight is positive', () => {
+      const a = makeAdapter();
+      expect(a.isComplete({ weight: 80, impedance: 0 })).toBe(true);
+      expect(a.isComplete({ weight: 0, impedance: 0 })).toBe(false);
+    });
+    it('is final only once impedance has arrived', () => {
+      const a = makeAdapter();
+      expect(a.isFinal({ weight: 80, impedance: 0 })).toBe(false);
+      expect(a.isFinal({ weight: 80, impedance: 332.8 })).toBe(true);
     });
   });
 
   describe('computeMetrics()', () => {
-    it('returns all BodyComposition fields using estimation (no impedance)', () => {
-      const adapter = makeAdapter();
+    it('uses impedance (BIA) for body fat when present', () => {
+      const a = makeAdapter();
       const profile = defaultProfile();
-      const payload = adapter.computeMetrics({ weight: 80, impedance: 0 }, profile);
-
-      expect(payload.weight).toBe(80);
-      expect(payload.impedance).toBe(0);
-      assertPayloadRanges(payload);
-    });
-
-    it('computes different results for different profiles', () => {
-      const adapter = makeAdapter();
-      const male = defaultProfile();
-      const female = defaultProfile({ gender: 'female', height: 165 });
-
-      const m = adapter.computeMetrics({ weight: 70, impedance: 0 }, male);
-      const f = adapter.computeMetrics({ weight: 70, impedance: 0 }, female);
-
-      expect(m.bodyFatPercent).not.toBe(f.bodyFatPercent);
-      assertPayloadRanges(m);
-      assertPayloadRanges(f);
+      const withImp = a.computeMetrics({ weight: 80, impedance: 500 }, profile);
+      const noImp = a.computeMetrics({ weight: 80, impedance: 0 }, profile);
+      assertPayloadRanges(withImp);
+      assertPayloadRanges(noImp);
+      expect(withImp.impedance).toBe(500);
+      // BIA-derived fat should differ from the BMI-only estimate.
+      expect(withImp.bodyFatPercent).not.toBe(noImp.bodyFatPercent);
     });
   });
 });

--- a/tests/scales/renpho.test.ts
+++ b/tests/scales/renpho.test.ts
@@ -120,6 +120,18 @@ describe('RenphoScaleAdapter', () => {
       expect(writtenChars).toContain(CHR_VENDOR_WRITE);
       expect(writtenChars).toContain(CHR_UCP);
     });
+
+    // #267 review (P1): the vendor 0xFFE2 service is not advertised (the matcher
+    // rejects devices advertising 0xFFE0), so a firmware variant may not expose
+    // it. Consent alone unlocks the stream, so a missing 0xFFE2 must not abort.
+    it('consents without throwing when the vendor write char is absent', async () => {
+      const a = makeAdapter();
+      const ctx = makeCtx({ availableChars: new Set([CHR_UCP]) });
+      await expect(a.onConnected(ctx)).resolves.toBeUndefined();
+      const writtenChars = (ctx.write as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0]);
+      expect(writtenChars).toContain(CHR_UCP);
+      expect(writtenChars).not.toContain(CHR_VENDOR_WRITE);
+    });
   });
 
   describe('parseCharNotification()', () => {

--- a/tests/scales/yunmai.test.ts
+++ b/tests/scales/yunmai.test.ts
@@ -140,11 +140,34 @@ describe('YunmaiScaleAdapter', () => {
       expect(adapter.isComplete({ weight: 0, impedance: 0 })).toBe(false);
     });
 
-    it('Mini variant: requires impedance > 0', () => {
+    it('Mini variant: complete on weight (impedance preferred via hold, not required)', () => {
       const adapter = makeAdapter();
       adapter.matches(mockPeripheral('Yunmai ISM', []));
-      expect(adapter.isComplete({ weight: 80, impedance: 0 })).toBe(false);
+      // #257: a weight-only final frame is complete so a unit that never reports
+      // impedance resolves weight-only instead of hanging until the read timeout.
+      expect(adapter.isComplete({ weight: 80, impedance: 0 })).toBe(true);
       expect(adapter.isComplete({ weight: 80, impedance: 500 })).toBe(true);
+    });
+  });
+
+  describe('completion hold (#257)', () => {
+    it('Mini/SE variant arms a hold window so impedance can arrive', () => {
+      const adapter = makeAdapter();
+      adapter.matches(mockPeripheral('Yunmai ISSE', []));
+      expect(adapter.completionHoldMs).toBeGreaterThan(0);
+    });
+
+    it('Standard variant sets no hold (resolves immediately)', () => {
+      const adapter = makeAdapter();
+      adapter.matches(mockPeripheral('Yunmai Standard', []));
+      expect(adapter.completionHoldMs).toBeUndefined();
+    });
+
+    it('isFinal resolves immediately once impedance is present', () => {
+      const adapter = makeAdapter();
+      adapter.matches(mockPeripheral('Yunmai ISSE', []));
+      expect(adapter.isFinal({ weight: 80, impedance: 500 })).toBe(true);
+      expect(adapter.isFinal({ weight: 80, impedance: 0 })).toBe(false);
     });
   });
 


### PR DESCRIPTION
Promotes the accumulated dev work to main so release-please cuts the next release. Merged with a merge commit (not squash) so every Conventional Commit reaches main and release-please can build the CHANGELOG.

New adapters:
- Koogeek-S1 (#270)
- Hutbit Smart Scale (#268, closes #254)

Fixes:
- Renpho ES-WBE28 SIG consent handshake so it streams readings (#267)
- QN Type-1 scales identify by char pair over the ESP32 proxy, no longer false-match Yunmai (#272)
- QN honours configured weight_unit, stops flipping the scale display (#269)
- Wrap the dynamic-adapter-path device.gatt() in a timeout so a dropped link cannot hang the watchdog (#273)
- ESP32 firmware writes the CCCD in start_notify so notifications actually stream (#274)
- Re-resolve the adapter after GATT discovery on proxy paths, fixing Eufy/QN false matches (#258, #251, #255)
- Complete a Yunmai weight-only reading instead of timing out (#257)
- Route Beurer BF500 to the SIG consent adapter (#83)
- Keep the ESPHome proxy connection alive on unknown API messages (#252)
- Run the Home Assistant add-on unconfined so it can reach BlueZ (#271)

All CI green on dev: 1883 tests, tsc, eslint, prettier clean.