### PR TITLE
Support reading stable weight

### DIFF
--- a/src/ble/notification-processor.ts
+++ b/src/ble/notification-processor.ts
@@ -1,4 +1,4 @@
-import type { ScaleReading } from '../interfaces/scale-adapter.js';
+import type { ScaleReading, WeightStabilityGate } from '../interfaces/scale-adapter.js';
 import { bleLog } from './types.js';
 
 /**
@@ -72,7 +72,7 @@ export class HoldTimer {
     this.held = reading;
     if (this.timer) return;
     bleLog.info(
-      `Weight stable; holding connection up to ` +
+      `Reading complete; holding connection up to ` +
         `${Math.round(this.holdMs / 1000)}s for body composition...`,
     );
     this.timer = setTimeout(() => {
@@ -91,5 +91,48 @@ export class HoldTimer {
       clearTimeout(this.timer);
       this.timer = null;
     }
+  }
+}
+
+/**
+ * Tracks an opt-in consecutive-weight stability rule across live readings.
+ * This is deliberately outside individual adapters so protocols can keep their
+ * own "complete" semantics while sharing the common "weight stopped moving"
+ * gate where it is useful.
+ */
+export class WeightStabilityTracker {
+  private readonly requiredSamples: number;
+  private readonly toleranceKg: number;
+  private previousWeight: number | null = null;
+  private consecutiveSamples = 0;
+
+  constructor(config: NonNullable<WeightStabilityGate['weightStability']>) {
+    this.requiredSamples = Math.max(1, Math.trunc(config.samples ?? 2));
+    this.toleranceKg = Math.max(0, config.toleranceKg ?? 0);
+  }
+
+  observe(reading: ScaleReading): boolean {
+    const weight = reading.weight;
+    if (!Number.isFinite(weight)) {
+      this.reset();
+      return false;
+    }
+
+    if (
+      this.previousWeight !== null &&
+      Math.abs(weight - this.previousWeight) <= this.toleranceKg
+    ) {
+      this.consecutiveSamples += 1;
+    } else {
+      this.consecutiveSamples = 1;
+    }
+
+    this.previousWeight = weight;
+    return this.consecutiveSamples >= this.requiredSamples;
+  }
+
+  reset(): void {
+    this.previousWeight = null;
+    this.consecutiveSamples = 0;
   }
 }

--- a/src/ble/shared.ts
+++ b/src/ble/shared.ts
@@ -9,7 +9,7 @@ import type {
 } from '../interfaces/scale-adapter.js';
 import type { WeightUnit } from '../config/schema.js';
 import { LBS_TO_KG, normalizeUuid, errMsg, bleLog } from './types.js';
-import { HistoryBuffer, HoldTimer } from './notification-processor.js';
+import { HistoryBuffer, HoldTimer, WeightStabilityTracker } from './notification-processor.js';
 
 // ─── Broadcast-vs-GATT routing ────────────────────────────────────────────────
 
