### PR TITLE
fix(scales): gate Eufy P2 and 1byone completion on a settled weight (#284)

### DIFF
--- a/src/scales/eufy-p2.ts
+++ b/src/scales/eufy-p2.ts
@@ -67,6 +67,18 @@ const AES_IV = Buffer.from('0000000000000000', 'ascii');
 const MIN_WEIGHT_KG = 2;
 const MAX_WEIGHT_KG = 200;
 
+/**
+ * Hold window (ms) for the weight-stability gate. The scale flags a frame as
+ * final (byte[12] == 0) while the weight can still be settling, so resolving on
+ * the first final frame occasionally exported a drifting value (#284). Instead
+ * we hold the link open after the first final frame and resolve as soon as two
+ * consecutive final frames report the same weight (isFinal). If the weight never
+ * settles to two equal frames within this window, shared.ts resolves the last
+ * held reading, so the gate can never lose a reading it would previously have
+ * returned.
+ */
+const WEIGHT_STABLE_HOLD_MS = 3000;
+
 /** Company ID used in Eufy P2/P2 Pro advertisement manufacturer data. */
 const EUFY_COMPANY_ID = 0xff48;
 
@@ -298,6 +310,11 @@ export class EufyP2Adapter
   private ctx: ConnectionContext | null = null;
   private readonly c3Seen = { done: false };
 
+  /** Raw weight (hundredths of kg) of the previous final GATT frame this session. */
+  private previousFinalRawWeight: number | null = null;
+  /** True once two consecutive final GATT frames reported the same weight. */
+  private weightStable = false;
+
   matches(device: BleDeviceInfo): boolean {
     const name = (device.localName || '').toLowerCase();
     if (name.startsWith('eufy t9148') || name.startsWith('eufy t9149')) return true;
@@ -320,6 +337,8 @@ export class EufyP2Adapter
     this.ctx = ctx;
     this.auth = null;
     this.c3Seen.done = false;
+    this.previousFinalRawWeight = null;
+    this.weightStable = false;
     if (!ctx.deviceAddress) {
       bleLog.warn('Eufy: no device address available — auth will fail without MAC');
       return;
@@ -344,14 +363,28 @@ export class EufyP2Adapter
         bleLog.debug('Eufy: FFF2 frame received before auth complete — ignoring');
         return null;
       }
-      return parseWeightNotification(data);
+      return this.trackStability(parseWeightNotification(data));
     }
     return null;
   }
 
   /** Fallback single-char path (not used when parseCharNotification is defined). */
   parseNotification(data: Buffer): ScaleReading | null {
-    return parseWeightNotification(data);
+    return this.trackStability(parseWeightNotification(data));
+  }
+
+  /**
+   * Record whether this final frame's weight matches the previous one, so
+   * isFinal() can report the reading as settled. parseWeightNotification only
+   * returns non-null for final frames, so consecutive calls compare final
+   * frames to each other.
+   */
+  private trackStability(reading: ScaleReading | null): ScaleReading | null {
+    if (!reading) return reading;
+    const rawWeight = Math.round(reading.weight * 100);
+    this.weightStable = this.previousFinalRawWeight === rawWeight;
+    this.previousFinalRawWeight = rawWeight;
+    return reading;
   }
 
   parseBroadcast(manufacturerData: Buffer): ScaleReading | null {
@@ -363,6 +396,19 @@ export class EufyP2Adapter
     // Authenticated GATT readings have non-zero impedance from the scale.
     if (reading.impedance === 0) return reading.weight > 0;
     return reading.weight > MIN_WEIGHT_KG && reading.impedance > 200;
+  }
+
+  /**
+   * Hold the link open after the first final frame so the weight can settle,
+   * rather than exporting the first (possibly still-drifting) final value.
+   * Only the GATT path (shared.ts) consults this; the broadcast path resolves
+   * on isComplete() alone, so passive reads are unaffected.
+   */
+  readonly completionHoldMs = WEIGHT_STABLE_HOLD_MS;
+
+  /** Resolve immediately once the weight has stabilized across two final frames. */
+  isFinal(_reading: ScaleReading): boolean {
+    return this.weightStable;
   }
 
   computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {

--- a/src/scales/one-byone.ts
+++ b/src/scales/one-byone.ts
@@ -11,6 +11,16 @@ import type {
 import { uuid16, buildPayload, xorChecksum, type ScaleBodyComp } from './body-comp-helpers.js';
 import { matchesDescriptor, type MatchDescriptor } from './match-descriptor.js';
 
+/**
+ * Hold window (ms) for the weight-stability gate (#284). 1byone frames stream
+ * continuously with no "measurement locked" flag, so resolving on the first
+ * weight>0 frame could export a value while the person was still settling.
+ * Instead we hold the link open and resolve once two consecutive frames report
+ * the same weight (isFinal). If that never happens within the window, shared.ts
+ * resolves the last held reading, so no reading is ever lost.
+ */
+const WEIGHT_STABLE_HOLD_MS = 3000;
+
 // ─── OneByoneAdapter (Eufy C1/P1, Health Scale) ─────────────────────────────
 
 /**
@@ -34,6 +44,11 @@ export class OneByoneAdapter implements ScaleAdapterCore, GattWiring {
   readonly charWriteUuid = uuid16(0xfff1);
   readonly normalizesWeight = true;
 
+  /** Raw weight (hundredths of kg) of the previous frame this session. */
+  private previousRawWeight: number | null = null;
+  /** True once two consecutive frames reported the same weight. */
+  private weightStable = false;
+
   matches(device: BleDeviceInfo): boolean {
     // Name match is unambiguous (T914x / Health Scale); keep it.
     const name = (device.localName || '').toLowerCase();
@@ -56,6 +71,9 @@ export class OneByoneAdapter implements ScaleAdapterCore, GattWiring {
    *   2. Clock sync: [0xF1, yearHi, yearLo, month, day, hour, min, sec]
    */
   async onConnected(ctx: ConnectionContext): Promise<void> {
+    this.previousRawWeight = null;
+    this.weightStable = false;
+
     // Step 1: Mode/unit command
     const unitCmd = [0xfd, 0x37, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
     unitCmd.push(xorChecksum(unitCmd, 0, unitCmd.length));
@@ -79,7 +97,8 @@ export class OneByoneAdapter implements ScaleAdapterCore, GattWiring {
   parseNotification(data: Buffer): ScaleReading | null {
     if (data.length < 5 || data[0] !== 0xcf) return null;
 
-    const weight = data.readUInt16LE(3) / 100;
+    const rawWeight = data.readUInt16LE(3);
+    const weight = rawWeight / 100;
 
     let impedance = 0;
     if (data.length >= 10) {
@@ -90,11 +109,25 @@ export class OneByoneAdapter implements ScaleAdapterCore, GattWiring {
       }
     }
 
+    this.weightStable = this.previousRawWeight === rawWeight;
+    this.previousRawWeight = rawWeight;
+
     return { weight, impedance };
   }
 
   isComplete(reading: ScaleReading): boolean {
     return reading.weight > 0;
+  }
+
+  /**
+   * Hold the link open after the first weight so it can settle, rather than
+   * exporting the first frame while the person is still stepping on.
+   */
+  readonly completionHoldMs = WEIGHT_STABLE_HOLD_MS;
+
+  /** Resolve immediately once the weight has stabilized across two frames. */
+  isFinal(_reading: ScaleReading): boolean {
+    return this.weightStable;
   }
 
   computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {

--- a/tests/scales/eufy-p2.test.ts
+++ b/tests/scales/eufy-p2.test.ts
@@ -252,6 +252,51 @@ describe('EufyP2Adapter', () => {
     await adapter.onConnected({ ...ctx, deviceAddress: '' });
     expect(adapter.parseCharNotification!('fff2', makeNotification(75, 500))).toBeNull();
   });
+
+  describe('weight-stability gate (#284)', () => {
+    it('holds until two consecutive final frames report the same weight', () => {
+      const adapter = new EufyP2Adapter();
+
+      const f1 = adapter.parseNotification(makeNotification(80.1, 520))!;
+      expect(adapter.isComplete(f1)).toBe(true); // permissive: arms the hold
+      expect(adapter.isFinal!(f1)).toBe(false); // not settled yet
+
+      const f2 = adapter.parseNotification(makeNotification(80.0, 520))!;
+      expect(adapter.isFinal!(f2)).toBe(false); // weight still changing
+
+      const f3 = adapter.parseNotification(makeNotification(80.0, 520))!;
+      expect(adapter.isFinal!(f3)).toBe(true); // stable
+    });
+
+    it('keeps isComplete permissive so a lone final frame is still a resolvable fallback', () => {
+      const adapter = new EufyP2Adapter();
+      // A single final frame that never repeats: isComplete true (so shared.ts
+      // holds it and can resolve it on disconnect), isFinal false (not settled).
+      const only = adapter.parseNotification(makeNotification(80, 520))!;
+      expect(adapter.isComplete(only)).toBe(true);
+      expect(adapter.isFinal!(only)).toBe(false);
+      expect(adapter.completionHoldMs).toBeGreaterThan(0);
+    });
+
+    it('re-arms stability per connection', async () => {
+      const adapter = new EufyP2Adapter();
+      const ctx = {
+        write: async () => {},
+        read: async () => Buffer.alloc(0),
+        subscribe: async () => {},
+        profile: defaultProfile(),
+        deviceAddress: '',
+      };
+
+      adapter.parseNotification(makeNotification(80, 500));
+      const stable = adapter.parseNotification(makeNotification(80, 500))!;
+      expect(adapter.isFinal!(stable)).toBe(true);
+
+      await adapter.onConnected(ctx); // resets stability even without a MAC
+      const afterReset = adapter.parseNotification(makeNotification(80, 500))!;
+      expect(adapter.isFinal!(afterReset)).toBe(false); // previous weight cleared
+    });
+  });
 });
 
 // ─── SegmentReassembler integrity (via handleC1 which uses it) ─────────────

--- a/tests/scales/one-byone.test.ts
+++ b/tests/scales/one-byone.test.ts
@@ -180,6 +180,48 @@ describe('OneByoneAdapter', () => {
     });
   });
 
+  describe('weight-stability gate (#284)', () => {
+    function cfFrame(weightKg: number): Buffer {
+      const buf = Buffer.alloc(10);
+      buf[0] = 0xcf;
+      buf.writeUInt16LE(Math.round(weightKg * 100), 3);
+      buf[9] = 1; // impedance invalid — isolate the weight-stability behaviour
+      return buf;
+    }
+
+    it('resolves only once two consecutive frames report the same weight', () => {
+      const adapter = makeAdapter();
+
+      const f1 = adapter.parseNotification(cfFrame(80.2))!;
+      expect(adapter.isComplete(f1)).toBe(true); // permissive: arms the hold
+      expect(adapter.isFinal!(f1)).toBe(false);
+
+      const f2 = adapter.parseNotification(cfFrame(80.0))!;
+      expect(adapter.isFinal!(f2)).toBe(false); // changed
+
+      const f3 = adapter.parseNotification(cfFrame(80.0))!;
+      expect(adapter.isFinal!(f3)).toBe(true); // stable
+      expect(adapter.completionHoldMs).toBeGreaterThan(0);
+    });
+
+    it('re-arms stability on reconnect', async () => {
+      const adapter = makeAdapter();
+      const ctx = {
+        write: async () => {},
+        read: async () => Buffer.alloc(0),
+        subscribe: async () => {},
+        profile: defaultProfile(),
+        deviceAddress: 'AA:BB:CC:DD:EE:FF',
+      };
+
+      adapter.parseNotification(cfFrame(80));
+      expect(adapter.isFinal!(adapter.parseNotification(cfFrame(80))!)).toBe(true);
+
+      await adapter.onConnected(ctx);
+      expect(adapter.isFinal!(adapter.parseNotification(cfFrame(80))!)).toBe(false);
+    });
+  });
+
   describe('computeMetrics()', () => {
     it('returns valid BodyComposition', () => {
       const adapter = makeAdapter();


### PR DESCRIPTION
## Summary

Fixes Eufy P2 and 1byone readings completing on a weight that is still settling, the problem #284 set out to solve, but without the never-completes regression that PR's approach carried.

## The bug

Both adapters resolved on the first frame the scale marked final (Eufy, `byte[12] == 0`) or the first `weight > 0` frame (1byone). On these units that first "final" frame can still carry a drifting weight, so an unsettled value was occasionally exported.

## The fix

Instead of a hard completion gate, this uses the existing completion-hold path (`completionHoldMs` + `isFinal`, the same mechanism Koogeek/Beurer already use):

- `isComplete` stays permissive, so `shared.ts` arms its hold window and always keeps a fallback reading.
- `isFinal(reading)` reports the reading settled only after two consecutive frames agree on the raw weight.

Flow: the first plausible reading arms the hold; the read resolves the instant the weight repeats (settled); and if it never settles, `shared.ts` resolves the last held reading on hold-timeout or on disconnect (`waitForRawReading`, `hold.heldReading`). So the gate can never lose a reading the old code would have returned. Worst case is a bounded few-seconds hold, never a hang or a hard reject.

Broadcast reads are unaffected: `completionHoldMs` / `isFinal` are consulted only on the GATT path in `shared.ts`, not on the advertisement/broadcast paths. Stability state resets per connection.

## Why not #284 as written

#284 tightened completion to "two consecutive equal frames" as the only resolve path, with no `completionHoldMs` fallback, so a scale that emits its settled weight once (or keeps micro-adjusting) then disconnects would never complete and the read would hard-reject. It also dropped the Eufy `impedance > 200` floor. This reworks the same idea through the hold mechanism so a reading is always resolved. Credit to @sanglt for the report and the stability approach.

## Tests

- Eufy P2: holds until two final frames agree; a lone final frame stays a resolvable fallback (`isComplete` true, `isFinal` false); stability re-arms per connection.
- 1byone: resolves only after two equal frames; re-arms on reconnect.
- Full suite: 1942 pass; tsc / eslint / prettier clean.

## Validation still wanted

Nobody here owns every unit, so before the release (not the merge) a live confirmation from a P2 or T914x owner that a normal weigh-in still completes promptly would be good.

Closes nothing on its own; supersedes the change in #284.
