### PR TITLE
fix(ble): decode esphome GATT payloads from toObject base64 `data` field

### DIFF
--- a/src/ble/handler-esphome-proxy/esphome-gatt-proto.ts
+++ b/src/ble/handler-esphome-proxy/esphome-gatt-proto.ts
@@ -79,10 +79,7 @@ export interface EsphomeNotifyData {
  * `data` — never `dataList` (#291). Accept every shape the library could
  * produce: base64 string, Uint8Array/Buffer, or a legacy `dataList` array.
  */
-export function esphomeGattPayload(m: {
-  data?: string | Uint8Array;
-  dataList?: number[];
-}): Buffer {
+export function esphomeGattPayload(m: { data?: string | Uint8Array; dataList?: number[] }): Buffer {
   if (typeof m.data === 'string') return Buffer.from(m.data, 'base64');
   if (m.data instanceof Uint8Array) return Buffer.from(m.data);
   if (Array.isArray(m.dataList)) return Buffer.from(m.dataList);

--- a/src/ble/handler-esphome-proxy/esphome-gatt-proto.ts
+++ b/src/ble/handler-esphome-proxy/esphome-gatt-proto.ts
@@ -64,7 +64,29 @@ export interface EsphomeGattServicesResponse {
 export interface EsphomeNotifyData {
   address: number;
   handle: number;
-  dataList: number[];
+  /** protobuf-JS `toObject()` renders the `bytes data = 3` field as a base64
+   * string named `data`; some historical library shapes used a `dataList`
+   * number array instead. Both are optional so either shape type-checks. */
+  data?: string | Uint8Array;
+  dataList?: number[];
+}
+
+/**
+ * Decode the payload of an ESPHome GATT read/notify response.
+ *
+ * @2colors/esphome-native-api emits `message.toObject()` for GATT responses
+ * unmapped, and protobuf-JS renders a `bytes` field as a base64 string named
+ * `data` — never `dataList` (#291). Accept every shape the library could
+ * produce: base64 string, Uint8Array/Buffer, or a legacy `dataList` array.
+ */
+export function esphomeGattPayload(m: {
+  data?: string | Uint8Array;
+  dataList?: number[];
+}): Buffer {
+  if (typeof m.data === 'string') return Buffer.from(m.data, 'base64');
+  if (m.data instanceof Uint8Array) return Buffer.from(m.data);
+  if (Array.isArray(m.dataList)) return Buffer.from(m.dataList);
+  return Buffer.alloc(0);
 }
 
 export interface EsphomeDeviceConnection {

--- a/src/ble/handler-esphome-proxy/gatt.ts
+++ b/src/ble/handler-esphome-proxy/gatt.ts
@@ -3,6 +3,7 @@ import { bleLog, errMsg, normalizeUuid } from '../types.js';
 import type { EsphomeClient, EsphomeConnection } from './client.js';
 import { macToInt } from './advert.js';
 import {
+  esphomeGattPayload,
   esphomeUuidToString,
   type EsphomeGattServicesResponse,
   type EsphomeNotifyData,
@@ -91,9 +92,10 @@ export async function openGattSession(
       const char: BleChar = {
         async read(): Promise<Buffer> {
           const r = (await conn.readBluetoothGATTCharacteristicService(addr, handle)) as {
-            dataList: number[];
+            data?: string | Uint8Array;
+            dataList?: number[];
           };
-          return Buffer.from(r.dataList ?? []);
+          return esphomeGattPayload(r);
         },
         async write(data: Buffer, withResponse: boolean): Promise<void> {
           if (closed) return;
@@ -114,7 +116,7 @@ export async function openGattSession(
             const m = raw as EsphomeNotifyData;
             if (m.address !== addr) return;
             if (m.handle === handle) {
-              const buf = Buffer.from(m.dataList ?? []);
+              const buf = esphomeGattPayload(m);
               bleLog.debug(
                 `ESPHome notify handle 0x${handle.toString(16)} (${buf.length}B): ${buf.toString('hex')}`,
               );


### PR DESCRIPTION
Fixes #291.

## What

`@2colors/esphome-native-api` emits GATT read/notify responses as raw `message.toObject()` output — `mapMessageByType` has no case for `BluetoothGATTNotifyDataResponse` / `BluetoothGATTReadResponse`, so they hit `default` — and protobuf-JS renders a `bytes` field as a **base64 string named `data`**, never `dataList`:

```js
new pb.BluetoothGATTNotifyDataResponse(...).toObject()
// { "address": 1, "handle": 24, "data": "rAID" }  ← 0xac 0x02 0x03, no dataList
```

So `Buffer.from(m.dataList ?? [])` in `gatt.ts` produced an empty buffer for **every** notification: adapters received 0-byte frames and decoded nothing over the esphome-proxy transport. The `read()` path had the same bug.

## Fix

New `esphomeGattPayload()` helper in `esphome-gatt-proto.ts` decoding every shape the library could hand us — base64 string, `Uint8Array`, or legacy `dataList` array — used in both the notify listener and the characteristic `read()` path.

## Verified live (Hutbit/SWAN over dedicated ESPHome proxy, the #291 setup)

Before (dev @ 25699e8): continuous `ESPHome notify handle 0x18 (0B):` / `Hutbit RAW (0B):` through two full weigh-ins — payload lost, mismatch line never fired.

After (this branch):

```
[BLE:debug] Hutbit RAW (8B): ac0203470000ca14
[BLE] Reading complete: 83.90 kg / 0 Ohm
```

Full ramp decoded (0x0095 → 0x01dc → 0x02e9 → 0x0344 → 0x0348 → stable 0xCA frame at 0x0347 = 83.9 kg), two consecutive weigh-ins, dedup correct.

`tsc --noEmit` clean; test suite 1947/1948 (the one failure is the `tests/config/watch.test.ts` sibling-file fs.watch flake on macOS, unrelated).