### PR TITLE
fix(scales): claim OEM/rebranded Hutbit ("SWAN") via the 0x02AC manufacturer signature

### DIFF
--- a/src/scales/hutbit.ts
+++ b/src/scales/hutbit.ts
@@ -17,6 +17,26 @@ import type { MatchDescriptor } from './match-descriptor.js';
 const CHR_FFB1 = uuid16(0xffb1); // write (handshake, phone→scale)
 const CHR_FFB2 = uuid16(0xffb2); // notify (weight stream, scale→phone)
 
+/** Lefu/Fitdays company id carried in the Hutbit's manufacturer data. */
+const MANUFACTURER_ID = 0x02ac;
+
+/**
+ * True when the advertisement carries the Hutbit's manufacturer-data signature:
+ * company id 0x02AC with a 7-byte payload of the device's own MAC reversed plus
+ * a status byte (0x00 idle / 0x01 active), as documented in #254. Exported so
+ * the Robi S9's nameless FFB0+FFB3 claim can exclude Hutbit units (#278): the
+ * Hutbit exposes an (unused) FFB3, and the local name does not survive every
+ * transport (the ESPHome proxy delivers advertisements with an empty name), so
+ * without this signature check the Robi adapter wins post-discovery
+ * re-resolution and replays a handshake the Hutbit rejects.
+ */
+export function hasHutbitSignature(device: BleDeviceInfo): boolean {
+  const m = device.manufacturerData;
+  return (
+    m?.id === MANUFACTURER_ID && m.data.length === 7 && (m.data[6] === 0x00 || m.data[6] === 0x01)
+  );
+}
+
 /**
  * Handshake replayed on FFB1 (write-without-response) after enabling FFB2
  * notifications. Fixed 8-byte AC02 frames decoded from two Fitdays HCI snoops
@@ -64,6 +84,7 @@ export class HutbitAdapter implements ScaleAdapterCore, GattWiring {
     custom: true,
     names: { includes: ['hutbit'] },
     serviceUuids: ['ffb0'],
+    manufacturerId: MANUFACTURER_ID,
   };
   readonly charNotifyUuid = CHR_FFB2;
   readonly charWriteUuid = CHR_FFB1;
@@ -77,12 +98,20 @@ export class HutbitAdapter implements ScaleAdapterCore, GattWiring {
   private final = false;
 
   matches(device: BleDeviceInfo): boolean {
-    // Advertised name is "Hutbit Scale"; match by name only. The nameless FFB0
-    // space is deliberately left to the Robi S9 (FFB3 result char) and the MGB
-    // fallback — the Hutbit exposes no unique post-discovery characteristic
-    // (FFB3 is present but unused), so claiming nameless FFB0 here would risk
-    // shadowing those adapters.
-    return (device.localName || '').toLowerCase().includes('hutbit');
+    // Branded units advertise "Hutbit Scale". Lefu OEM stock units advertise a
+    // generic name instead (observed: "SWAN", #278) — and over the ESPHome
+    // proxy the local name arrives empty entirely — so the name alone is not
+    // enough.
+    if ((device.localName || '').toLowerCase().includes('hutbit')) return true;
+
+    // OEM/rebranded units: claim on the manufacturer-data signature (0x02AC +
+    // reversed-MAC payload + status byte) combined with the advertised FFB0
+    // vendor service. This deliberately does NOT claim the broader nameless
+    // FFB0 space — without the 0x02AC signature that space still belongs to
+    // the Robi S9 (FFB3 result char) and the MGB fallback.
+    const uuids = (device.serviceUuids || []).map((u) => u.toLowerCase());
+    const hasFfb0 = uuids.some((u) => u === 'ffb0' || u === uuid16(0xffb0));
+    return hasFfb0 && hasHutbitSignature(device);
   }
 
   async onConnected(ctx: ConnectionContext): Promise<void> {

--- a/src/scales/robi-s9.ts
+++ b/src/scales/robi-s9.ts
@@ -11,6 +11,7 @@ import type {
 } from '../interfaces/scale-adapter.js';
 import { uuid16, buildPayload } from './body-comp-helpers.js';
 import { bleLog } from '../ble/types.js';
+import { hasHutbitSignature } from './hutbit.js';
 import type { MatchDescriptor } from './match-descriptor.js';
 
 // ─── Robi S9 (Lefu / Fitdays FFB0-new protocol) ─────────────────────────────
@@ -96,6 +97,14 @@ export class RobiS9Adapter implements ScaleAdapterCore, GattWiring, MultiCharNot
     // Swan/Icomon/YG are the openScale MGB protocol, not this one.
     if (name.startsWith('swan') || name === 'icomon' || name === 'yg') return false;
     if (name.includes('robi')) return true;
+
+    // Hutbit units expose an (unused) FFB3 too, and their local name does not
+    // survive every transport (the ESPHome proxy delivers an empty name), so the
+    // swan-name guard above cannot catch a rebranded Hutbit here. Exclude their
+    // manufacturer-data signature before claiming nameless FFB0 (#278) —
+    // otherwise this adapter wins post-discovery re-resolution and replays a
+    // handshake the Hutbit rejects.
+    if (hasHutbitSignature(device)) return false;
 
     // Nameless: require the FFB0 vendor service AND the FFB3 result characteristic
     // (post-discovery) to disambiguate from MGB scales, which expose FFB1/FFB2

--- a/tests/scales/hutbit.test.ts
+++ b/tests/scales/hutbit.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import { HutbitAdapter } from '../../src/scales/hutbit.js';
+import { HutbitAdapter, hasHutbitSignature } from '../../src/scales/hutbit.js';
 import { adapters } from '../../src/scales/index.js';
+import { resolveAdapter } from '../../src/scales/resolve.js';
 import { uuid16 } from '../../src/scales/body-comp-helpers.js';
-import type { ConnectionContext } from '../../src/interfaces/scale-adapter.js';
+import type { BleDeviceInfo, ConnectionContext } from '../../src/interfaces/scale-adapter.js';
 import {
   mockPeripheral,
   defaultProfile,
@@ -35,6 +36,68 @@ describe('HutbitAdapter (#254)', () => {
         uuid16(0xffb2),
       ]);
       expect(makeAdapter().matches(info)).toBe(false);
+    });
+  });
+
+  describe('OEM/rebranded advertisement (SWAN, #278)', () => {
+    // Real capture: Lefu OEM stock branding. Manufacturer data 0x02AC carries
+    // the device's MAC reversed (03:B3:EC:93:B8:7E) + status byte (01 = active).
+    // Over the ESPHome proxy the local name arrives empty.
+    function swanAdvert(name = 'SWAN', charUuids?: string[]): BleDeviceInfo {
+      return {
+        localName: name,
+        serviceUuids: [uuid16(0xd618), uuid16(0xffb0)],
+        manufacturerData: { id: 0x02ac, data: Buffer.from('7eb893ecb30301', 'hex') },
+        ...(charUuids ? { characteristicUuids: charUuids } : {}),
+      };
+    }
+
+    it('claims the SWAN-branded advert via the 0x02AC manufacturer signature', () => {
+      expect(makeAdapter().matches(swanAdvert())).toBe(true);
+      expect(hasHutbitSignature(swanAdvert())).toBe(true);
+    });
+
+    it('claims the same advert with an empty name (ESPHome proxy transport)', () => {
+      expect(makeAdapter().matches(swanAdvert(''))).toBe(true);
+    });
+
+    it('accepts the idle-status variant (payload ends 0x00)', () => {
+      const idle = swanAdvert();
+      idle.manufacturerData = { id: 0x02ac, data: Buffer.from('7eb893ecb30300', 'hex') };
+      expect(makeAdapter().matches(idle)).toBe(true);
+    });
+
+    it('rejects 0x02AC data that does not fit the signature shape', () => {
+      const wrongLen = swanAdvert('');
+      wrongLen.manufacturerData = { id: 0x02ac, data: Buffer.from('7eb893ecb303', 'hex') };
+      expect(makeAdapter().matches(wrongLen)).toBe(false);
+
+      const wrongStatus = swanAdvert('');
+      wrongStatus.manufacturerData = { id: 0x02ac, data: Buffer.from('7eb893ecb303ff', 'hex') };
+      expect(makeAdapter().matches(wrongStatus)).toBe(false);
+    });
+
+    it('registry resolves the SWAN broadcast to Hutbit, not MGB', () => {
+      expect(resolveAdapter(swanAdvert(), adapters)?.name).toBe('Hutbit');
+      expect(resolveAdapter(swanAdvert(''), adapters)?.name).toBe('Hutbit');
+    });
+
+    it('post-discovery re-resolution stays on Hutbit — Robi S9 must not steal FFB3 (#278)', () => {
+      // Mirrors the esphome-proxy watcher: after GATT discovery the device info
+      // gains characteristicUuids (the Hutbit exposes an unused FFB3) and has no
+      // usable name. Without the Robi-side signature guard, Robi S9 (prio 40)
+      // would claim this and replay a handshake the Hutbit rejects.
+      const postDiscovery = swanAdvert('', [uuid16(0xffb1), uuid16(0xffb2), uuid16(0xffb3)]);
+      expect(resolveAdapter(postDiscovery, adapters)?.name).toBe('Hutbit');
+    });
+
+    it('does not shadow the Robi S9: nameless FFB0+FFB3 without the signature still resolves to Robi', () => {
+      const robiLike: BleDeviceInfo = {
+        localName: '',
+        serviceUuids: [uuid16(0xffb0)],
+        characteristicUuids: [uuid16(0xffb1), uuid16(0xffb2), uuid16(0xffb3)],
+      };
+      expect(resolveAdapter(robiLike, adapters)?.name).toBe('Robi S9');
     });
   });
 


### PR DESCRIPTION
Fixes #278 (follow-up to #254 / #268 — same unit, live-tested today on v1.20.0).

## Problem

The Hutbit 218008 ships with Lefu OEM stock branding: it advertises **`SWAN`** instead of `Hutbit Scale` — and over the ESPHome proxy the local name arrives **empty** entirely (it lives in the scan response, which the proxy advertisement doesn't carry). The name-only `matches()` therefore never claims the unit. Observed chain on v1.20.0:

```
Matched: MGB (Swan/Icomon/YG) (03:B3:EC:93:B8:7E); opening GATT via ESPHome proxy
Re-resolved adapter after GATT discovery: MGB (Swan/Icomon/YG) -> Robi S9
Subscribed to 2 notification(s). Step on the scale.
   ... scale rejects the Robi handshake and drops the link; repeats every ~6 s
```

Robi's swan-name guard can't fire at re-resolution because `localName` is empty there, so its nameless ffb0+ffb3 path claims the Hutbit's (unused) FFB3. A full weigh-in produced zero frames.

## Fix

Match on the stable fingerprint from the advertisement instead of the name: **manufacturer data company id `0x02AC` whose 7-byte payload is the device's own MAC reversed plus a status byte (`0x00` idle / `0x01` active)** — the signature documented in #254 — combined with the advertised `ffb0` service. nRF capture of both variants today:

```
Company: <0x02AC>  0x7EB893ECB30301   (active)
Company: <0x02AC>  0x7EB893ECB30300   (idle)
Services: 0xD618, 0xFFB0 · Legacy, connectable · name: SWAN
```

- `hutbit.ts`: `matches()` claims name-'hutbit' (unchanged) **or** ffb0 + the 0x02AC signature; exports `hasHutbitSignature()`; descriptor gains `manufacturerId`.
- `robi-s9.ts`: the nameless ffb0+ffb3 claim now excludes devices carrying the Hutbit signature, so post-discovery re-resolution stays on Hutbit (prio 35 < Robi's 40 makes the guard necessary). Named/real Robi units are unaffected, and nameless FFB3 units **without** the signature still resolve to Robi (covered by a test).
- The broader nameless FFB0 space is deliberately still left to Robi/MGB — without the 0x02AC signature nothing changes.

## Tests

7 new cases in `tests/scales/hutbit.test.ts` from the real capture: SWAN-named + empty-name (proxy) claims, idle/active payload variants, malformed-payload rejection, registry resolution (broadcast → Hutbit, not MGB), post-discovery re-resolution (→ Hutbit, not Robi), and the Robi non-shadowing control.

`vitest run`: 1907/1908 passing — the one failure is `tests/config/watch.test.ts > ignores edits to other files in the same directory`, a macOS `fs.watch` sibling-event flake unrelated to this change.

I'll live-test on the physical unit (HAOS add-on, esphome-proxy) as soon as a build is available — it reproduces within seconds here.