### PR TITLE
Fix premature Eufy/1byone scale completion while weight is settling

### DIFF
--- a/src/scales/eufy-p2.ts
+++ b/src/scales/eufy-p2.ts
@@ -78,6 +78,12 @@ const EUFY_COMPANY_ID = 0xff48;
  */
 const EUFY_WRITE_DELAY_MS = 1000;
 
+interface ParsedEufyWeightFrame {
+  reading: ScaleReading;
+  rawWeight: number;
+  isFinal: boolean;
+}
+
 /** XOR checksum over every byte of a frame (matches Python util.compute_checksum). */
 function xor(bytes: Buffer): number {
   return xorChecksum(bytes, 0, bytes.length);
@@ -247,17 +253,23 @@ export class EufyAuthHandler {
 }
 
 /** Parse a 16-byte weight notification frame from FFF2. Returns null if malformed. */
-export function parseWeightNotification(data: Buffer): ScaleReading | null {
+function parseWeightNotificationFrame(data: Buffer): ParsedEufyWeightFrame | null {
   if (data.length !== 16 || data[0] !== 0xcf || data[2] !== 0x00) return null;
 
-  const weight = ((data[7] << 8) | data[6]) / 100;
+  const rawWeight = (data[7] << 8) | data[6];
+  const weight = rawWeight / 100;
   if (!Number.isFinite(weight) || weight < MIN_WEIGHT_KG || weight > MAX_WEIGHT_KG) return null;
 
   const isFinal = data[12] === 0x00;
-  if (!isFinal) return null;
-
   const impedance = (data[10] << 16) | (data[9] << 8) | data[8];
-  return { weight, impedance };
+  return { reading: { weight, impedance }, rawWeight, isFinal };
+}
+
+/** Parse a final 16-byte weight notification from FFF2. Returns null if malformed/in-progress. */
+export function parseWeightNotification(data: Buffer): ScaleReading | null {
+  const frame = parseWeightNotificationFrame(data);
+  if (!frame?.isFinal) return null;
+  return frame.reading;
 }
 
 /** Parse 19-byte advertisement vendor payload. Returns null if not a final reading. */
@@ -297,6 +309,9 @@ export class EufyP2Adapter
   private auth: EufyAuthHandler | null = null;
   private ctx: ConnectionContext | null = null;
   private readonly c3Seen = { done: false };
+  private previousRawWeight: number | null = null;
+  private stableRawWeight: number | null = null;
+  private lastGattReading: ScaleReading | null = null;
 
   matches(device: BleDeviceInfo): boolean {
     const name = (device.localName || '').toLowerCase();
@@ -320,6 +335,7 @@ export class EufyP2Adapter
     this.ctx = ctx;
     this.auth = null;
     this.c3Seen.done = false;
+    this.resetStability();
     if (!ctx.deviceAddress) {
       bleLog.warn('Eufy: no device address available — auth will fail without MAC');
       return;
@@ -344,14 +360,14 @@ export class EufyP2Adapter
         bleLog.debug('Eufy: FFF2 frame received before auth complete — ignoring');
         return null;
       }
-      return parseWeightNotification(data);
+      return this.parseGattWeight(data);
     }
     return null;
   }
 
   /** Fallback single-char path (not used when parseCharNotification is defined). */
   parseNotification(data: Buffer): ScaleReading | null {
-    return parseWeightNotification(data);
+    return this.parseGattWeight(data);
   }
 
   parseBroadcast(manufacturerData: Buffer): ScaleReading | null {
@@ -359,10 +375,12 @@ export class EufyP2Adapter
   }
 
   isComplete(reading: ScaleReading): boolean {
-    // Broadcast readings have impedance=0 (passive mode, no BIA).
-    // Authenticated GATT readings have non-zero impedance from the scale.
-    if (reading.impedance === 0) return reading.weight > 0;
-    return reading.weight > MIN_WEIGHT_KG && reading.impedance > 200;
+    // Broadcast readings have impedance=0 (passive mode, no BIA), but GATT
+    // frames can also lack impedance, so only skip stability for non-GATT reads.
+    const isGattReading = reading === this.lastGattReading;
+    if (!isGattReading && reading.impedance === 0) return reading.weight > 0;
+    const rawWeight = Math.round(reading.weight * 100);
+    return reading.weight > MIN_WEIGHT_KG && rawWeight === this.stableRawWeight;
   }
 
   computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {
@@ -404,5 +422,28 @@ export class EufyP2Adapter
       await this.ctx.write(CHR_WRITE, frame, true);
       await new Promise<void>((r) => setTimeout(r, EUFY_WRITE_DELAY_MS));
     }
+  }
+
+  private parseGattWeight(data: Buffer): ScaleReading | null {
+    const frame = parseWeightNotificationFrame(data);
+    if (!frame) return null;
+    this.updateStability(frame);
+    this.lastGattReading = frame.reading;
+    return frame.reading;
+  }
+
+  private updateStability(frame: ParsedEufyWeightFrame): void {
+    if (frame.isFinal && this.previousRawWeight === frame.rawWeight) {
+      this.stableRawWeight = frame.rawWeight;
+    } else if (this.stableRawWeight !== frame.rawWeight) {
+      this.stableRawWeight = null;
+    }
+    this.previousRawWeight = frame.rawWeight;
+  }
+
+  private resetStability(): void {
+    this.previousRawWeight = null;
+    this.stableRawWeight = null;
+    this.lastGattReading = null;
   }
 }