@@ -365,6 +365,9 @@ export function waitForRawReading(
     let resolved = false;
     const history = new HistoryBuffer(MAX_HISTORY_FRAMES, adapter.name);
     const ackWriteChar = resolveWriteChar(charMap, adapter);
+    const weightStability = adapter.weightStability
+      ? new WeightStabilityTracker(adapter.weightStability)
+      : null;
 
     const finishWith = (r: ScaleReading): void => {
       resolved = true;
@@ -416,7 +419,10 @@ export function waitForRawReading(
         return;
       }
 
+      const weightIsStable = weightStability ? weightStability.observe(reading) : true;
+
       if (adapter.isComplete(reading)) {
+        if (!weightIsStable) return;
         const final = adapter.isFinal ? adapter.isFinal(reading) : true;
         if (adapter.completionHoldMs && !final) {
           hold.hold(reading);

--- a/src/interfaces/scale-adapter.ts
+++ b/src/interfaces/scale-adapter.ts
@@ -329,6 +329,24 @@ export interface HoldForComposition {
 }
 
 /**
+ * Opt-in gate for adapters that stream live weight values before the protocol's
+ * own completion signal is trustworthy enough to finish immediately. The shared
+ * GATT reader observes every live reading and only allows completion after
+ * `samples` consecutive weights are within `toleranceKg` of each other.
+ *
+ * Keep this opt-in: several scales only emit one final frame, and a mandatory
+ * global stability rule would make those adapters wait for disconnect/timeout.
+ */
+export interface WeightStabilityGate {
+  readonly weightStability?: {
+    /** Consecutive matching readings required before completion. Defaults to 2. */
+    readonly samples?: number;
+    /** Maximum allowed kg delta between consecutive readings. Defaults to 0. */
+    readonly toleranceKg?: number;
+  };
+}
+
+/**
  * The registry element type. Core is required; every capability mixin is folded
  * in as a Partial so ANY adapter (and any strict-object-literal test mock) is
  * assignable, the production `ScaleAdapter[]` registry stays homogeneous, and
@@ -344,4 +362,5 @@ export type ScaleAdapter = ScaleAdapterCore &
   Partial<BroadcastSource> &
   Partial<MultiCharNotify> &
   Partial<AckProtocol> &
-  Partial<HoldForComposition>;
+  Partial<HoldForComposition> &
+  Partial<WeightStabilityGate>;

--- a/src/scales/eufy-p2.ts
+++ b/src/scales/eufy-p2.ts
@@ -8,6 +8,7 @@ import type {
   GattWiring,
   MultiCharNotify,
   BroadcastSource,
+  WeightStabilityGate,
   ScaleReading,
   UserProfile,
   BodyComposition,
@@ -77,6 +78,11 @@ const EUFY_COMPANY_ID = 0xff48;
  * were observed to trigger disconnects on some T9149 units.
  */
 const EUFY_WRITE_DELAY_MS = 1000;
+
+interface ParsedEufyWeightFrame {
+  reading: ScaleReading;
+  isFinal: boolean;
+}
 
 /** XOR checksum over every byte of a frame (matches Python util.compute_checksum). */
 function xor(bytes: Buffer): number {
@@ -247,17 +253,23 @@ export class EufyAuthHandler {
 }
 
 /** Parse a 16-byte weight notification frame from FFF2. Returns null if malformed. */
-export function parseWeightNotification(data: Buffer): ScaleReading | null {
+function parseWeightNotificationFrame(data: Buffer): ParsedEufyWeightFrame | null {
   if (data.length !== 16 || data[0] !== 0xcf || data[2] !== 0x00) return null;
 
-  const weight = ((data[7] << 8) | data[6]) / 100;
+  const rawWeight = (data[7] << 8) | data[6];
+  const weight = rawWeight / 100;
   if (!Number.isFinite(weight) || weight < MIN_WEIGHT_KG || weight > MAX_WEIGHT_KG) return null;
 
   const isFinal = data[12] === 0x00;
-  if (!isFinal) return null;
-
   const impedance = (data[10] << 16) | (data[9] << 8) | data[8];
-  return { weight, impedance };
+  return { reading: { weight, impedance }, isFinal };
+}
+
+/** Parse a final 16-byte weight notification from FFF2. Returns null if malformed/in-progress. */
+export function parseWeightNotification(data: Buffer): ScaleReading | null {
+  const frame = parseWeightNotificationFrame(data);
+  if (!frame?.isFinal) return null;
+  return frame.reading;
 }
 
 /** Parse 19-byte advertisement vendor payload. Returns null if not a final reading. */
@@ -275,7 +287,7 @@ export function parseEufyAdvertisement(vendor: Buffer): ScaleReading | null {
 }
 
 export class EufyP2Adapter
-  implements ScaleAdapterCore, GattWiring, MultiCharNotify, BroadcastSource
+  implements ScaleAdapterCore, GattWiring, MultiCharNotify, BroadcastSource, WeightStabilityGate
 {
   readonly name = 'Eufy Smart Scale P2/P2 Pro';
   readonly match: MatchDescriptor = {
@@ -287,6 +299,7 @@ export class EufyP2Adapter
   readonly charNotifyUuid = CHR_DATA;
   readonly charWriteUuid = CHR_WRITE;
   readonly normalizesWeight = true;
+  readonly weightStability = { samples: 2, toleranceKg: 0 };
 
   readonly characteristics: CharacteristicBinding[] = [
     { service: SVC_UUID, uuid: CHR_WRITE, type: 'write' },
@@ -297,6 +310,8 @@ export class EufyP2Adapter
   private auth: EufyAuthHandler | null = null;
   private ctx: ConnectionContext | null = null;
   private readonly c3Seen = { done: false };
+  private lastGattReading: ScaleReading | null = null;
+  private lastGattIsFinal = false;
 
   matches(device: BleDeviceInfo): boolean {
     const name = (device.localName || '').toLowerCase();
@@ -320,6 +335,7 @@ export class EufyP2Adapter
     this.ctx = ctx;
     this.auth = null;
     this.c3Seen.done = false;
+    this.resetStability();
     if (!ctx.deviceAddress) {
       bleLog.warn('Eufy: no device address available — auth will fail without MAC');
       return;
@@ -344,14 +360,14 @@ export class EufyP2Adapter
         bleLog.debug('Eufy: FFF2 frame received before auth complete — ignoring');
         return null;
       }
-      return parseWeightNotification(data);
+      return this.parseGattWeight(data);
     }
     return null;
   }
 
   /** Fallback single-char path (not used when parseCharNotification is defined). */
   parseNotification(data: Buffer): ScaleReading | null {
-    return parseWeightNotification(data);
+    return this.parseGattWeight(data);
   }
 
   parseBroadcast(manufacturerData: Buffer): ScaleReading | null {
@@ -359,9 +375,11 @@ export class EufyP2Adapter
   }
 
   isComplete(reading: ScaleReading): boolean {
-    // Broadcast readings have impedance=0 (passive mode, no BIA).
-    // Authenticated GATT readings have non-zero impedance from the scale.
-    if (reading.impedance === 0) return reading.weight > 0;
+    // Broadcast readings have impedance=0 (passive mode, no BIA), but GATT
+    // frames can also lack impedance, so only skip stability for non-GATT reads.
+    const isGattReading = reading === this.lastGattReading;
+    if (!isGattReading && reading.impedance === 0) return reading.weight > 0;
+    if (isGattReading) return this.lastGattIsFinal && reading.weight > MIN_WEIGHT_KG;
     return reading.weight > MIN_WEIGHT_KG && reading.impedance > 200;
   }
 
@@ -404,5 +422,18 @@ export class EufyP2Adapter
       await this.ctx.write(CHR_WRITE, frame, true);
       await new Promise<void>((r) => setTimeout(r, EUFY_WRITE_DELAY_MS));
     }
+  }
+
+  private parseGattWeight(data: Buffer): ScaleReading | null {
+    const frame = parseWeightNotificationFrame(data);
+    if (!frame) return null;
+    this.lastGattReading = frame.reading;
+    this.lastGattIsFinal = frame.isFinal;
+    return frame.reading;
+  }
+
+  private resetStability(): void {
+    this.lastGattReading = null;
+    this.lastGattIsFinal = false;
   }
 }

--- a/src/scales/one-byone.ts
+++ b/src/scales/one-byone.ts
@@ -4,6 +4,7 @@ import type {
   ScaleAdapterCore,
   GattWiring,
   Unlockable,
+  WeightStabilityGate,
   ScaleReading,
   UserProfile,
   BodyComposition,
@@ -22,7 +23,7 @@ import { matchesDescriptor, type MatchDescriptor } from './match-descriptor.js';
  *   Weight at bytes [3-4] little-endian uint16 / 100 (kg).
  *   Impedance: ((data[2]<<8)+data[1]) * 0.1, valid when byte[9] != 1 and != 0.
  */
-export class OneByoneAdapter implements ScaleAdapterCore, GattWiring {
+export class OneByoneAdapter implements ScaleAdapterCore, GattWiring, WeightStabilityGate {
   readonly name = '1byone (Eufy)';
   readonly match: MatchDescriptor = {
     priority: 70,
@@ -33,6 +34,7 @@ export class OneByoneAdapter implements ScaleAdapterCore, GattWiring {
   readonly charNotifyUuid = uuid16(0xfff4);
   readonly charWriteUuid = uuid16(0xfff1);
   readonly normalizesWeight = true;
+  readonly weightStability = { samples: 2, toleranceKg: 0 };
 
   matches(device: BleDeviceInfo): boolean {
     // Name match is unambiguous (T914x / Health Scale); keep it.

--- a/tests/ble/notification-processor.test.ts
+++ b/tests/ble/notification-processor.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { HistoryBuffer, HoldTimer } from '../../src/ble/notification-processor.js';
+import {
+  HistoryBuffer,
+  HoldTimer,
+  WeightStabilityTracker,
+} from '../../src/ble/notification-processor.js';
 import { bleLog } from '../../src/ble/types.js';
 import type { ScaleReading } from '../../src/interfaces/scale-adapter.js';
 
@@ -105,5 +109,30 @@ describe('HoldTimer', () => {
   it('heldReading is null before any hold', () => {
     const t = new HoldTimer(15000, vi.fn());
     expect(t.heldReading).toBeNull();
+  });
+});
+
+describe('WeightStabilityTracker', () => {
+  it('requires consecutive equal weights by default', () => {
+    const t = new WeightStabilityTracker({});
+    expect(t.observe({ weight: 80.1, impedance: 0 })).toBe(false);
+    expect(t.observe({ weight: 80, impedance: 0 })).toBe(false);
+    expect(t.observe({ weight: 80, impedance: 0 })).toBe(true);
+  });
+
+  it('uses toleranceKg when comparing consecutive readings', () => {
+    const t = new WeightStabilityTracker({ samples: 3, toleranceKg: 0.05 });
+    expect(t.observe({ weight: 80, impedance: 0 })).toBe(false);
+    expect(t.observe({ weight: 80.03, impedance: 0 })).toBe(false);
+    expect(t.observe({ weight: 80.01, impedance: 0 })).toBe(true);
+    expect(t.observe({ weight: 80.2, impedance: 0 })).toBe(false);
+  });
+
+  it('resets on non-finite readings', () => {
+    const t = new WeightStabilityTracker({});
+    expect(t.observe({ weight: 80, impedance: 0 })).toBe(false);
+    expect(t.observe({ weight: Number.NaN, impedance: 0 })).toBe(false);
+    expect(t.observe({ weight: 80, impedance: 0 })).toBe(false);
+    expect(t.observe({ weight: 80, impedance: 0 })).toBe(true);
   });
 });

--- a/tests/ble/shared.test.ts
+++ b/tests/ble/shared.test.ts
@@ -970,6 +970,69 @@ describe('waitForRawReading() — per-frame ACK + completion hold', () => {
     expect(result.reading).toEqual({ weight: 83.55, impedance: 437 });
   });
 
+  it('applies opt-in weight stability before resolving a complete reading', async () => {
+    const notifyChar = createMockChar();
+    const writeChar = createMockChar();
+    const device = createMockDevice();
+    const { charMap } = createCharMap([
+      [NOTIFY_UUID, notifyChar],
+      [WRITE_UUID, writeChar],
+    ]);
+
+    const readings = [
+      { weight: 83.4, impedance: 0 },
+      { weight: 83.2, impedance: 0 },
+      { weight: 83.2, impedance: 0 },
+    ];
+    const adapter = createLegacyAdapter({
+      weightStability: { samples: 2, toleranceKg: 0 },
+      isComplete: vi.fn((r: ScaleReading) => r.weight > 0),
+      parseNotification: vi.fn(() => readings.shift() ?? { weight: 83.2, impedance: 0 }),
+    });
+
+    const promise = waitForRawReading(charMap, device, adapter, PROFILE, '');
+    await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
+
+    notifyChar.triggerData(Buffer.from([0x01]));
+    notifyChar.triggerData(Buffer.from([0x02]));
+    const pending = await Promise.race([
+      promise.then(() => 'resolved'),
+      new Promise((r) => setTimeout(() => r('pending'), 50)),
+    ]);
+    expect(pending).toBe('pending');
+
+    notifyChar.triggerData(Buffer.from([0x03]));
+    const result = await promise;
+    expect(result.reading).toEqual({ weight: 83.2, impedance: 0 });
+  });
+
+  it('counts incomplete live readings toward opt-in weight stability', async () => {
+    const notifyChar = createMockChar();
+    const writeChar = createMockChar();
+    const device = createMockDevice();
+    const { charMap } = createCharMap([
+      [NOTIFY_UUID, notifyChar],
+      [WRITE_UUID, writeChar],
+    ]);
+
+    let final = false;
+    const adapter = createLegacyAdapter({
+      weightStability: { samples: 2, toleranceKg: 0 },
+      isComplete: vi.fn((r: ScaleReading) => final && r.weight > 0),
+      parseNotification: vi.fn(() => ({ weight: 83.2, impedance: 0 })),
+    });
+
+    const promise = waitForRawReading(charMap, device, adapter, PROFILE, '');
+    await vi.waitFor(() => expect(notifyChar.subscribeCalled).toBe(true));
+
+    notifyChar.triggerData(Buffer.from([0x01]));
+    final = true;
+    notifyChar.triggerData(Buffer.from([0x02]));
+
+    const result = await promise;
+    expect(result.reading).toEqual({ weight: 83.2, impedance: 0 });
+  });
+
   it('resolves with the last weight-only reading when the hold window elapses', async () => {
     vi.useFakeTimers();
     try {

--- a/tests/interfaces/scale-adapter-types.test.ts
+++ b/tests/interfaces/scale-adapter-types.test.ts
@@ -8,6 +8,7 @@ import type {
   MultiCharNotify,
   AckProtocol,
   HoldForComposition,
+  WeightStabilityGate,
   ScaleReading,
   BodyComposition,
   BleDeviceInfo,
@@ -105,5 +106,12 @@ describe('ScaleAdapter capability types', () => {
   it('BroadcastSource is an all-optional grouping', () => {
     const b: BroadcastSource = {};
     expect(b.parseBroadcast).toBeUndefined();
+  });
+
+  it('WeightStabilityGate is an all-optional grouping', () => {
+    const empty: WeightStabilityGate = {};
+    expect(empty.weightStability).toBeUndefined();
+    const gated: WeightStabilityGate = { weightStability: { samples: 2, toleranceKg: 0 } };
+    expect(gated.weightStability?.samples).toBe(2);
   });
 });

--- a/tests/scales/eufy-p2.test.ts
+++ b/tests/scales/eufy-p2.test.ts
@@ -228,6 +228,29 @@ describe('EufyP2Adapter', () => {
     assertPayloadRanges(payload);
   });
 
+  it('uses the protocol final flag for GATT completion candidates', () => {
+    const adapter = new EufyP2Adapter();
+
+    const inProgress = adapter.parseNotification(makeNotification(80.1, 520, false))!;
+    expect(inProgress.weight).toBe(80.1);
+    expect(adapter.isComplete(inProgress)).toBe(false);
+
+    const final = adapter.parseNotification(makeNotification(80.0, 520, true))!;
+    expect(adapter.isComplete(final)).toBe(true);
+  });
+
+  it('does not require impedance once a GATT frame is final', () => {
+    const adapter = new EufyP2Adapter();
+
+    const final = adapter.parseNotification(makeNotification(80, 0, true))!;
+    expect(adapter.isComplete(final)).toBe(true);
+  });
+
+  it('opts into shared consecutive-weight stability gating', () => {
+    const adapter = new EufyP2Adapter();
+    expect(adapter.weightStability).toEqual({ samples: 2, toleranceKg: 0 });
+  });
+
   it('rejects FFF2 weight frames when onConnected had no deviceAddress (no stale auth)', async () => {
     const adapter = new EufyP2Adapter();
 

--- a/tests/scales/one-byone.test.ts
+++ b/tests/scales/one-byone.test.ts
@@ -15,6 +15,16 @@ describe('OneByoneAdapter', () => {
     return new OneByoneAdapter();
   }
 
+  function makeCfFrame(weightKg: number, impedanceRaw = 500, impedanceStatus = 0): Buffer {
+    const buf = Buffer.alloc(10);
+    buf[0] = 0xcf;
+    buf[1] = impedanceRaw & 0xff;
+    buf[2] = (impedanceRaw >> 8) & 0xff;
+    buf.writeUInt16LE(Math.round(weightKg * 100), 3);
+    buf[9] = impedanceStatus;
+    return buf;
+  }
+
   describe('matches()', () => {
     it.each(['t9146', 't9147', 't9120', 'health scale'])('matches "%s"', (name) => {
       const adapter = makeAdapter();
@@ -113,13 +123,8 @@ describe('OneByoneAdapter', () => {
   describe('parseNotification()', () => {
     it('parses 0xCF frame with weight and impedance', () => {
       const adapter = makeAdapter();
-      const buf = Buffer.alloc(10);
-      buf[0] = 0xcf;
-      // impedance raw: (data[2]<<8) + data[1] = (0x01<<8) + 0xF4 = 500 → * 0.1 = 50.0
-      buf[1] = 0xf4;
-      buf[2] = 0x01;
-      buf.writeUInt16LE(8000, 3); // weight = 8000 / 100 = 80.0 kg
-      buf[9] = 0; // not invalid
+      // impedance raw: (data[2]<<8) + data[1] = 500 → * 0.1 = 50.0
+      const buf = makeCfFrame(80);
 
       const reading = adapter.parseNotification(buf);
       expect(reading).not.toBeNull();
@@ -129,12 +134,7 @@ describe('OneByoneAdapter', () => {
 
     it('impedance is 0 when byte[9] = 1', () => {
       const adapter = makeAdapter();
-      const buf = Buffer.alloc(10);
-      buf[0] = 0xcf;
-      buf[1] = 0xf4;
-      buf[2] = 0x01;
-      buf.writeUInt16LE(8000, 3);
-      buf[9] = 1; // impedance invalid
+      const buf = makeCfFrame(80, 500, 1); // impedance invalid
 
       const reading = adapter.parseNotification(buf);
       expect(reading).not.toBeNull();
@@ -143,12 +143,7 @@ describe('OneByoneAdapter', () => {
 
     it('impedance is 0 when raw value is 0', () => {
       const adapter = makeAdapter();
-      const buf = Buffer.alloc(10);
-      buf[0] = 0xcf;
-      buf[1] = 0x00;
-      buf[2] = 0x00;
-      buf.writeUInt16LE(8000, 3);
-      buf[9] = 0;
+      const buf = makeCfFrame(80, 0);
 
       const reading = adapter.parseNotification(buf);
       expect(reading).not.toBeNull();
@@ -172,6 +167,11 @@ describe('OneByoneAdapter', () => {
     it('returns true when weight > 0', () => {
       const adapter = makeAdapter();
       expect(adapter.isComplete({ weight: 80, impedance: 0 })).toBe(true);
+    });
+
+    it('opts into shared consecutive-weight stability gating', () => {
+      const adapter = makeAdapter();
+      expect(adapter.weightStability).toEqual({ samples: 2, toleranceKg: 0 });
     });
 
     it('returns false when weight is 0', () => {


### PR DESCRIPTION
Summary
Fixes premature measurement completion for Eufy/1byone scales by adding a generic opt-in weight stability gate. Some scales can emit realtime weight frames before the user has fully settled, so adapters can now require consecutive matching weight readings before the shared BLE pipeline marks a measurement complete.
Changes
Added a reusable weightStability adapter capability.
Added shared consecutive-weight tracking in the GATT reading pipeline.
Opted Eufy P2/P2 Pro and 1byone/Eufy adapters into two-sample exact weight stability.
Kept adapter-specific completion logic focused on protocol semantics, such as Eufy’s final-frame flag.
Renamed the composition-hold log from Weight stable; holding... to Reading complete; holding... to avoid confusing it with raw weight stability.
Added regression coverage for the shared stability gate and affected adapters.
Test Plan

Tests pass (npm test -- tests/ble/notification-processor.test.ts tests/ble/shared.test.ts tests/interfaces/scale-adapter-types.test.ts tests/scales/eufy-p2.test.ts tests/scales/one-byone.test.ts)

Lint clean (npx eslint ...)

TypeScript compiles (npm run build)

Tested manually (describe below)
Notes
This is opt-in, not global, so scales that only emit one final frame are not forced to wait for extra samples.