--- a/src/scales/one-byone.ts
+++ b/src/scales/one-byone.ts
@@ -34,6 +34,9 @@ export class OneByoneAdapter implements ScaleAdapterCore, GattWiring {
   readonly charWriteUuid = uuid16(0xfff1);
   readonly normalizesWeight = true;
 
+  private previousRawWeight: number | null = null;
+  private stableRawWeight: number | null = null;
+
   matches(device: BleDeviceInfo): boolean {
     // Name match is unambiguous (T914x / Health Scale); keep it.
     const name = (device.localName || '').toLowerCase();
@@ -56,6 +59,8 @@ export class OneByoneAdapter implements ScaleAdapterCore, GattWiring {
    *   2. Clock sync: [0xF1, yearHi, yearLo, month, day, hour, min, sec]
    */
   async onConnected(ctx: ConnectionContext): Promise<void> {
+    this.resetStability();
+
     // Step 1: Mode/unit command
     const unitCmd = [0xfd, 0x37, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
     unitCmd.push(xorChecksum(unitCmd, 0, unitCmd.length));
@@ -79,7 +84,8 @@ export class OneByoneAdapter implements ScaleAdapterCore, GattWiring {
   parseNotification(data: Buffer): ScaleReading | null {
     if (data.length < 5 || data[0] !== 0xcf) return null;
 
-    const weight = data.readUInt16LE(3) / 100;
+    const rawWeight = data.readUInt16LE(3);
+    const weight = rawWeight / 100;
 
     let impedance = 0;
     if (data.length >= 10) {
@@ -90,16 +96,31 @@ export class OneByoneAdapter implements ScaleAdapterCore, GattWiring {
       }
     }
 
+    this.updateStability(rawWeight);
     return { weight, impedance };
   }
 
   isComplete(reading: ScaleReading): boolean {
-    return reading.weight > 0;
+    return reading.weight > 0 && Math.round(reading.weight * 100) === this.stableRawWeight;
   }
 
   computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {
     const comp: ScaleBodyComp = {};
     return buildPayload(reading.weight, reading.impedance, comp, profile);
+  }
+
+  private updateStability(rawWeight: number): void {
+    if (this.previousRawWeight === rawWeight) {
+      this.stableRawWeight = rawWeight;
+    } else if (this.stableRawWeight !== rawWeight) {
+      this.stableRawWeight = null;
+    }
+    this.previousRawWeight = rawWeight;
+  }
+
+  private resetStability(): void {
+    this.previousRawWeight = null;
+    this.stableRawWeight = null;
   }
 }
 

--- a/tests/scales/eufy-p2.test.ts
+++ b/tests/scales/eufy-p2.test.ts
@@ -228,6 +228,41 @@ describe('EufyP2Adapter', () => {
     assertPayloadRanges(payload);
   });
 
+  it('waits for a final GATT weight to match the previous realtime weight before completing', () => {
+    const adapter = new EufyP2Adapter();
+
+    const first = adapter.parseNotification(makeNotification(80.1, 520, false))!;
+    expect(first.weight).toBe(80.1);
+    expect(adapter.isComplete(first)).toBe(false);
+
+    const changingFinal = adapter.parseNotification(makeNotification(80.0, 520, true))!;
+    expect(adapter.isComplete(changingFinal)).toBe(false);
+
+    const stableFinal = adapter.parseNotification(makeNotification(80.0, 520, true))!;
+    expect(adapter.isComplete(stableFinal)).toBe(true);
+  });
+
+  it('clears GATT stability when the weight changes again', () => {
+    const adapter = new EufyP2Adapter();
+
+    adapter.parseNotification(makeNotification(80, 520, false));
+    const stable = adapter.parseNotification(makeNotification(80, 520, true))!;
+    expect(adapter.isComplete(stable)).toBe(true);
+
+    const changed = adapter.parseNotification(makeNotification(80.2, 520, true))!;
+    expect(adapter.isComplete(changed)).toBe(false);
+  });
+
+  it('still stability-gates GATT readings when impedance is absent', () => {
+    const adapter = new EufyP2Adapter();
+
+    const first = adapter.parseNotification(makeNotification(80, 0, true))!;
+    expect(adapter.isComplete(first)).toBe(false);
+
+    const stable = adapter.parseNotification(makeNotification(80, 0, true))!;
+    expect(adapter.isComplete(stable)).toBe(true);
+  });
+
   it('rejects FFF2 weight frames when onConnected had no deviceAddress (no stale auth)', async () => {
     const adapter = new EufyP2Adapter();
 

--- a/tests/scales/one-byone.test.ts
+++ b/tests/scales/one-byone.test.ts
@@ -15,6 +15,16 @@ describe('OneByoneAdapter', () => {
     return new OneByoneAdapter();
   }
 
+  function makeCfFrame(weightKg: number, impedanceRaw = 500, impedanceStatus = 0): Buffer {
+    const buf = Buffer.alloc(10);
+    buf[0] = 0xcf;
+    buf[1] = impedanceRaw & 0xff;
+    buf[2] = (impedanceRaw >> 8) & 0xff;
+    buf.writeUInt16LE(Math.round(weightKg * 100), 3);
+    buf[9] = impedanceStatus;
+    return buf;
+  }
+
   describe('matches()', () => {
     it.each(['t9146', 't9147', 't9120', 'health scale'])('matches "%s"', (name) => {
       const adapter = makeAdapter();
@@ -113,13 +123,8 @@ describe('OneByoneAdapter', () => {
   describe('parseNotification()', () => {
     it('parses 0xCF frame with weight and impedance', () => {
       const adapter = makeAdapter();
-      const buf = Buffer.alloc(10);
-      buf[0] = 0xcf;
-      // impedance raw: (data[2]<<8) + data[1] = (0x01<<8) + 0xF4 = 500 → * 0.1 = 50.0
-      buf[1] = 0xf4;
-      buf[2] = 0x01;
-      buf.writeUInt16LE(8000, 3); // weight = 8000 / 100 = 80.0 kg
-      buf[9] = 0; // not invalid
+      // impedance raw: (data[2]<<8) + data[1] = 500 → * 0.1 = 50.0
+      const buf = makeCfFrame(80);
 
       const reading = adapter.parseNotification(buf);
       expect(reading).not.toBeNull();
@@ -129,12 +134,7 @@ describe('OneByoneAdapter', () => {
 
     it('impedance is 0 when byte[9] = 1', () => {
       const adapter = makeAdapter();
-      const buf = Buffer.alloc(10);
-      buf[0] = 0xcf;
-      buf[1] = 0xf4;
-      buf[2] = 0x01;
-      buf.writeUInt16LE(8000, 3);
-      buf[9] = 1; // impedance invalid
+      const buf = makeCfFrame(80, 500, 1); // impedance invalid
 
       const reading = adapter.parseNotification(buf);
       expect(reading).not.toBeNull();
@@ -143,12 +143,7 @@ describe('OneByoneAdapter', () => {
 
     it('impedance is 0 when raw value is 0', () => {
       const adapter = makeAdapter();
-      const buf = Buffer.alloc(10);
-      buf[0] = 0xcf;
-      buf[1] = 0x00;
-      buf[2] = 0x00;
-      buf.writeUInt16LE(8000, 3);
-      buf[9] = 0;
+      const buf = makeCfFrame(80, 0);
 
       const reading = adapter.parseNotification(buf);
       expect(reading).not.toBeNull();
@@ -169,9 +164,26 @@ describe('OneByoneAdapter', () => {
   });
 
   describe('isComplete()', () => {
-    it('returns true when weight > 0', () => {
+    it('returns true only after two consecutive readings have the same weight', () => {
       const adapter = makeAdapter();
-      expect(adapter.isComplete({ weight: 80, impedance: 0 })).toBe(true);
+      const first = adapter.parseNotification(makeCfFrame(80.2))!;
+      expect(adapter.isComplete(first)).toBe(false);
+
+      const changing = adapter.parseNotification(makeCfFrame(80))!;
+      expect(adapter.isComplete(changing)).toBe(false);
+
+      const stable = adapter.parseNotification(makeCfFrame(80))!;
+      expect(adapter.isComplete(stable)).toBe(true);
+    });
+
+    it('clears stability when the weight changes again', () => {
+      const adapter = makeAdapter();
+      adapter.parseNotification(makeCfFrame(80));
+      const stable = adapter.parseNotification(makeCfFrame(80))!;
+      expect(adapter.isComplete(stable)).toBe(true);
+
+      const changed = adapter.parseNotification(makeCfFrame(80.1))!;
+      expect(adapter.isComplete(changed)).toBe(false);
     });
 
     it('returns false when weight is 0', () => {


### PR DESCRIPTION
## Summary

Fixes Eufy/1byone scale measurements completing too early while the scale is still settling. The adapters now wait for consecutive realtime weight frames with the same value before marking the reading complete.

## Changes

- Added weight stability tracking to Eufy P2 GATT readings.
- Added the same stability gate for 1byone/Eufy T9146 readings.
- Added regression tests for changing, stable, and reset-after-change weight frames.

## Test Plan

- [x] Tests pass (`npm test -- tests/scales/eufy-p2.test.ts tests/scales/one-byone.test.ts`)
- [x] Lint clean (`npx eslint src/scales/eufy-p2.ts src/scales/one-byone.ts tests/scales/eufy-p2.test.ts tests/scales/one-byone.test.ts`)
- [x] TypeScript compiles (`npm run build`)
- [ ] Tested manually (describe below)

## Notes

The reported `eufy T9146` device resolves to the `1byone (Eufy)` adapter, so this PR updates both that adapter and the Eufy P2 adapter.