### PR TITLE
Release: esphome CCCD + payload decode, node-ble device-object recovery, ESP32 session guard, Beurer profile commit, generated add-on changelog

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,3 +29,41 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # release-please owns CHANGELOG.md but cannot write a second changelog, so
+      # the Home Assistant add-on copy is regenerated on the release PR branch
+      # here. Without this the maintainer has to remember a manual step, which
+      # is exactly how the add-on changelog fell 16 releases behind (#294), and
+      # the guard in tests/addon-changelog-sync.test.ts would fail the release PR.
+      # The generator imports only node: builtins, so it runs straight off
+      # source with no install step.
+      # Node 24: the generator is TypeScript run directly, which needs the
+      # native type stripping that only recent Node has enabled by default.
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Sync the add-on changelog on the release PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" repo-sync
+          cd repo-sync
+          BRANCH=$(git ls-remote --heads origin 'release-please--*' | awk '{print $2}' | sed 's#refs/heads/##' | head -1)
+          if [ -z "$BRANCH" ]; then
+            echo "No release-please branch, nothing to sync."
+            exit 0
+          fi
+          git fetch --depth 1 origin "$BRANCH"
+          git switch --track "origin/$BRANCH"
+          node src/tools/sync-addon-changelog.ts
+          if git diff --quiet -- ble-scale-sync-addon/CHANGELOG.md; then
+            echo "Add-on changelog already in sync."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add ble-scale-sync-addon/CHANGELOG.md
+          git commit -m 'chore(addon): sync the add-on changelog from the project changelog'
+          git push origin "HEAD:$BRANCH"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -317,9 +317,9 @@ Releases are fully automated via [release-please](https://github.com/googleapis/
 
 Do not edit these files in a feature PR. If you need to correct the version or changelog, do it in the release PR before merging.
 
-### Files still maintained by hand
+### Generated companion files
 
-- `ble-scale-sync-addon/CHANGELOG.md` is the user-facing changelog shown inside the Home Assistant add-on UI. It benefits from a shorter, curated log, so release-please does not touch it. Update it in the release PR when user-facing add-on changes ship.
+- `ble-scale-sync-addon/CHANGELOG.md` is the changelog Home Assistant renders on the add-on page. It is generated from the root `CHANGELOG.md` by `src/tools/sync-addon-changelog.ts`; never edit it directly. After the root changelog changes (that is, in the release PR), run `npm run sync:addon-changelog` and commit the result. `tests/addon-changelog-sync.test.ts` fails the build while the copy is stale, which is how it fell 16 releases behind while it was maintained by hand (#294).
 - `docs/changelog.md` is a one-line VitePress include (`<!--@include: ../CHANGELOG.md-->`), so it updates automatically as soon as `CHANGELOG.md` does. Do not replace that include with hand-written content.
 
 ### Optional: `RELEASE_PLEASE_TOKEN` secret

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -305,6 +305,13 @@ Releases are fully automated via [release-please](https://github.com/googleapis/
 2. When `dev` is ready to ship, open a PR `dev` → `main` and merge it.
 3. The `release-please` workflow (`.github/workflows/release-please.yml`) runs on every push to `main` and opens (or updates) a release PR titled `chore(main): release vX.Y.Z`.
 4. That PR shows the proposed version bump plus the generated `CHANGELOG.md` diff. Review, optionally edit the PR body or the CHANGELOG entry in the PR to add prose (for example a `### Thanks` section, the one thing release-please does not generate by itself), then merge it with `--admin` like any other release PR.
+   - The same workflow run also pushes a `chore(addon): sync the add-on changelog` commit to the release branch, because release-please cannot generate a second changelog. If you edit the CHANGELOG entry in the PR afterwards, or the sync step was skipped, regenerate it yourself before merging, otherwise `tests/addon-changelog-sync.test.ts` fails the release PR:
+     ```bash
+     git switch release-please--branches--main--components--ble-scale-sync
+     npm run sync:addon-changelog
+     git commit -am "chore(addon): sync the add-on changelog from the project changelog"
+     git push
+     ```
 5. On merge, release-please tags the release (`vX.Y.Z`), creates a GitHub Release, and emits the `release: published` event that `docker.yml` listens for. The multi-arch image is published to GHCR automatically. VitePress rebuilds `docs/changelog.md` from `CHANGELOG.md` via an `@include` directive, so the public changelog updates too.
 
 ### Files managed by release-please

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Requires Node.js v22+ and a BLE adapter. See the **[full install guide](https://
 <td align="center"><a href="https://github.com/fromport"><img src="https://avatars.githubusercontent.com/u/5751308?v=4" width="60" height="60" alt="fromport"><br><sub>fromport</sub></a></td>
 <td align="center"><a href="https://github.com/boildead"><img src="https://avatars.githubusercontent.com/u/17303016?v=4" width="60" height="60" alt="boildead"><br><sub>boildead</sub></a></td>
 <td align="center"><a href="https://github.com/alexw23"><img src="https://avatars.githubusercontent.com/u/1505496?v=4" width="60" height="60" alt="alexw23"><br><sub>alexw23</sub></a></td>
+<td align="center"><a href="https://github.com/bondesen"><img src="https://avatars.githubusercontent.com/u/4944294?v=4" width="60" height="60" alt="bondesen"><br><sub>bondesen</sub></a></td>
+<td align="center"><a href="https://github.com/junaidk"><img src="https://avatars.githubusercontent.com/u/1422281?v=4" width="60" height="60" alt="junaidk"><br><sub>junaidk</sub></a></td>
 </tr></table>
 
 ## Contributing

--- a/ble-scale-sync-addon/CHANGELOG.md
+++ b/ble-scale-sync-addon/CHANGELOG.md
@@ -1,42 +1,734 @@
 # Changelog
 
-## 1.10.2
+<!-- GENERATED FILE. Do not edit by hand. Produced from the root CHANGELOG.md by
+     src/tools/sync-addon-changelog.ts. Run `npm run sync:addon-changelog` after
+     the root changelog changes. -->
 
-- Fix Renpho ES-26M weight readings being rejected by the QN-Scale handshake (the 18-byte scale-info frame was misread, leaving the scale at `proto=0xFF`). Stable readings without impedance (e.g. when wearing socks) are no longer skipped on the ES-26M variant.
-- ESPHome proxy: on connect, the add-on now logs which configured scale brands are broadcast-capable and which need a GATT connection (Phase 2). Makes it obvious from the logs whether your scale is supported by the ESPHome proxy transport instead of having to reproduce the failure twice.
+The add-on version always matches the application version, so every entry below
+applies to this add-on.
 
-## 1.10.1
+## [1.21.1](https://github.com/KristianP26/ble-scale-sync/compare/v1.21.0...v1.21.1) (2026-07-22)
 
-- Fix `debug: true` in custom `config.yaml` not switching the log level. The add-on UI's **Debug logging** option already worked, but custom-config users had to set the `DEBUG` env var to get verbose BLE logs. Now both paths produce the same logs.
-- ESPHome proxy: GATT-only scales (e.g. Renpho Elis 1) now log a one-time warning instead of silently dropping every advertisement.
 
-## 1.10.0
+### Fixed
 
-- Add **embedded MQTT broker for the ESP32 BLE proxy**: zero-config, no Mosquitto add-on required. When using the ESP32 proxy through custom config, leave `broker_url` empty and the add-on starts its own broker on port 1883.
-- Add **ESPHome Bluetooth proxy** as a third BLE transport option (experimental, broadcast-only in phase 1). If you already run an ESPHome BT proxy mesh for Home Assistant, you can reuse it as the BLE radio without flashing a dedicated ESP32 or running an MQTT broker. Configurable via custom config (`ble.handler: esphome-proxy`).
-- Setup wizard (custom-config users): adds an **embedded broker** option for the mqtt-proxy handler and an **ESPHome Bluetooth proxy** option in the BLE handler picker.
+* **ble:** bond and retry GATT discovery for consent scales on timeout ([a3a828e](https://github.com/KristianP26/ble-scale-sync/commit/a3a828e869baf9a5dc886871b31355a6a6e5ef69))
+* **scales:** treat Eufy P2/P2 Pro GATT reading as weight-only ([76ca675](https://github.com/KristianP26/ble-scale-sync/commit/76ca67532ede4abce150d7f312988c531aa587a4))
 
-## 1.9.0
 
-- Add **Eufy Smart Scale P2 (T9148)** and **P2 Pro (T9149)** support. Previous versions misidentified these as QN-Scales and failed with "Operation is not supported" on FFF1. The new adapter does the AES-128 handshake required by these models and reads weight + impedance over GATT FFF2.
-- Fix add-on with no exporters configured exiting with code 1 immediately after a successful weigh-in. The runtime now warns once that no exporters are configured and continues.
+### Docs
 
-## 1.8.2
+* correct adapter and exporter counts, add Robi S9 row ([87b6bbd](https://github.com/KristianP26/ble-scale-sync/commit/87b6bbd1d1d1478523ca2bf7260406b7b1a72e59))
 
-- Fix **Sanitas SBF70 / Beurer BF710** family showing a stuck `12.80 kg` reading regardless of the real weight. The BF710 variant uses a compact 5-byte frame at a different byte offset than its BF700 / BF800 siblings; the adapter now branches on the variant and applies a 3-reading stability window so the scale's metadata frame no longer triggers early completion.
+## [1.21.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.20.0...v1.21.0) (2026-07-20)
 
-## 1.8.1
 
-- Fix Garmin upload failing with `'Garmin' object has no attribute 'garth'` after `garminconnect` 0.3.0 dropped the garth dependency. Migrated to the new native auth API and single `garmin_tokens.json` token format.
-- Legacy `oauth1_token.json` / `oauth2_token.json` files are automatically removed on first start; the add-on re-authenticates from the credentials you entered in the UI. MFA users regenerate the token file per the MFA workaround in DOCS.md.
-- Docker: added `libcurl4-openssl-dev` so `curl_cffi` (new transitive dep) builds from source on armv7.
+### Added
 
-## 1.7.0
+* **ble:** add weight-only Renpho R-MSC04 scale adapter ([#117](https://github.com/KristianP26/ble-scale-sync/issues/117), [#265](https://github.com/KristianP26/ble-scale-sync/issues/265)) ([f0dc658](https://github.com/KristianP26/ble-scale-sync/commit/f0dc658b2ced52550a98151caba94908b3e8ff07))
 
-- Initial Home Assistant Add-on release
-- MQTT auto-detection from Mosquitto add-on
-- HA auto-discovery for 10 body composition sensors
-- Garmin Connect export support
-- BLE adapter selection for multi-adapter setups
-- Custom config.yaml support for advanced users
-- 23 supported BLE scale brands
+
+### Fixed
+
+* **body-comp:** report muscle mass as fat-free mass minus bone ([#253](https://github.com/KristianP26/ble-scale-sync/issues/253)) ([7efa781](https://github.com/KristianP26/ble-scale-sync/commit/7efa7816fab080a0b629266dd1207d27842ee4bd))
+* **runtime:** tick the healthcheck heartbeat on a timer so idle is not unhealthy ([#277](https://github.com/KristianP26/ble-scale-sync/issues/277)) ([2fca68f](https://github.com/KristianP26/ble-scale-sync/commit/2fca68feb0fe921adc6bbfa0681b092798009469))
+* **scales:** claim OEM/rebranded Hutbit ("SWAN") via the 0x02AC manufacturer signature ([#279](https://github.com/KristianP26/ble-scale-sync/issues/279)) ([eb3b669](https://github.com/KristianP26/ble-scale-sync/commit/eb3b669759edb2ef110a306040fb238847131497))
+* **scales:** gate Eufy P2 and 1byone completion on a settled weight ([#284](https://github.com/KristianP26/ble-scale-sync/issues/284)) ([#285](https://github.com/KristianP26/ble-scale-sync/issues/285)) ([7edfe6c](https://github.com/KristianP26/ble-scale-sync/commit/7edfe6c5ef463ff4d45678cabcb335fe81d514f9))
+* **scales:** narrow the Hutbit OEM claim and pass mfg data on noble target-MAC ([#278](https://github.com/KristianP26/ble-scale-sync/issues/278)) ([9d17405](https://github.com/KristianP26/ble-scale-sync/commit/9d174056bc8c52c4fb92fa7527bcd1fe3b2898a1))
+* **scales:** route Beurer BF788 and BF950 to the SIG consent adapter ([#229](https://github.com/KristianP26/ble-scale-sync/issues/229), [#255](https://github.com/KristianP26/ble-scale-sync/issues/255)) ([5cd3f92](https://github.com/KristianP26/ble-scale-sync/commit/5cd3f929e496d25fb7e0e14b28faa14f79e8a974))
+* **scales:** stop the Beurer adapter hijacking its siblings, and honour lb frames ([c5362a2](https://github.com/KristianP26/ble-scale-sync/commit/c5362a2baefcafe8d5a659e947e3d0064e220c40))
+
+
+### Docs
+
+* document the shipped Renpho R-MSC04 adapter and its weight-only limitation ([#117](https://github.com/KristianP26/ble-scale-sync/issues/117)) ([8ece358](https://github.com/KristianP26/ble-scale-sync/commit/8ece358543352d1debfe06318ccd991bfe191f48))
+
+## [1.20.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.19.0...v1.20.0) (2026-07-13)
+
+
+### Added
+
+* **scales:** add Hutbit Smart Scale adapter ([#268](https://github.com/KristianP26/ble-scale-sync/issues/268)) ([f20f7a8](https://github.com/KristianP26/ble-scale-sync/commit/f20f7a87a6edcdde99edab671b679b840e78eba8))
+* **scales:** add Koogeek-S1 adapter ([#270](https://github.com/KristianP26/ble-scale-sync/issues/270)) ([50ae1d6](https://github.com/KristianP26/ble-scale-sync/commit/50ae1d6b5e0250a05c59dd88471ce0c5254da2d5))
+
+
+### Fixed
+
+* **addon:** run the Home Assistant add-on unconfined so it can reach BlueZ ([cac714b](https://github.com/KristianP26/ble-scale-sync/commit/cac714b6ea651b35b2d5f9e3b3af3922dd822cde)), closes [#271](https://github.com/KristianP26/ble-scale-sync/issues/271)
+* **ble:** keep the ESPHome proxy connection alive on unknown API messages ([#252](https://github.com/KristianP26/ble-scale-sync/issues/252)) ([e561b91](https://github.com/KristianP26/ble-scale-sync/commit/e561b91aecaebc656c6552130eb9a45a2afc8260))
+* **ble:** re-resolve adapter after GATT discovery on proxy paths ([#258](https://github.com/KristianP26/ble-scale-sync/issues/258), [#251](https://github.com/KristianP26/ble-scale-sync/issues/251), [#255](https://github.com/KristianP26/ble-scale-sync/issues/255)) ([9aca212](https://github.com/KristianP26/ble-scale-sync/commit/9aca21290f5df83ff5327c69affc881d5cd28e01))
+* **ble:** wrap dynamic-path device.gatt() in withTimeout ([#273](https://github.com/KristianP26/ble-scale-sync/issues/273)) ([0531e35](https://github.com/KristianP26/ble-scale-sync/commit/0531e35a9011f72d05253c99111cbbd50719d479))
+* **firmware:** enable BLE CCCD notifications in start_notify ([#274](https://github.com/KristianP26/ble-scale-sync/issues/274)) ([368353e](https://github.com/KristianP26/ble-scale-sync/commit/368353e846491e9527b041f891f7875de86b56be))
+* **renpho:** only require the UCP char, guard the vendor 0xFFE2 writes ([#267](https://github.com/KristianP26/ble-scale-sync/issues/267)) ([f4d7d5c](https://github.com/KristianP26/ble-scale-sync/commit/f4d7d5cb055163df009c81cdc39feb7ef20644f1))
+* **renpho:** perform SIG consent handshake so the ES-WBE28 streams readings ([#267](https://github.com/KristianP26/ble-scale-sync/issues/267)) ([65ed721](https://github.com/KristianP26/ble-scale-sync/commit/65ed7213f1108a867710a81072c794f743afb867))
+* **scales:** complete Yunmai weight-only reading instead of timing out ([a86ffe8](https://github.com/KristianP26/ble-scale-sync/commit/a86ffe873dd4854121e7de7c61a3ddf26b35c4e5))
+* **scales:** honour configured weight_unit in the QN display command ([#269](https://github.com/KristianP26/ble-scale-sync/issues/269)) ([d188970](https://github.com/KristianP26/ble-scale-sync/commit/d1889704be25b0505f0ef9bd335af736080a5cbf))
+* **scales:** identify Type-1 QN scales by char pair over the ESP32 proxy ([#272](https://github.com/KristianP26/ble-scale-sync/issues/272)) ([76737ed](https://github.com/KristianP26/ble-scale-sync/commit/76737edbdb4c63d7afeed81c629dd40125a1949b))
+* **scales:** route Beurer BF500 to the SIG consent adapter ([#83](https://github.com/KristianP26/ble-scale-sync/issues/83)) ([25bbc20](https://github.com/KristianP26/ble-scale-sync/commit/25bbc200271d1b505245e3cb214468ca5d0fb43c))
+* **scales:** write the Hutbit FFB1 handshake without response ([#268](https://github.com/KristianP26/ble-scale-sync/issues/268)) ([de12300](https://github.com/KristianP26/ble-scale-sync/commit/de123007abdc97ebd667fec26916344e471652ae))
+
+## [1.19.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.18.0...v1.19.0) (2026-06-19)
+
+
+### Added
+
+* **config:** add ble.bind_key and adapter configure() hook ([#232](https://github.com/KristianP26/ble-scale-sync/issues/232)) ([b319e69](https://github.com/KristianP26/ble-scale-sync/commit/b319e69f7ea085472bfcb5ba6218b21b37aaede1))
+* **scales:** add declarative MatchDescriptor and matchesDescriptor helper ([#245](https://github.com/KristianP26/ble-scale-sync/issues/245)) ([7e63799](https://github.com/KristianP26/ble-scale-sync/commit/7e637998ba8c68002fad9f9bb331f9340263305e))
+* **scales:** add Xiaomi Mijia S800 broadcast adapter ([#232](https://github.com/KristianP26/ble-scale-sync/issues/232)) ([5ee2c2e](https://github.com/KristianP26/ble-scale-sync/commit/5ee2c2eb4edf600eba414e91585743b103db641c))
+* **scales:** central resolveAdapter with priority-based precedence and startup overlap detection ([#245](https://github.com/KristianP26/ble-scale-sync/issues/245)) ([dcc2bdd](https://github.com/KristianP26/ble-scale-sync/commit/dcc2bddafa31f5320729538b1d59a1ac08fad2ba))
+* **scales:** register Xiaomi S800 and inject bind key at startup ([#232](https://github.com/KristianP26/ble-scale-sync/issues/232)) ([d3fdb65](https://github.com/KristianP26/ble-scale-sync/commit/d3fdb655fdf9d89f96f3e2770d15b0aa9c7db685))
+
+
+### Fixed
+
+* **ble:** advertise lazy_notify capability to ESP32 proxy ([#231](https://github.com/KristianP26/ble-scale-sync/issues/231)) ([9004d31](https://github.com/KristianP26/ble-scale-sync/commit/9004d316b60b70c3cc7e76f673a4dbada609fa96))
+* **ble:** command host-ordered proxy notify enable after subscribe ([#231](https://github.com/KristianP26/ble-scale-sync/issues/231)) ([d33e3aa](https://github.com/KristianP26/ble-scale-sync/commit/d33e3aa60214dad1326c706bdb9cbde97c09fa61))
+* **ble:** correct Robi S9 weight scaling to 3-byte grams ([#248](https://github.com/KristianP26/ble-scale-sync/issues/248)) ([21b3afa](https://github.com/KristianP26/ble-scale-sync/commit/21b3afa5a707815ddceb3f8a750f65f2eea69ee9))
+* **firmware:** add per-board IDF-heap guard tunables defaulting to 0 ([#139](https://github.com/KristianP26/ble-scale-sync/issues/139)) ([59bd65f](https://github.com/KristianP26/ble-scale-sync/commit/59bd65f8a7b83851c1acecd75c8d91054409b992))
+* **firmware:** drain aioble services before characteristic discovery ([#231](https://github.com/KristianP26/ble-scale-sync/issues/231)) ([c584098](https://github.com/KristianP26/ble-scale-sync/commit/c58409824672a9ab163d523a9bcbe3d7e9a36498))
+* **firmware:** drive aioble GATT discovery with async for ([#231](https://github.com/KristianP26/ble-scale-sync/issues/231)) ([c943e11](https://github.com/KristianP26/ble-scale-sync/commit/c943e11b87213300619872656b5af91ea3579970))
+* **firmware:** enable proxy notify lazily on per-char subscribe command ([#231](https://github.com/KristianP26/ble-scale-sync/issues/231)) ([f4a4492](https://github.com/KristianP26/ble-scale-sync/commit/f4a4492606bd798d3813d698806d5c46f8cb073f))
+* **firmware:** parse lazy_notify capability flag from config ([#231](https://github.com/KristianP26/ble-scale-sync/issues/231)) ([b24292a](https://github.com/KristianP26/ble-scale-sync/commit/b24292a447bd851f92c7db9508047b3050a05841))
+* **firmware:** refuse GATT connect on near-empty IDF heap instead of crashing ([#139](https://github.com/KristianP26/ble-scale-sync/issues/139)) ([1beac82](https://github.com/KristianP26/ble-scale-sync/commit/1beac82c6fdf57279855a7f06972f83a05502ac2))
+* **firmware:** retry opposite BLE address type on any connect failure ([#231](https://github.com/KristianP26/ble-scale-sync/issues/231)) ([7a958ab](https://github.com/KristianP26/ble-scale-sync/commit/7a958ab0f4ca83364014617281bed1f21a259d64))
+* **firmware:** trust controller-reported BLE address type on autonomous connect ([#231](https://github.com/KristianP26/ble-scale-sync/issues/231)) ([4ae2662](https://github.com/KristianP26/ble-scale-sync/commit/4ae2662fd96e8b29d13226c1909a97222254f758))
+* **scales:** preserve exact/startsWith claim semantics in generic-adapter exclusion ([#245](https://github.com/KristianP26/ble-scale-sync/issues/245)) ([99a5a10](https://github.com/KristianP26/ble-scale-sync/commit/99a5a1085f13c91bba3661a8a88e2c0fe459103b))
+
+
+### Docs
+
+* align scale-type vs board support table cells for [#139](https://github.com/KristianP26/ble-scale-sync/issues/139) ([e301da7](https://github.com/KristianP26/ble-scale-sync/commit/e301da7839398fd8868e48bb23704aae0df96831))
+* document no-PSRAM broadcast-only vs PSRAM GATT support for [#139](https://github.com/KristianP26/ble-scale-sync/issues/139) ([fa63930](https://github.com/KristianP26/ble-scale-sync/commit/fa6393045e168020b7dc19932f96a7cc8da311bb))
+* document Xiaomi S800 support and ble.bind_key ([#232](https://github.com/KristianP26/ble-scale-sync/issues/232)) ([6ccccb0](https://github.com/KristianP26/ble-scale-sync/commit/6ccccb09e937db62ac09f58aebea9b38c98f3ae9))
+* **firmware:** correct gc-vs-IDF-heap comment around the connect guard ([#139](https://github.com/KristianP26/ble-scale-sync/issues/139)) ([e576e8e](https://github.com/KristianP26/ble-scale-sync/commit/e576e8e4d36baac608c1dd9419e099dfa4c79242))
+* fix stale counts, logo easter egg, and consolidate changelog menu ([cf85243](https://github.com/KristianP26/ble-scale-sync/commit/cf852434b591a49370f8d711008dcd7920946735))
+* unify historical changelog entries to release-please format ([6d29c7e](https://github.com/KristianP26/ble-scale-sync/commit/6d29c7e839827685cefd6072c1a172523a64d4a5))
+
+## [1.18.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.17.0...v1.18.0) (2026-06-16)
+
+
+### Added
+
+* **exporter:** add Runalyze exporter ([#204](https://github.com/KristianP26/ble-scale-sync/issues/204)) ([8f8d7a0](https://github.com/KristianP26/ble-scale-sync/commit/8f8d7a0222bfb883fedf9c989764aed585769712))
+* **exporter:** add Wger exporter ([#205](https://github.com/KristianP26/ble-scale-sync/issues/205)) ([a9aed3a](https://github.com/KristianP26/ble-scale-sync/commit/a9aed3a7d57db9a8a93ebf6c6bc1bc8d710085d3))
+
+
+### Fixed
+
+* **ble:** bootstrap ESP32 autonomous GATT connect for GATT-only scales ([#231](https://github.com/KristianP26/ble-scale-sync/issues/231)) ([2266086](https://github.com/KristianP26/ble-scale-sync/commit/226608682f973e444b3741cae4af92a9c98d5427))
+* **ble:** connect before publishing scan results on autonomous path ([#231](https://github.com/KristianP26/ble-scale-sync/issues/231)) ([793fdb2](https://github.com/KristianP26/ble-scale-sync/commit/793fdb2025d8da47500b2eaa5a102c34811c0d2e))
+* **ble:** connect random-address GATT scales via ESP32 proxy ([#231](https://github.com/KristianP26/ble-scale-sync/issues/231)) ([989ace6](https://github.com/KristianP26/ble-scale-sync/commit/989ace6a529d8252a149016349bad231fe07f940))
+* **ble:** correct misreported static-random addr_type at scan source ([#231](https://github.com/KristianP26/ble-scale-sync/issues/231)) ([0a2097e](https://github.com/KristianP26/ble-scale-sync/commit/0a2097e8973445a6201599b41d5a7f872dfeb34e))
+* **ble:** derive connect addr_type from MAC bits for misreported random scales ([#231](https://github.com/KristianP26/ble-scale-sync/issues/231)) ([4909038](https://github.com/KristianP26/ble-scale-sync/commit/4909038b2a4f2052d0fba85e7fc10131e4fad938))
+* **ble:** preserve bond by not RemoveDevice'ing paired scales ([#168](https://github.com/KristianP26/ble-scale-sync/issues/168)) ([d662199](https://github.com/KristianP26/ble-scale-sync/commit/d662199e45a14c6bfaf45018682177bbe618e6a1))
+* **ble:** register BlueZ pairing agent for BF720 encrypted bonding ([#168](https://github.com/KristianP26/ble-scale-sync/issues/168)) ([d2a1aaf](https://github.com/KristianP26/ble-scale-sync/commit/d2a1aafa650c4e02dc5da89db7c99d15a0f0e012))
+* **esp32:** restore aioble IRQ before GATT connect ([#231](https://github.com/KristianP26/ble-scale-sync/issues/231)) ([c29dc1c](https://github.com/KristianP26/ble-scale-sync/commit/c29dc1c41439b35207b16759481aa81ffd6c5d9e))
+
+
+### Changed
+
+* **ble:** single pre-connect GC pass on PSRAM boards ([#231](https://github.com/KristianP26/ble-scale-sync/issues/231)) ([62e134b](https://github.com/KristianP26/ble-scale-sync/commit/62e134b1f4859a613bfb99f002d60bbc5316edb6))
+
+
+### Docs
+
+* note minimal-delay autonomous connect for GATT scales ([#231](https://github.com/KristianP26/ble-scale-sync/issues/231)) ([b679550](https://github.com/KristianP26/ble-scale-sync/commit/b6795504c6dc562c18c2551629fbbe38cd381c61))
+* recommend scale_mac for GATT-only scales over the ESP32 proxy ([#231](https://github.com/KristianP26/ble-scale-sync/issues/231)) ([8b670c1](https://github.com/KristianP26/ble-scale-sync/commit/8b670c1e1042d1b8d76fcb9c65d8eb3743cc49f7))
+
+## [1.17.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.16.1...v1.17.0) (2026-06-15)
+
+
+### Added
+
+* **ble:** add Robi S9 adapter (Lefu/Fitdays FFB0-new protocol) ([#228](https://github.com/KristianP26/ble-scale-sync/issues/228)) ([4a8fda5](https://github.com/KristianP26/ble-scale-sync/commit/4a8fda56fa57bbb4f97b2a7cb36ca475a70e5515))
+
+
+### Fixed
+
+* **ble:** attempt bonding and name failed CCCD subscribe for Beurer BF720 ([#168](https://github.com/KristianP26/ble-scale-sync/issues/168)) ([45bfd87](https://github.com/KristianP26/ble-scale-sync/commit/45bfd87cf51de6ec565d6fdcd7038f5da197d31e))
+* **ble:** match QN scales advertising AE00 alongside fff0 ([#235](https://github.com/KristianP26/ble-scale-sync/issues/235)) ([6a12687](https://github.com/KristianP26/ble-scale-sync/commit/6a126877120b106ff1a9d452e46eb146477c3160))
+* **firmware:** ease GATT connect on no-PSRAM ESP32 + heap diagnostic ([#139](https://github.com/KristianP26/ble-scale-sync/issues/139)) ([7bef0f6](https://github.com/KristianP26/ble-scale-sync/commit/7bef0f6866a3e1700eff607d1adbe18dea0cf00e))
+
+## [1.16.1](https://github.com/KristianP26/ble-scale-sync/compare/v1.16.0...v1.16.1) (2026-06-15)
+
+
+### Fixed
+
+* **ble:** decode Sanitas SBF70/BF710 body composition via 0x59 ACK stream ([#211](https://github.com/KristianP26/ble-scale-sync/issues/211)) ([c3beb00](https://github.com/KristianP26/ble-scale-sync/commit/c3beb007372ff0a051a82d1ba411b6ef14d9e7ab))
+* **ble:** parse QN 0x23 stored record for V10 Renpho/ES-CS20M ([#213](https://github.com/KristianP26/ble-scale-sync/issues/213)) ([5617f28](https://github.com/KristianP26/ble-scale-sync/commit/5617f28fb7d02f47a34c86a2aa7b29fbdbe33688))
+* **ble:** read ESPHome proxy pre-decoded GATT uuid ([#229](https://github.com/KristianP26/ble-scale-sync/issues/229)) ([#234](https://github.com/KristianP26/ble-scale-sync/issues/234)) ([c1079c7](https://github.com/KristianP26/ble-scale-sync/commit/c1079c72375856b8179234bebd5d5e1ef82a7f60))
+
+## [1.16.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.15.0...v1.16.0) (2026-06-04)
+
+
+### Added
+
+* **ble:** add adapter liveness probe for watchdog classification ([#213](https://github.com/KristianP26/ble-scale-sync/issues/213)) ([e50ce5b](https://github.com/KristianP26/ble-scale-sync/commit/e50ce5b0128ab488f06ec3895306cdc4e557bfbe))
+* **ble:** add poll-failure classification helpers ([#213](https://github.com/KristianP26/ble-scale-sync/issues/213)) ([484e16a](https://github.com/KristianP26/ble-scale-sync/commit/484e16ac32d58bd24dd78fe6d190afd97bd5dd04))
+* **mqtt-proxy:** ESP32 autonomous GATT connect for fast-sleeping scales ([#214](https://github.com/KristianP26/ble-scale-sync/issues/214)) ([c4a3b33](https://github.com/KristianP26/ble-scale-sync/commit/c4a3b33ce28a003e63dfbdf14ae10991d6df9ff1))
+
+
+### Fixed
+
+* **ble:** keep a permanent error listener on the ESPHome proxy client ([#210](https://github.com/KristianP26/ble-scale-sync/issues/210)) ([ca7eb7d](https://github.com/KristianP26/ble-scale-sync/commit/ca7eb7d2f048a6f90d65d75878340ba7b0544525))
+* **ble:** reset gattInProgress on failed GATT connect + clearer ESP32 errors ([#201](https://github.com/KristianP26/ble-scale-sync/issues/201)) ([dcd1ac6](https://github.com/KristianP26/ble-scale-sync/commit/dcd1ac6f7d1a456b1e83eecf57a3709bddb2dd5f))
+* **ble:** send BLE address type on ESPHome proxy GATT connect ([#215](https://github.com/KristianP26/ble-scale-sync/issues/215)) ([#223](https://github.com/KristianP26/ble-scale-sync/issues/223)) ([71e735b](https://github.com/KristianP26/ble-scale-sync/commit/71e735b6c3460f9aa2b3d2d9e724c06da94ddeae))
+* **ble:** tag idle vs wedge poll failures in scanAndReadRaw ([#213](https://github.com/KristianP26/ble-scale-sync/issues/213)) ([407753e](https://github.com/KristianP26/ble-scale-sync/commit/407753e261815f31e128a88b5f97da7352baabda))
+* **config:** accept bare 32-hex CoreBluetooth UUID for scale_mac ([#212](https://github.com/KristianP26/ble-scale-sync/issues/212)) ([#224](https://github.com/KristianP26/ble-scale-sync/issues/224)) ([47d5033](https://github.com/KristianP26/ble-scale-sync/commit/47d503329a828c5127c827df98e902dc26cee36c))
+* **firmware:** flush scan batch early on a known scale MAC ([#201](https://github.com/KristianP26/ble-scale-sync/issues/201)) ([c692b42](https://github.com/KristianP26/ble-scale-sync/commit/c692b426972edaf0fb895475262afa166cf72587))
+* **runtime:** watchdog ignores idle no-shows ([#213](https://github.com/KristianP26/ble-scale-sync/issues/213)) ([9e1588f](https://github.com/KristianP26/ble-scale-sync/commit/9e1588faf84ac352ec3f9e41029d8406007e060c))
+
+
+### Docs
+
+* note idle-aware watchdog behavior ([#213](https://github.com/KristianP26/ble-scale-sync/issues/213)) ([7de309e](https://github.com/KristianP26/ble-scale-sync/commit/7de309ed6a33fab0150a2101909bcaa65544af6f))
+
+## [1.15.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.14.1...v1.15.0) (2026-05-21)
+
+
+### Added
+
+* **exporter:** add Intervals.icu exporter ([#203](https://github.com/KristianP26/ble-scale-sync/issues/203)) ([60af3d0](https://github.com/KristianP26/ble-scale-sync/commit/60af3d0e98fdb90268dbe43d7316b6bc8e9ff3c1))
+* **exporter:** add Telegram exporter ([#207](https://github.com/KristianP26/ble-scale-sync/issues/207)) ([0b73e0f](https://github.com/KristianP26/ble-scale-sync/commit/0b73e0f76601603e578f824d5b92cccf2c451e29))
+* **firmware:** support generic ESP-WROOM-32 boards ([487e482](https://github.com/KristianP26/ble-scale-sync/commit/487e482084ac42be73f8f6f4bde9d356f2f6a1a1))
+
+
+### Fixed
+
+* **ble:** route dual-mode adapters to GATT when no broadcast data ([#201](https://github.com/KristianP26/ble-scale-sync/issues/201)) ([9de2dee](https://github.com/KristianP26/ble-scale-sync/commit/9de2deea0f8223f72a1c631ed31584a5600a6fba))
+* **exporters:** fail fast on non-retryable HTTP errors + validate required config ([6ebea77](https://github.com/KristianP26/ble-scale-sync/commit/6ebea77b81320eeb7bf20a106c96b1cb460c524a))
+* **firmware:** harden constrained ESP32 boards against scan-buffer OOM ([c99605e](https://github.com/KristianP26/ble-scale-sync/commit/c99605e22f667f06023fdd9ee3f57c4f0c8b9e36))
+* **firmware:** parse 128-bit / 32-bit service UUIDs and service data ([bf918ad](https://github.com/KristianP26/ble-scale-sync/commit/bf918ad75fbaeb35465544af74871a5f0bd286fb))
+* **firmware:** publish service-UUID-only devices in scan results ([c1f9723](https://github.com/KristianP26/ble-scale-sync/commit/c1f9723013972749846acb7ff76fa5ec169a164c)), closes [#201](https://github.com/KristianP26/ble-scale-sync/issues/201)
+
+
+### Docs
+
+* bump adapter and exporter counts to 25 and 8 ([0e21abe](https://github.com/KristianP26/ble-scale-sync/commit/0e21abe88f5073238d2e3bdc7da840a505270304))
+* **scales:** note Mi Scale 2 works on all BLE transports ([e126848](https://github.com/KristianP26/ble-scale-sync/commit/e126848ad11a976c6956dbff5ee67ce755553306))
+
+## [1.14.1](https://github.com/KristianP26/ble-scale-sync/compare/v1.14.0...v1.14.1) (2026-05-19)
+
+
+### Fixed
+
+* **firmware:** correct mip ref position for async primitives install ([8974caa](https://github.com/KristianP26/ble-scale-sync/commit/8974caa1f9b55cabb792fb0532b29785518feabb)), closes [#198](https://github.com/KristianP26/ble-scale-sync/issues/198)
+* force-exit on hung shutdown so the watchdog actually restarts the container ([#194](https://github.com/KristianP26/ble-scale-sync/issues/194)) ([#196](https://github.com/KristianP26/ble-scale-sync/issues/196)) ([3b60393](https://github.com/KristianP26/ble-scale-sync/commit/3b6039397f53bc4d85f94a9889b7fedac4b24356))
+
+## [1.14.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.13.1...v1.14.0) (2026-05-18)
+
+
+### Added
+
+* **ble:** registry self-check to prevent adapter matches() collisions ([#182](https://github.com/KristianP26/ble-scale-sync/issues/182)) ([663f55a](https://github.com/KristianP26/ble-scale-sync/commit/663f55a8a9736967626312ca6d4f561a6db62295))
+* **ble:** ESPHome proxy Phase 2 - GATT + multi-proxy ([#116](https://github.com/KristianP26/ble-scale-sync/issues/116)) ([#187](https://github.com/KristianP26/ble-scale-sync/issues/187)) ([c850aa3](https://github.com/KristianP26/ble-scale-sync/commit/c850aa3b55b018143cb99e4659b53f04f1720ae2))
+* **scales:** Beurer BF720 / BF105 SIG-standard adapter ([#168](https://github.com/KristianP26/ble-scale-sync/issues/168)) ([#180](https://github.com/KristianP26/ble-scale-sync/issues/180)) ([3f52568](https://github.com/KristianP26/ble-scale-sync/commit/3f525688a099d5e5510edfb96e60cec9ab91fe3e))
+* **scales:** add Eufy T9120 (A1) support ([#178](https://github.com/KristianP26/ble-scale-sync/issues/178)) ([3f5ecd4](https://github.com/KristianP26/ble-scale-sync/commit/3f5ecd44e6f511b86e343f4dd392a9d031960ba1))
+
+
+### Fixed
+
+* **scales:** defer Renpho ES-WBE28 from the QN adapter ([#191](https://github.com/KristianP26/ble-scale-sync/issues/191)) ([27a58d5](https://github.com/KristianP26/ble-scale-sync/commit/27a58d5dda2e10ff6aced5df296637efa890c851))
+* **ble:** characteristic-aware adapter matching for 0xFFF0 collision ([#177](https://github.com/KristianP26/ble-scale-sync/issues/177)) ([#179](https://github.com/KristianP26/ble-scale-sync/issues/179)) ([6cb7992](https://github.com/KristianP26/ble-scale-sync/commit/6cb799290687fd02c84dbcbfb7dd1fc5106eddcb))
+
+
+### Docs
+
+* add boildead and alexw23 to contributors ([bf15b87](https://github.com/KristianP26/ble-scale-sync/commit/bf15b8766da1670600dc71d246d04d7587001226))
+
+## [1.13.1](https://github.com/KristianP26/ble-scale-sync/compare/v1.13.0...v1.13.1) (2026-05-18)
+
+
+### Fixed
+
+* **docker:** add missing setup-strava command to entrypoint ([#188](https://github.com/KristianP26/ble-scale-sync/issues/188)) ([#189](https://github.com/KristianP26/ble-scale-sync/issues/189)) ([af47e3a](https://github.com/KristianP26/ble-scale-sync/commit/af47e3aa1322fa34a440f8d43781793802a46080))
+
+## [1.13.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.12.1...v1.13.0) (2026-05-13)
+
+
+### Added
+
+* drop Node 20 support, require Node 22+ ([25712d1](https://github.com/KristianP26/ble-scale-sync/commit/25712d1b84274fbab95f0adbef3c76bcf423f3d8))
+* replay cached offline frames with timestamps ([#164](https://github.com/KristianP26/ble-scale-sync/issues/164)) ([6bae585](https://github.com/KristianP26/ble-scale-sync/commit/6bae5858a8d63f373361ed1aef979915a23c1183))
+* **scale:** support Renpho ES-32MD via ES-CS20M adapter ([#172](https://github.com/KristianP26/ble-scale-sync/issues/172)) ([068c14f](https://github.com/KristianP26/ble-scale-sync/commit/068c14f4563a6529afb6b5bbc7bfaa716371642f))
+
+
+### Fixed
+
+* **deps:** regen package-lock.json with emnapi entries (CI fix) ([40b3d9d](https://github.com/KristianP26/ble-scale-sync/commit/40b3d9dd5e77aeafc45818363a52db3bb50ab15a))
+* **runtime:** use raw weight for single-user mqtt display ([b8d0b90](https://github.com/KristianP26/ble-scale-sync/commit/b8d0b909874f44385d2d2b595481d7a3f8e3f306))
+
+## [1.12.1](https://github.com/KristianP26/ble-scale-sync/compare/v1.12.0...v1.12.1) (2026-05-12)
+
+
+### Fixed
+
+* **ble:** RSSI freshness no longer treats absent prop as stale ([#167](https://github.com/KristianP26/ble-scale-sync/issues/167)) ([8340caa](https://github.com/KristianP26/ble-scale-sync/commit/8340caa0ef3de7a5499dfca26190cc5864ab8e7e)), closes [#169](https://github.com/KristianP26/ble-scale-sync/issues/169)
+
+## [1.12.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.11.0...v1.12.0) (2026-05-06)
+
+
+### Added
+
+* **config:** hot-reload config.yaml without restart ([#123](https://github.com/KristianP26/ble-scale-sync/issues/123)) ([d213d5c](https://github.com/KristianP26/ble-scale-sync/commit/d213d5ccd242312f5251c59128708ca503b0cb23))
+* **runtime:** systemd Type=notify watchdog integration ([#144](https://github.com/KristianP26/ble-scale-sync/issues/144)) ([68ee5bf](https://github.com/KristianP26/ble-scale-sync/commit/68ee5bf4b1aede87080c432512233f4e09b5a680))
+* **scales:** add Xiaomi Mi Scale 2 broadcast adapter ([#134](https://github.com/KristianP26/ble-scale-sync/issues/134)) ([6e5ffb4](https://github.com/KristianP26/ble-scale-sync/commit/6e5ffb4fa994546231d42b6493cd875e2f2e46fe))
+* **scales:** scaffold experimental ADE A2 adapter ([#159](https://github.com/KristianP26/ble-scale-sync/issues/159)) ([#160](https://github.com/KristianP26/ble-scale-sync/issues/160)) ([11aec6f](https://github.com/KristianP26/ble-scale-sync/commit/11aec6f79bc01c4c4a7dee9e68ffa2e0c72b2d51))
+* **trisa:** implement ADE BA 1600 challenge response ([#138](https://github.com/KristianP26/ble-scale-sync/issues/138)) ([#158](https://github.com/KristianP26/ble-scale-sync/issues/158)) ([91aa28e](https://github.com/KristianP26/ble-scale-sync/commit/91aa28eedef68e0c77da7ceb389fe411b151f48c))
+
+
+### Fixed
+
+* **ble:** guard against dying-peer connect stall ([#143](https://github.com/KristianP26/ble-scale-sync/issues/143)) ([abd3c22](https://github.com/KristianP26/ble-scale-sync/commit/abd3c227547c4a92f05f2d5be47087049339b7c3))
+* **ble:** per-address grace state in esphome-proxy scanAndReadRaw ([#161](https://github.com/KristianP26/ble-scale-sync/issues/161)) ([875cb28](https://github.com/KristianP26/ble-scale-sync/commit/875cb283c9df725e615f76e1c9919185ad773cc0))
+* **review:** address v1.12.0 review findings ([ed90fbf](https://github.com/KristianP26/ble-scale-sync/commit/ed90fbf4d7fc3bbc1bdd94bc241942ef10df7c10))
+* **runtime:** cache systemd-notify ENOENT to avoid spawn-storm on hosts without it ([#144](https://github.com/KristianP26/ble-scale-sync/issues/144)) ([8959287](https://github.com/KristianP26/ble-scale-sync/commit/895928768b78e84cd70c79a9bc7e26ff285a308d))
+* **scales:** ack offline frames on Renpho ES-26BB-B ([#157](https://github.com/KristianP26/ble-scale-sync/issues/157)) ([70f2066](https://github.com/KristianP26/ble-scale-sync/commit/70f20669e178d99a2aa6783ed1f65b3c8fed1997))
+* **scales:** warn instead of debug when ES-26BB-B offline ack write fails ([4e265e1](https://github.com/KristianP26/ble-scale-sync/commit/4e265e16bf20c5bedaff52c636f0fe71128982bf))
+
+
+### Docs
+
+* deep consistency sweep across guide and reference pages ([e979b0c](https://github.com/KristianP26/ble-scale-sync/commit/e979b0cf5b12d75f6d74e3152db9628a824297b8))
+* **readme:** bump scale count, note Linux stability features ([5a47c06](https://github.com/KristianP26/ble-scale-sync/commit/5a47c064911a36b46f909e3e8bd55b7ad1a1fdab))
+
+## [1.11.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.10.2...v1.11.0) (2026-05-01)
+
+
+### Added
+
+* **ble:** consecutive-failure watchdog for BlueZ stuck-state recovery ([#154](https://github.com/KristianP26/ble-scale-sync/pull/154)) ([dcc822d](https://github.com/KristianP26/ble-scale-sync/commit/dcc822d16bbebe7682490114febc92326b69a611))
+* **trisa:** support ADE BA 1600 (fitvigo) firmware variant — weight only ([#153](https://github.com/KristianP26/ble-scale-sync/pull/153)) ([515d1a7](https://github.com/KristianP26/ble-scale-sync/commit/515d1a72faab28abbadddc41ddca60337358b68b))
+
+
+### Fixed
+
+* **firmware:** match scan_duration_ms to GATT connect timeout ([#141](https://github.com/KristianP26/ble-scale-sync/issues/141)) ([54dcc3b](https://github.com/KristianP26/ble-scale-sync/commit/54dcc3bda965ac9482659017f3c08d68efea716d))
+* **node-ble:** add timeout to device.gatt() and waitForRawReading ([#142](https://github.com/KristianP26/ble-scale-sync/pull/142)) ([2e45366](https://github.com/KristianP26/ble-scale-sync/commit/2e45366623f873aaf1b415c3f1ccc4edef860613)), closes [#140](https://github.com/KristianP26/ble-scale-sync/issues/140)
+* prevent orphaned BlueZ discovery sessions in continuous mode ([#81](https://github.com/KristianP26/ble-scale-sync/pull/81)) ([e6ee513](https://github.com/KristianP26/ble-scale-sync/commit/e6ee51350ced0ef9a50d77380d201a21627fcc76))
+* **trisa:** fail fast when no measurement char and harden ADE parser boundary ([74a34a6](https://github.com/KristianP26/ble-scale-sync/commit/74a34a6e14d6b525114ed78372c43e07a0de6cd3))
+
+
+### Docs
+
+* **addon:** backfill CHANGELOG and refresh DOCS for v1.8.2 through v1.10.2 ([d918a1d](https://github.com/KristianP26/ble-scale-sync/commit/d918a1d677dad982dc123133352ae58539b93fb1))
+* document Pi 3/4 BlueZ stuck-state limitation + watchdog mitigation ([a039b4b](https://github.com/KristianP26/ble-scale-sync/commit/a039b4b155b5677001994a1f6a3bbfc723b2b876))
+* **esp32-proxy:** add Windows flashing guidance ([#152](https://github.com/KristianP26/ble-scale-sync/pull/152)) ([2796d7b](https://github.com/KristianP26/ble-scale-sync/commit/2796d7b0bcbced0bc1e5bca026fc275b6e02be21))
+* **trisa:** clarify optional-binding + variant-detection semantics ([ae87d84](https://github.com/KristianP26/ble-scale-sync/commit/ae87d8421a446dd3b56cec63ab3baad476d87a0a))
+
+
+### Thanks
+
+* [@fromport](https://github.com/fromport) for the `device.gatt()` / `waitForRawReading` GATT-acquisition timeout fix that prevents indefinite hangs on stalled BlueZ adapters ([#142](https://github.com/KristianP26/ble-scale-sync/pull/142))
+
+## [1.10.2](https://github.com/KristianP26/ble-scale-sync/compare/v1.10.1...v1.10.2) (2026-04-24)
+
+
+### Fixed
+
+* **Renpho ES-26M**: the 18-byte `0x12` scale-info frame (where byte[1] is the packet length and bytes [2-7] carry the device MAC) was being misread as "byte[2] is the protocol type", yielding `proto=0xFF` and causing every subsequent handshake command to be rejected by the scale. No `0x10` weight frames were ever returned. The QN-Scale adapter now detects the long-frame format (`data.length >= 18 && data[1] === length`) and falls through to the ES-30M code path with `weightScaleFactor=10`, so the existing heuristic auto-corrects the weight divisor. The unconditional skip of `R1=R2=0` stable frames in ES-30M mode is also lifted: the ES-26M never reports impedance when the user is wearing socks, and those frames are the only stable reading available in that scenario. Contributed by [@fromport](https://github.com/fromport) ([#128](https://github.com/KristianP26/ble-scale-sync/pull/128))
+
+
+### Changed
+
+* **ESPHome proxy**: the handler now logs a one-time Phase 1 capability summary on connect, listing which configured scale adapters are broadcast-capable (produce readings on this transport) and which are GATT-only (will time out until Phase 2 / [#116](https://github.com/KristianP26/ble-scale-sync/issues/116) ships). Users who were only seeing the generic `Timed out waiting for any recognized scale broadcast via ESPHome proxy` line now immediately see whether their scale brand is in the broadcast-capable set, instead of having to reproduce the failure twice to catch the per-MAC warn. Surfaces the Yunmai / Beurer / Mi Scale 2 / etc. mismatch reported by [@geniusliang](https://github.com/geniusliang) in [#133](https://github.com/KristianP26/ble-scale-sync/issues/133)
+
+
+### Docs
+
+* **CONTRIBUTING.md**: project structure tree refreshed to match the current layout (HA add-on, ESPHome proxy handler, updated scale/test files)
+* **README**: contributors migrated to a GitHub-style table with inline avatars, [@fromport](https://github.com/fromport) added for the ES-26M contribution
+
+
+### Thanks
+
+* [@fromport](https://github.com/fromport) for diagnosing and fixing the ES-26M handshake end to end, including the heuristic weight-divisor path
+* [@geniusliang](https://github.com/geniusliang) for the detailed ESPHome proxy repro that led to the capability-summary UX improvement
+
+## [1.10.1](https://github.com/KristianP26/ble-scale-sync/compare/v1.10.0...v1.10.1) (2026-04-22)
+
+
+### Fixed
+
+* **ESPHome proxy**: the `ReadingWatcher` silently dropped advertisements from dual-mode scale adapters (`parseBroadcast` defined **and** `charNotifyUuid` set) when the broadcast frame was not weight-bearing. Reported by [@deadhurricane](https://github.com/deadhurricane) on an Elis 1 / ES-30M, which matches by name as a QN-Scale but only beacons its MAC in manufacturer data and carries weight over GATT. The handler now warns once per MAC that the scale needs a GATT connection (Phase 2), pointing the user at the native BLE handler or the ESP32 MQTT proxy as workarounds instead of leaving them staring at a silent log ([#116](https://github.com/KristianP26/ble-scale-sync/issues/116), [#75](https://github.com/KristianP26/ble-scale-sync/issues/75))
+* **Logger**: `runtime.debug: true` in `config.yaml` did not switch the log level to DEBUG, only the `DEBUG=true` env var did. The app now honors the config value on startup, so HA Add-on users (who pass `debug` as an option, not an env var) and anyone driving the runtime from `config.yaml` get the verbose BLE logs they expect
+
+## [1.10.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.9.0...v1.10.0) (2026-04-22)
+
+
+### Added
+
+* **Embedded MQTT broker for the ESP32 proxy**: zero-config setup, no Mosquitto required. When `ble.mqtt_proxy.broker_url` is omitted, BLE Scale Sync now starts an embedded [aedes](https://github.com/moscajs/aedes) broker on `0.0.0.0:1883` by default; the internal client connects over loopback, and the ESP32 firmware just points at the host machine's LAN IP. Port and bind interface are configurable via `embedded_broker_port` and `embedded_broker_bind`, optional username/password are enforced when set. Existing `broker_url` setups are untouched ([#54](https://github.com/KristianP26/ble-scale-sync/issues/54))
+* **ESPHome Bluetooth proxy transport (experimental, phase 1 / broadcast-only)**: third BLE handler option `ble.handler: esphome-proxy`. If you already run an [ESPHome Bluetooth proxy](https://esphome.io/components/bluetooth_proxy.html) mesh for Home Assistant, BLE Scale Sync can connect to it over Native API (port 6053, optional Noise encryption or legacy password) and reuse it as its BLE radio, so no dedicated ESP32 with custom firmware and no MQTT broker are required. Phase 1 handles broadcast scales only; GATT scales log a warning and are skipped until phase 2 lands. New `docs/guide/esphome-proxy.md` covers setup, encryption key handling and limitations ([#116](https://github.com/KristianP26/ble-scale-sync/issues/116))
+* **Setup wizard**: new "Use built-in embedded broker" option for the mqtt-proxy handler, so new installs skip the external broker prompt by default. Handler selection now also includes "Via ESPHome Bluetooth proxy" with prompts for host, port and authentication mode
+
+
+### Security
+
+* **Embedded MQTT broker**: configs that bind the embedded broker to a non-loopback interface (default `0.0.0.0`) now require `username` + `password` and are rejected at schema validation time. The wizard defaults to requiring auth and falls back to `127.0.0.1` when the user declines, so misconfiguration cannot silently expose a LAN-reachable broker without credentials.
+* **ESPHome proxy**: configs that set both `encryption_key` and `password` are rejected at schema validation time. Pick Noise (`encryption_key`, recommended) or legacy password, not both.
+
+## [1.9.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.8.2...v1.9.0) (2026-04-21)
+
+
+### Added
+
+* **Eufy Smart Scale P2 (T9148) and P2 Pro (T9149)**: new dedicated adapter with the AES-128-CBC C0/C1/C2/C3 handshake required by these models. Weight + impedance over GATT FFF2 after authentication, passive weight reading from the 19-byte advertisement without connecting. Prevents the prior false match as a QN scale that crashed with `Operation is not supported` on FFF1 ([#98](https://github.com/KristianP26/ble-scale-sync/issues/98))
+
+
+### Fixed
+
+* **Setup wizard**: picking no exporter in the export-targets checkbox silently produced a config without any `global_exporters` block, so the first run emitted `All exports failed` and exited with code 1. The wizard now asks an explicit `Continue without exporters?` confirmation when the checkbox is submitted empty and re-prompts if the user declines ([#98](https://github.com/KristianP26/ble-scale-sync/issues/98))
+* **Orchestrator**: `dispatchExports([])` logged `All exports failed` because `allFailed` defaulted to `true` with zero iterations. Empty exporter lists now short-circuit with a clear warning (`No exporters configured — measurement processed but not sent anywhere`) and return `success`, so single-shot mode no longer exits with code 1 when the config has no exporters
+
+
+### Thanks
+
+* [@mart1058](https://github.com/mart1058) and [@dbrb2](https://github.com/dbrb2) for diagnose output, HCI snoop logs, and testing the Eufy P2 Pro protocol reverse-engineering ([#98](https://github.com/KristianP26/ble-scale-sync/issues/98))
+* [bdr99/eufylife-ble-client](https://github.com/bdr99/eufylife-ble-client) for the reference Python implementation of the Eufy T9148/T9149 auth handshake and frame formats
+
+## [1.8.2](https://github.com/KristianP26/ble-scale-sync/compare/v1.8.1...v1.8.2) (2026-04-20)
+
+
+### Fixed
+
+* **Sanitas SBF70 / Beurer BF710 family**: weight parsed as a stuck `12.80 kg` regardless of the real reading on the scale. Root cause: the BF710 variant (start byte `0xE7`) sends a compact 5-byte `0x58` frame with weight at bytes `[3-4]` BE, not the 6+ byte BF700/BF800 layout the adapter assumed. The adapter rejected every live weight frame as too short and then mis-parsed the `0x59` finalize frame. Now branches on `isBf710Type` and applies a 3-reading stability window (0.3 kg tolerance) so the scale's initial metadata frame does not trigger early completion ([#112](https://github.com/KristianP26/ble-scale-sync/issues/112))
+
+
+### Thanks
+
+* [@flow778](https://github.com/flow778) for capturing raw BLE frames that made the fix possible ([#112](https://github.com/KristianP26/ble-scale-sync/issues/112))
+
+## [1.8.1](https://github.com/KristianP26/ble-scale-sync/compare/v1.8.0...v1.8.1) (2026-04-20)
+
+
+### Fixed
+
+* **Garmin**: upload failed with `'Garmin' object has no attribute 'garth'` after `garminconnect` released 0.3.0 on 2026-04-02, which dropped the `garth` dependency in favor of native authentication. The Python bridge accessed `garmin.garth.sess.headers` and `garmin.garth.dump()`, both removed in 0.3.x. Migrated to the new API: `Garmin.login(tokenstore)` auto-persists on successful credential login, and `client.dump(token_dir)` saves tokens after MFA. Custom User-Agent override is no longer needed because `garminconnect` now uses `curl_cffi` TLS impersonation and randomized browser fingerprints internally ([#114](https://github.com/KristianP26/ble-scale-sync/issues/114))
+* **Docker**: added `libcurl4-openssl-dev` so `curl_cffi` (new transitive dep via `garminconnect` 0.3.x) builds from source on armv7, where PyPI has no prebuilt wheel
+
+
+### Breaking
+
+* Tokens from `garminconnect` 0.2.x (old garth OAuth1/OAuth2 files) are incompatible with 0.3.x. Existing installs must re-authenticate: `npm run setup-garmin`, or in the HA Add-on just restart the add-on so it re-runs setup from the credentials you entered. The setup script auto-removes leftover `oauth*_token.json` files before writing the new token format.
+
+
+### Thanks
+
+* [@Phipseyy](https://github.com/Phipseyy) and [@mooredav87](https://github.com/mooredav87) for reporting the Garmin upload regression ([#114](https://github.com/KristianP26/ble-scale-sync/issues/114))
+
+## [1.8.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.7.5...v1.8.0) (2026-04-17)
+
+
+### Added
+
+* **HA Add-on**: one-click install via a [My Home Assistant](https://www.home-assistant.io/integrations/my/) badge in the README, landing page, getting-started guide, and HA Add-on guide. Manual steps remain as a fallback for users without My Home Assistant configured
+* **HA Add-on**: `weight_unit` and `height_unit` exposed as add-on options (kg/lbs, cm/in). The CLI and exporters display in the chosen unit while internal math stays in kg/cm
+* **HA Add-on**: `last_known_weight` persists across restarts. The runtime config lives at `/data/config.yaml` and a small Python helper (`merge_last_weights.py`) copies preserved per-user weights from the previous run into the freshly generated config on every startup, so multi-user identification by weight stays accurate after reboots and add-on updates
+* **Docs**: new [Home Assistant Add-on guide](https://blescalesync.dev/guide/home-assistant-addon) covering install, full configuration reference, MQTT auto-detection, Garmin setup (including the MFA and IP-block workarounds), custom config mode, persistence semantics, and troubleshooting. Promoted to a first-class quick-start in the README and landing page
+
+## [1.7.5](https://github.com/KristianP26/ble-scale-sync/compare/v1.7.4...v1.7.5) (2026-04-15)
+
+
+### Fixed
+
+* **HA Add-on**: Garmin Connect uploads now work out of the box. The add-on previously created an empty `/data/garmin-tokens/` directory and never ran the authentication step, so the first upload always failed with `No such file or directory: '/data/garmin-tokens/oauth1_token.json'`. On first start the add-on now runs `setup_garmin.py --from-config` to generate OAuth tokens from the email and password you entered in the UI ([#111](https://github.com/KristianP26/ble-scale-sync/issues/111))
+* **Docker**: armv7 image builds failed because `cffi` (transitive dep via `garminconnect`) had no pre-built wheel for armv7 + Python 3.11 and pip could not compile from source. Added `python3-dev`, `libffi-dev`, and `libssl-dev` to the image so cffi builds cleanly
+
+
+### Added
+
+* **HA Add-on**: MFA-friendly token import. If your Garmin account uses 2FA, drop pre-generated `oauth1_token.json` and `oauth2_token.json` files into `/share/ble-scale-sync/garmin-tokens/` and the add-on imports them on startup, skipping the interactive auth that has no terminal inside an add-on container
+* **HA Add-on**: DOCS.md now explains the full Garmin setup flow including the MFA workaround and the IP-block workaround
+
+
+### Thanks
+
+* [@Phipseyy](https://github.com/Phipseyy) for reporting the HA Add-on Garmin failure ([#111](https://github.com/KristianP26/ble-scale-sync/issues/111))
+
+## [1.7.4](https://github.com/KristianP26/ble-scale-sync/compare/v1.7.3...v1.7.4) (2026-04-02)
+
+
+### Fixed
+
+* **QN Scale**: rewrote adapter as a notification-driven state machine for newer firmware (Renpho Elis 1, ES-CS20M) that requires an AE00 service handshake before measurement data flows ([#75](https://github.com/KristianP26/ble-scale-sync/issues/75), [#84](https://github.com/KristianP26/ble-scale-sync/issues/84))
+* **QN Scale**: added ES-30M weight frame format detection (different byte layout for weight and impedance)
+* **QN Scale**: 0x13 config byte now sends 0x01 (kg) instead of 0x08, which was switching the scale display to lb
+* **QN Scale**: 2-second fallback timer for Linux (BlueZ D-Bus) where the initial 0x12 frame may be lost due to a CCCD subscription race condition
+* **QN Scale**: skip impedance-less stable frames on ES-30M so the adapter waits for the full body composition reading
+
+
+### Thanks
+
+* [@DJBenson](https://github.com/DJBenson) for extensive macOS testing, packet capture analysis, and reverse-engineering the state machine flow ([#84](https://github.com/KristianP26/ble-scale-sync/issues/84))
+* [@ericandreani](https://github.com/ericandreani) for persistent Linux/Docker testing across multiple iterations ([#75](https://github.com/KristianP26/ble-scale-sync/issues/75))
+
+## [1.7.3](https://github.com/KristianP26/ble-scale-sync/compare/v1.7.2...v1.7.3) (2026-04-02)
+
+
+### Fixed
+
+* **Docker**: `diagnose` command was missing from the entrypoint, causing "exec: diagnose: not found" when running `docker run ... diagnose <MAC>` ([#98](https://github.com/KristianP26/ble-scale-sync/issues/98))
+
+
+### Thanks
+
+* [@mart1058](https://github.com/mart1058) for reporting the missing Docker diagnose command ([#98](https://github.com/KristianP26/ble-scale-sync/issues/98))
+
+## [1.7.2](https://github.com/KristianP26/ble-scale-sync/compare/v1.7.1...v1.7.2) (2026-04-01)
+
+
+### Fixed
+
+* **QN Scale**: UUID fallback (FFF0/FFE0) no longer matches named devices from other brands. Prevents Eufy, 1byone, and similar scales that share the FFF0 service from being incorrectly identified as QN Scale and failing with "Operation is not supported" ([#98](https://github.com/KristianP26/ble-scale-sync/issues/98))
+
+
+### Thanks
+
+* [@mart1058](https://github.com/mart1058) for reporting the Eufy P2 Pro connection failure ([#98](https://github.com/KristianP26/ble-scale-sync/issues/98))
+
+## [1.7.1](https://github.com/KristianP26/ble-scale-sync/compare/v1.7.0...v1.7.1) (2026-03-30)
+
+
+### Fixed
+
+* **Update check**: replaced strict 24-hour cooldown with calendar-day (UTC) comparison. Users who weigh in slightly earlier each day (e.g. 7:00 AM, then 6:55 AM) were being skipped
+
+## [1.7.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.6.4...v1.7.0) (2026-03-29)
+
+
+### Added
+
+* **Update check** with anonymous usage statistics ([#87](https://github.com/KristianP26/ble-scale-sync/issues/87)). After each successful measurement (max once per 24h), the app checks `api.blescalesync.dev` for newer versions. Only the app version, OS, and architecture are sent via the User-Agent header. Disable with `update_check: false` in config.yaml. Automatically disabled in CI environments
+* **Cloudflare Worker** (`worker/`) serving the `/version` endpoint and a public stats dashboard at [stats.blescalesync.dev](https://stats.blescalesync.dev) with aggregated anonymous data (version distribution, OS/architecture breakdown)
+* Setup wizard shows an update notice before the first step if a newer version is available
+* **CI**: GitHub Actions workflow for automatic Cloudflare Worker deployment on push to main (`worker.yml`)
+
+## [1.6.4](https://github.com/KristianP26/ble-scale-sync/compare/v1.6.3...v1.6.4) (2026-03-27)
+
+
+### Fixed
+
+* **BLE**: use ATT Write Request instead of Reliable Write in node-ble handler, fixing "Operation is not supported" errors on Medisana BS430 and similar scales that do not support reliable writes ([#85](https://github.com/KristianP26/ble-scale-sync/issues/85))
+
+
+### Improved
+
+* **BLE**: GATT characteristic flags are now logged during discovery (`DEBUG=true`) for easier troubleshooting
+
+
+### Thanks
+
+* [@Ikari34](https://github.com/Ikari34) for reporting the Medisana BS430 issue ([#85](https://github.com/KristianP26/ble-scale-sync/issues/85))
+
+## [1.6.3](https://github.com/KristianP26/ble-scale-sync/compare/v1.6.2...v1.6.3) (2026-03-04)
+
+
+### Fixed
+
+* **Docker**: removed cleanup workflow that was deleting multi-arch platform manifests, making all Docker images unpullable ([#74](https://github.com/KristianP26/ble-scale-sync/issues/74), [#76](https://github.com/KristianP26/ble-scale-sync/issues/76))
+
+
+### Thanks
+
+* [@marcelorodrigo](https://github.com/marcelorodrigo) for reporting the broken Docker images ([#74](https://github.com/KristianP26/ble-scale-sync/issues/74))
+* [@mtcerio](https://github.com/mtcerio) for the additional report ([#76](https://github.com/KristianP26/ble-scale-sync/issues/76))
+
+## [1.6.2](https://github.com/KristianP26/ble-scale-sync/compare/v1.6.1...v1.6.2) (2026-03-02)
+
+
+### Changed
+
+* **CI**: Docker `latest` tag now only applies to GitHub releases, not every push to main ([#70](https://github.com/KristianP26/ble-scale-sync/pull/70))
+* **CI**: Removed push-to-main Docker build trigger ([#71](https://github.com/KristianP26/ble-scale-sync/pull/71))
+* **Docs**: SEO meta keywords added to all documentation pages ([#69](https://github.com/KristianP26/ble-scale-sync/pull/69))
+* **Docs**: Alternatives page updated with Strava, file export, and ESP32 proxy sections ([#68](https://github.com/KristianP26/ble-scale-sync/pull/68))
+* **Docs**: ESP32 BLE proxy section added to getting started guide ([#67](https://github.com/KristianP26/ble-scale-sync/pull/67))
+
+## [1.6.1](https://github.com/KristianP26/ble-scale-sync/compare/v1.6.0...v1.6.1) (2026-03-01)
+
+
+### Fixed
+
+* **BlueZ stale discovery recovery** after Docker container restart. Adds kernel-level adapter reset via `btmgmt` as Tier 4 fallback when D-Bus recovery fails, plus proactive adapter reset in Docker entrypoint ([#39](https://github.com/KristianP26/ble-scale-sync/issues/39), [#43](https://github.com/KristianP26/ble-scale-sync/pull/43))
+
+
+### Changed
+
+* **CI**: Docker cleanup workflow removes PR images and untagged versions from GHCR ([#58](https://github.com/KristianP26/ble-scale-sync/pull/58))
+* **Docs**: Contributors section added to README
+* **Node.js**: minimum version bumped to 20.19.0 (required by eslint 10.0.2)
+* **Deps**: @stoprocent/noble 2.3.16, eslint 10.0.2, typescript-eslint 8.56.1, @types/node 25.3.3, @inquirer/prompts 8.3.0
+
+
+### Thanks
+
+* [@marcelorodrigo](https://github.com/marcelorodrigo) for reporting the stale BlueZ discovery issue ([#39](https://github.com/KristianP26/ble-scale-sync/issues/39))
+
+## [1.6.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.5.0...v1.6.0) (2026-02-28)
+
+
+### Added
+
+* **ESP32 BLE proxy** (experimental) for remote BLE scanning over MQTT. Use a cheap ESP32 board (~8€) as a wireless Bluetooth radio, enabling BLE Scale Sync on machines without local Bluetooth. Supports both broadcast and GATT scales
+* **ESP32 display board** (Guition ESP32-S3-4848S040) with LVGL UI showing scan status, user matches, and export results
+* **Beep feedback** on ESP32 boards with I2S buzzer (Atom Echo) when a known scale is detected
+* **Streaming BLE scan** for ESP32-S3 boards with hardware radio coexistence
+* **Docker mqtt-proxy compose** (`docker-compose.mqtt-proxy.yml`) requiring no BlueZ, D-Bus, or `NET_ADMIN`
+* Setup wizard includes interactive mqtt-proxy configuration
+* `BLE_HANDLER=mqtt-proxy` environment variable as alternative to config.yaml
+* ESP32 proxy documentation page with architecture diagram, flashing guide, and MQTT topics reference
+
+
+### Changed
+
+* Renpho broadcast parsing consolidated into QN scale adapter
+* Landing page updated with ESP32 proxy and Setup Wizard feature cards
+
+
+### Thanks
+
+* [@APIUM](https://github.com/APIUM) for the ESP32 MQTT proxy implementation ([#45](https://github.com/KristianP26/ble-scale-sync/pull/45))
+
+## [1.5.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.4.0...v1.5.0) (2026-02-24)
+
+
+### Added
+
+* **File exporter** (CSV/JSONL) for local measurement logging without external services. Auto-header CSV with proper escaping, JSONL format, per-user file paths, and directory writability healthcheck
+* **Strava exporter** with OAuth2 token management. Updates athlete weight via PUT /api/v3/athlete. Automatic token refresh, restricted file permissions (0o600), and interactive setup script (`npm run setup-strava`)
+* Strava API application setup guide in documentation with step-by-step instructions
+
+## [1.4.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.3.1...v1.4.0) (2026-02-24)
+
+
+### Added
+
+* **BLE diagnostic tool** (`npm run diagnose`) for detailed device analysis: advertisement data, service UUIDs, RSSI, connectable flag, and step-by-step GATT connection testing
+* **Broadcast mode** for non-connectable QN-protocol scales (#34). Reads weight directly from BLE advertisement data without requiring a GATT connection
+* **Garmin 2FA/MFA support** in `setup_garmin.py`. Prompts for authenticator code when Garmin requires multi-factor authentication
+
+
+### Fixed
+
+* **QN broadcast parser**: corrected byte layout (LE uint16 at bytes 17-18, stability flag at byte 15). Previous layout produced incorrect weight values
+* **ES-CS20M**: service UUID 0x1A10 fallback for unnamed Yunmai-protocol devices (#34)
+* **ES-CS20M**: 0x11 STOP frame support as stability signal (#34)
+
+
+### Changed
+
+* **CI**: Node.js 24 added to test matrix (required check)
+* **CI**: PR-triggered Docker image builds with `pr-{id}` tags (#44)
+* **Deps**: ESLint v10, typescript-eslint v8.56
+
+
+### Thanks
+
+* [@APIUM](https://github.com/APIUM) for Garmin 2FA support ([#41](https://github.com/KristianP26/ble-scale-sync/pull/41))
+* [@Tosiman-Global](https://github.com/Tosiman-Global) and [@BenBaril83](https://github.com/BenBaril83) for debugging the ES-CS20M broadcast protocol (#34)
+* [@marcelorodrigo](https://github.com/marcelorodrigo) for PR-triggered Docker builds ([#44](https://github.com/KristianP26/ble-scale-sync/pull/44))
+
+## [1.3.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.2.2...v1.3.0) (2026-02-16)
+
+
+### Added
+
+* Garmin multi-user Docker authentication — `setup-garmin --user <name>` and `--all-users` commands
+* `setup_garmin.py --from-config` mode reads users and credentials from `config.yaml`
+* `--token-dir` argument for `garmin_upload.py` and `setup_garmin.py` — per-user token directories
+* Tilde expansion for `token_dir` in TypeScript exporter
+* 4 new Garmin exporter tests (token_dir passing, tilde expansion, backward compat)
+* `pyyaml` dependency for config.yaml parsing in Python scripts
+* Docker multi-user volume examples in `docker-compose.example.yml` and docs
+
+
+### Fixed
+
+* Friendly error message when D-Bus socket is not accessible (missing `-v /var/run/dbus:/var/run/dbus:ro` in Docker) instead of raw `ENOENT` crash (#25)
+
+
+### Changed
+
+* Wizard passes Garmin credentials via environment variables instead of CLI arguments (security)
+
+
+### Thanks
+
+* [@marcelorodrigo](https://github.com/marcelorodrigo) for [#29](https://github.com/KristianP26/ble-scale-sync/pull/29) — the initial implementation that inspired this solution
+
+## [1.2.2](https://github.com/KristianP26/ble-scale-sync/compare/v1.2.1...v1.2.2) (2026-02-14)
+
+
+### Added
+
+* Annotated `config.yaml.example` with all sections and exporters
+* `CONTRIBUTING.md` — development guide, project structure, test coverage, adding adapters/exporters, PR guidelines
+* `CHANGELOG.md`
+* GitHub Release and TypeScript badges
+* Documentation split into `docs/` — exporters, multi-user, body-composition, troubleshooting
+
+
+### Changed
+
+* Rewrite README (~220 lines, Docker-first quick start, simplified scales table)
+* Move dev content (project structure, test coverage, adding adapters/exporters) into CONTRIBUTING.md
+* `.env.example` now notes that `config.yaml` is the preferred configuration method
+
+## [1.2.1](https://github.com/KristianP26/ble-scale-sync/compare/v1.2.0...v1.2.1) (2026-02-13)
+
+
+### Added
+
+* Docker support with multi-arch images (`linux/amd64`, `linux/arm64`, `linux/arm/v7`)
+* `Dockerfile`, `docker-entrypoint.sh`, `docker-compose.example.yml`
+* GitHub Actions workflow for automated GHCR builds on release
+* Docker health check via heartbeat file
+
+## [1.2.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.1.0...v1.2.0) (2026-02-13)
+
+
+### Added
+
+* Interactive setup wizard (`npm run setup`) — BLE discovery, user profiles, exporter configuration, connectivity tests
+* Edit mode — reconfigure any section without starting over
+* Non-interactive mode (`--non-interactive`) for CI/automation
+* Schema-driven exporter prompts — new exporters auto-appear in the wizard
+
+## [1.1.0](https://github.com/KristianP26/ble-scale-sync/compare/v1.0.1...v1.1.0) (2026-02-13)
+
+
+### Added
+
+* Multi-user support — weight-based user matching (4-tier priority)
+* Per-user exporters (override global for specific users)
+* `config.yaml` as primary configuration format (`.env` fallback preserved)
+* Automatic `last_known_weight` tracking (debounced, atomic YAML writes)
+* Drift detection — warns when weight approaches range boundaries
+* `unknown_user` strategy (`nearest`, `log`, `ignore`)
+* SIGHUP config reload (Linux/macOS)
+* Exporter registry with self-describing schemas
+* Multi-user context propagation to all 5 exporters (MQTT topic routing, InfluxDB tags, Webhook fields, Ntfy prefix)
+
+## [1.0.1](https://github.com/KristianP26/ble-scale-sync/compare/v1.0.0...v1.0.1) (2026-02-13)
+
+
+### Changed
+
+* Configuration is now `config.yaml`-first with `.env` as legacy fallback
+* README rewritten for `config.yaml` workflow
+
+## [1.0.0](https://github.com/KristianP26/ble-scale-sync/releases/tag/v1.0.0) (2026-02-12)
+
+
+### Added
+
+* Initial release
+* 23 BLE scale adapters (QN-Scale, Xiaomi Mi Scale 2, Yunmai, Beurer, Sanitas, Medisana, and more)
+* 5 export targets: Garmin Connect, MQTT (Home Assistant), Webhook, InfluxDB, Ntfy
+* BIA body composition calculation (10 metrics)
+* Cross-platform BLE support (Linux/node-ble, Windows/@abandonware/noble, macOS/@stoprocent/noble)
+* Continuous mode with auto-reconnect
+* Auto-discovery (no MAC address required)
+* Exporter healthchecks at startup
+* 894 unit tests across 49 test files

--- a/docs/guide/esp32-proxy.md
+++ b/docs/guide/esp32-proxy.md
@@ -44,6 +44,8 @@ The ESP32 scans autonomously for BLE advertisements and publishes results over M
 
 ::: tip Autonomous connect
 The ESP32 connects to known scales autonomously the instant it detects them, eliminating the MQTT round-trip that previously caused some fast-sleeping scales to power off before the connection could be established. This behavior is on by default. To disable it and use the old host-initiated connect flow, set `auto_connect: false` under `mqtt_proxy` in your config.
+
+Run the server in continuous mode with this handler. The ESP32 decides when to connect, and only the continuous-mode watcher stays subscribed to the `connected` topic; a single run listens only during its own scan window, so an autonomous connect that lands outside it is lost. Set `runtime.continuous_mode: true` (or `CONTINUOUS_MODE=true`). The server warns at startup if the mqtt-proxy handler is used without it.
 :::
 
 ## Supported Boards
@@ -419,6 +421,14 @@ Broadcast-only scales are unaffected and work on every board.
 ### A GATT-only scale never connects with auto_connect
 
 Some scales (for example the QN-Scale) expose no broadcast data and must be GATT-connected to read. With `auto_connect` on, the ESP32 connects itself the instant it sees a known scale MAC, but it only treats a MAC as known once the server has told it about that MAC. Set `ble.scale_mac` to your scale so the server seeds that MAC to the ESP32 at startup and the autonomous connect can fire on the first sighting. Without a `scale_mac`, the server still recovers by falling back to a slower host-initiated connect after a few scan cycles, so a configured `scale_mac` is recommended for GATT-only scales.
+
+### The ESP32 connects once per boot and then stops scanning
+
+The proxy pauses its scan for the duration of a GATT session, and a session used to end only when the server said so or when a notify reader saw the link drop. With lazy notify no reader runs until the server subscribes, so a session the server never engaged with left the scan paused until the ESP32 was reset: exactly one autonomous connect per boot.
+
+The firmware now guards every session it publishes. It ends the session and resumes scanning by itself when the link is already down, when no server command arrives for about 20 seconds, or when the session runs past three minutes, and prints the reason (`GATT session guard: ...`) on the serial console. Boards can tune this with `GATT_SESSION_IDLE_MS` and `GATT_SESSION_MAX_MS`.
+
+If the server did engage but the session still ends this way, the usual cause is a server not in continuous mode: see the autonomous-connect note above.
 
 ### A random-address scale times out on connect
 

--- a/docs/guide/esphome-proxy.md
+++ b/docs/guide/esphome-proxy.md
@@ -168,6 +168,20 @@ If a GATT scale still does not produce readings:
   scale's advertisement) with every GATT connect, and falls back to the other
   type if the first attempt is refused. Update to the latest version if you
   still see this on older builds.
+- **The scale connects and is written to, then stays silent:** resolved. The
+  proxy's notify registration only routes notifications the ESP32 receives; the
+  0x2902 descriptor still has to be written for the scale to send any, and that
+  write was missing, so strict firmware (QN, Renpho) never streamed a byte
+  ([#252](https://github.com/KristianP26/ble-scale-sync/issues/252)). A related
+  bug decoded every GATT payload as empty
+  ([#291](https://github.com/KristianP26/ble-scale-sync/issues/291)). Both are
+  fixed; with `debug: true` you now get a `cccd=` line per characteristic and an
+  explicit `ESPHome CCCD write ...` line.
+- **The scale needs a bonded or encrypted link:** the ESPHome proxy does not
+  bond, so a scale that demands encryption for its notifications (the Beurer
+  BF7xx consent family, for example) cannot be read over this transport. With
+  debug on it shows as `ESPHome GATT error: handle 0x.. status=5` (or `15`)
+  right after the CCCD write. Those scales need the native Linux BlueZ path.
 
 ### Multiple ESPHome proxies (mesh)
 

--- a/firmware/ble_bridge.py
+++ b/firmware/ble_bridge.py
@@ -582,23 +582,45 @@ class BleBridge:
         if not char:
             return
 
+        can_notify = bool(char.properties & bluetooth.FLAG_NOTIFY)
+        can_indicate = bool(char.properties & bluetooth.FLAG_INDICATE)
+        if not can_notify and not can_indicate:
+            # Nothing to consume: no CCCD to write and notified()/indicated()
+            # would both raise ValueError("Unsupported"). Skip cleanly.
+            print(f"Subscribe: {uuid_str} supports neither notify nor indicate, skipping")
+            return
+
         # Enable notify/indicate on the peripheral. aioble's notified() only
         # consumes events; it does not turn on the CCCD bit itself.
         print(f"Subscribe: enabling CCCD for {uuid_str}")
         try:
-            await char.subscribe(
-                notify=bool(char.properties & bluetooth.FLAG_NOTIFY),
-                indicate=bool(char.properties & bluetooth.FLAG_INDICATE),
-            )
+            await char.subscribe(notify=can_notify, indicate=can_indicate)
         except Exception as e:
             print(f"Subscribe: CCCD enable failed for {uuid_str}: {type(e).__name__}: {e}")
             raise
         print(f"Subscribe: CCCD enabled for {uuid_str}")
 
+        # Read from the queue the characteristic actually feeds. aioble's
+        # notified() raises ValueError("Unsupported") on an indicate-only char
+        # (Robi S9 FFB3 result), which killed the read task and left the final
+        # A3 frame undelivered (#248). A char exposing BOTH flags is drained via
+        # notified() by convention; this assumes such a device streams via
+        # notify rather than indicate, which holds for every registry scale.
+        prefer_indicate = can_indicate and not can_notify
+
         async def _notify_loop():
             try:
                 while self._conn and self._conn.is_connected():
-                    data = await char.notified(timeout_ms=10000)
+                    try:
+                        if prefer_indicate:
+                            data = await char.indicated(timeout_ms=10000)
+                        else:
+                            data = await char.notified(timeout_ms=10000)
+                    except asyncio.TimeoutError:
+                        # No data in the 10s window but the link is still up
+                        # (the final result frame can lag the live stream).
+                        # Re-arm instead of killing the reader for good (#248).
+                        continue
                     if data:
                         await publish_fn(uuid_str, bytes(data))
             except asyncio.CancelledError:

--- a/firmware/ble_bridge.py
+++ b/firmware/ble_bridge.py
@@ -245,6 +245,25 @@ class BleBridge:
         self._on_disconnect = callback
         self._disconnect_fired = False
 
+    def is_connected(self):
+        """True while the GATT link is up. Never raises."""
+        try:
+            return bool(self._conn and self._conn.is_connected())
+        except Exception:
+            return False
+
+    def notify_disconnected(self):
+        """Fire the disconnect callback once, from any producer.
+
+        With lazy notify the notify loop may never start, so it cannot be the
+        only path that reports a dead session (#296).
+        """
+        if self._disconnect_fired:
+            return
+        self._disconnect_fired = True
+        if self._on_disconnect:
+            self._on_disconnect()
+
     async def scan(self, duration_ms=None):
         """Scan for BLE peripherals using raw BLE API (batch mode).
 
@@ -628,10 +647,8 @@ class BleBridge:
             except Exception as e:
                 print(f"Notify loop error ({uuid_str}): {e}")
             # Fire disconnect callback once if connection was lost (not cancelled)
-            if not self._disconnect_fired and self._conn and not self._conn.is_connected():
-                self._disconnect_fired = True
-                if self._on_disconnect:
-                    self._on_disconnect()
+            if self._conn and not self._conn.is_connected():
+                self.notify_disconnected()
 
         task = asyncio.create_task(_notify_loop())
         self._notify_tasks.append(task)

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -38,6 +38,16 @@ _busy = False
 # Pause autonomous scanning when a GATT connection is active
 _scan_paused = False
 
+# GATT session guard (#296). A session the host never engages with used to park
+# the scan loop until the ESP32 was reset: with lazy notify no notify reader is
+# running, and the notify reader is the only thing that reported a dead link.
+GATT_SESSION_IDLE_MS = getattr(board, "GATT_SESSION_IDLE_MS", 20000)
+GATT_SESSION_MAX_MS = getattr(board, "GATT_SESSION_MAX_MS", 180000)
+_gatt_session_task = None
+# Set the moment a 'connected' event is published, cleared when the session ends.
+_gatt_session_armed = False
+_last_host_activity = 0
+
 # Set True after on_connect finishes re-subscribing (avoids race with isconnected)
 _subs_ready = False
 
@@ -83,7 +93,7 @@ mqtt_config["queue_len"] = 0  # callback mode
 
 def on_message(topic_bytes, msg, retained):
     """Sync callback — queue the command for async processing."""
-    global _scale_macs, _auto_connect, _lazy_notify
+    global _scale_macs, _auto_connect, _lazy_notify, _last_host_activity
     t = topic_bytes.decode() if isinstance(topic_bytes, (bytes, bytearray)) else topic_bytes
     if t == topic("config"):
         try:
@@ -98,6 +108,8 @@ def on_message(topic_bytes, msg, retained):
         except Exception as e:
             print(f"Bad config payload: {e}")
         return
+    # Any host command counts as engagement with the current GATT session (#296).
+    _last_host_activity = time.ticks_ms()
     _pending.append((t, msg))
 
 
@@ -207,6 +219,53 @@ def _find_scale_in_raw(raw_results):
     return None
 
 
+async def _gatt_session_guard():
+    """End a GATT session the host never finishes, so scanning resumes (#296).
+
+    Gives up when the link is already down, when no host command has arrived for
+    GATT_SESSION_IDLE_MS, or when the session outlives GATT_SESSION_MAX_MS. The
+    recovery path is the existing unexpected-disconnect handler, reached through
+    the same callback the notify loop uses.
+    """
+    global _gatt_session_task
+    started = time.ticks_ms()
+    try:
+        while _scan_paused:
+            await asyncio.sleep_ms(1000)
+            # A BLE operation is in flight; it owns the session for now.
+            if _busy:
+                continue
+            if not _scan_paused:
+                return
+            now = time.ticks_ms()
+            reason = None
+            if not bridge.is_connected():
+                reason = "link is down"
+            elif time.ticks_diff(now, _last_host_activity) > GATT_SESSION_IDLE_MS:
+                reason = f"no host command for {GATT_SESSION_IDLE_MS}ms"
+            elif time.ticks_diff(now, started) > GATT_SESSION_MAX_MS:
+                reason = f"session exceeded {GATT_SESSION_MAX_MS}ms"
+            if reason:
+                print(f"GATT session guard: {reason}, ending session and resuming scan")
+                bridge.notify_disconnected()
+                return
+    except asyncio.CancelledError:
+        pass
+    except Exception as e:
+        print(f"GATT session guard error: {describe_exc(e)}")
+    finally:
+        _gatt_session_task = None
+
+
+def _arm_session_guard():
+    """Start the session guard for the session just published to the host."""
+    global _gatt_session_task, _gatt_session_armed, _last_host_activity
+    _gatt_session_armed = True
+    _last_host_activity = time.ticks_ms()
+    if _gatt_session_task is None:
+        _gatt_session_task = asyncio.create_task(_gatt_session_guard())
+
+
 async def _auto_gatt_connect(mac, addr_type):
     """Autonomously connect to a known scale and publish the connected event.
 
@@ -247,6 +306,7 @@ async def _auto_gatt_connect(mac, addr_type):
         result["autonomous"] = True
         result["address"] = mac
         await client.publish(topic("connected"), json.dumps(result), qos=0)
+        _arm_session_guard()
         print(f"Auto-connect to {mac} succeeded, {len(result['chars'])} chars published to host")
     except Exception as e:
         import sys
@@ -278,6 +338,12 @@ async def _streaming_scan_loop():
             await asyncio.sleep(1)
 
         if _scan_paused:
+            # Backstop for a paused scan with no guard running: only ever true
+            # for a session that was published to the host, so it cannot fire
+            # in the window where a connect has paused scanning but not yet
+            # taken _busy (#296).
+            if _gatt_session_armed and _gatt_session_task is None and not _busy:
+                await handle_unexpected_disconnect()
             await asyncio.sleep(1)
             continue
 
@@ -352,6 +418,9 @@ async def _batch_scan_loop():
 
         # Skip if a GATT connection is active or another BLE op is in progress
         if _scan_paused or _busy:
+            # Same backstop as the streaming loop (#296).
+            if _scan_paused and _gatt_session_armed and _gatt_session_task is None and not _busy:
+                await handle_unexpected_disconnect()
             await asyncio.sleep(1)
             continue
 
@@ -478,6 +547,7 @@ async def handle_connect(payload):
 
         bridge.set_on_disconnect(lambda: _pending.append(("__ble_disconnected__", b"")))
         await client.publish(topic("connected"), json.dumps(result), qos=0)
+        _arm_session_guard()
     except Exception as e:
         _scan_paused = False  # Resume scanning on connect failure
         if board.CONTINUOUS_SCAN:
@@ -489,7 +559,8 @@ async def handle_connect(payload):
 
 async def handle_disconnect():
     """Disconnect from BLE device and resume autonomous scanning."""
-    global _char_subscribed, _scan_paused
+    global _char_subscribed, _scan_paused, _gatt_session_armed
+    _gatt_session_armed = False
     await bridge.disconnect()
     _char_subscribed = False
     _scan_paused = False  # Resume autonomous scanning
@@ -499,8 +570,9 @@ async def handle_disconnect():
 
 
 async def handle_unexpected_disconnect():
-    """Handle unexpected BLE peripheral disconnect — notify TS, resume scanning."""
-    global _char_subscribed, _scan_paused
+    """Handle unexpected BLE peripheral disconnect, notify the host, resume scanning."""
+    global _char_subscribed, _scan_paused, _gatt_session_armed
+    _gatt_session_armed = False
     print("BLE peripheral disconnected unexpectedly")
     await bridge.disconnect()
     _char_subscribed = False

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -46,6 +46,10 @@ GATT_SESSION_MAX_MS = getattr(board, "GATT_SESSION_MAX_MS", 180000)
 _gatt_session_task = None
 # Set the moment a 'connected' event is published, cleared when the session ends.
 _gatt_session_armed = False
+# True once the host has sent any command for the current session. A host that
+# has engaged is then silent by design while it waits for notifications, so the
+# idle timeout must never apply to it, only to a session nobody ever answered.
+_host_engaged = False
 _last_host_activity = 0
 
 # Set True after on_connect finishes re-subscribing (avoids race with isconnected)
@@ -93,7 +97,7 @@ mqtt_config["queue_len"] = 0  # callback mode
 
 def on_message(topic_bytes, msg, retained):
     """Sync callback — queue the command for async processing."""
-    global _scale_macs, _auto_connect, _lazy_notify, _last_host_activity
+    global _scale_macs, _auto_connect, _lazy_notify, _last_host_activity, _host_engaged
     t = topic_bytes.decode() if isinstance(topic_bytes, (bytes, bytearray)) else topic_bytes
     if t == topic("config"):
         try:
@@ -110,6 +114,8 @@ def on_message(topic_bytes, msg, retained):
         return
     # Any host command counts as engagement with the current GATT session (#296).
     _last_host_activity = time.ticks_ms()
+    if _gatt_session_armed:
+        _host_engaged = True
     _pending.append((t, msg))
 
 
@@ -241,8 +247,14 @@ async def _gatt_session_guard():
             reason = None
             if not bridge.is_connected():
                 reason = "link is down"
-            elif time.ticks_diff(now, _last_host_activity) > GATT_SESSION_IDLE_MS:
-                reason = f"no host command for {GATT_SESSION_IDLE_MS}ms"
+            elif (
+                not _host_engaged
+                and time.ticks_diff(now, _last_host_activity) > GATT_SESSION_IDLE_MS
+            ):
+                # Only a session the host never answered. Once it has subscribed
+                # and written its handshake it just listens, often for the whole
+                # weigh-in, so an idle timeout there would kill working setups.
+                reason = f"host never engaged within {GATT_SESSION_IDLE_MS}ms"
             elif time.ticks_diff(now, started) > GATT_SESSION_MAX_MS:
                 reason = f"session exceeded {GATT_SESSION_MAX_MS}ms"
             if reason:
@@ -259,11 +271,27 @@ async def _gatt_session_guard():
 
 def _arm_session_guard():
     """Start the session guard for the session just published to the host."""
-    global _gatt_session_task, _gatt_session_armed, _last_host_activity
+    global _gatt_session_task, _gatt_session_armed, _last_host_activity, _host_engaged
     _gatt_session_armed = True
+    _host_engaged = False
     _last_host_activity = time.ticks_ms()
     if _gatt_session_task is None:
         _gatt_session_task = asyncio.create_task(_gatt_session_guard())
+
+
+def _resume_scanning():
+    """Leave the GATT session state and restart autonomous scanning.
+
+    Clearing `_scan_paused` without clearing `_gatt_session_armed` would leave
+    the scan loops believing a session is live, so these always move together
+    (#296).
+    """
+    global _scan_paused, _gatt_session_armed, _host_engaged
+    _scan_paused = False
+    _gatt_session_armed = False
+    _host_engaged = False
+    if board.CONTINUOUS_SCAN:
+        bridge.start_streaming()
 
 
 async def _auto_gatt_connect(mac, addr_type):
@@ -313,9 +341,8 @@ async def _auto_gatt_connect(mac, addr_type):
 
         sys.print_exception(e)
         print(f"Auto-connect failed for {mac}: {describe_exc(e)}")
-        _scan_paused = False
+        _resume_scanning()
         if board.CONTINUOUS_SCAN:
-            bridge.start_streaming()
             print(f"Auto-connect: resumed streaming scan after failure")
         await publish_error(f"Auto-connect failed for {mac}: {describe_exc(e)}")
     finally:
@@ -516,7 +543,7 @@ async def handle_connect(payload):
     # host-initiated fallback connect (#231) re-enters aioble on the same bridge
     # concurrently, which can abort the connect mid-flight.
     if not await _wait_not_busy():
-        _scan_paused = False
+        _resume_scanning()
         await publish_error("Busy: another BLE operation is in progress")
         return
 
@@ -549,9 +576,7 @@ async def handle_connect(payload):
         await client.publish(topic("connected"), json.dumps(result), qos=0)
         _arm_session_guard()
     except Exception as e:
-        _scan_paused = False  # Resume scanning on connect failure
-        if board.CONTINUOUS_SCAN:
-            bridge.start_streaming()
+        _resume_scanning()  # Resume scanning on connect failure
         raise e
     finally:
         _busy = False
@@ -559,26 +584,20 @@ async def handle_connect(payload):
 
 async def handle_disconnect():
     """Disconnect from BLE device and resume autonomous scanning."""
-    global _char_subscribed, _scan_paused, _gatt_session_armed
-    _gatt_session_armed = False
+    global _char_subscribed
     await bridge.disconnect()
     _char_subscribed = False
-    _scan_paused = False  # Resume autonomous scanning
-    if board.CONTINUOUS_SCAN:
-        bridge.start_streaming()
+    _resume_scanning()  # Resume autonomous scanning
     await client.publish(topic("disconnected"), "", qos=0)
 
 
 async def handle_unexpected_disconnect():
     """Handle unexpected BLE peripheral disconnect, notify the host, resume scanning."""
-    global _char_subscribed, _scan_paused, _gatt_session_armed
-    _gatt_session_armed = False
+    global _char_subscribed
     print("BLE peripheral disconnected unexpectedly")
     await bridge.disconnect()
     _char_subscribed = False
-    _scan_paused = False
-    if board.CONTINUOUS_SCAN:
-        bridge.start_streaming()
+    _resume_scanning()
     await client.publish(topic("disconnected"), "", qos=0)
 
 

--- a/firmware/tests/test_connect_irq.py
+++ b/firmware/tests/test_connect_irq.py
@@ -101,21 +101,55 @@ class _FakeChar:
 
 
 class _SubscribableFakeChar:
-    """Models aioble's ClientCharacteristic subscribe/notified surface. Records
-    whether subscribe() was awaited and with which CCCD flags, and lets the
-    notify loop block until cancelled so tests can assert on the subscribe call
-    without the loop racing ahead (#231)."""
+    """Models aioble's ClientCharacteristic subscribe/notified/indicated surface.
+    Records whether subscribe() was awaited and with which CCCD flags, counts
+    notified()/indicated() calls, and mirrors aioble's _check(): notified()
+    requires FLAG_NOTIFY and indicated() requires FLAG_INDICATE, else both raise
+    ValueError("Unsupported") (#248). With *_data set, the matching read returns
+    it once; otherwise it blocks until cancelled so subscribe-only tests can
+    assert without the loop racing ahead (#231)."""
 
-    def __init__(self, uuid, properties):
+    def __init__(
+        self, uuid, properties, indicate_data=None, notify_data=None,
+        timeouts_before_data=0,
+    ):
         self.uuid = uuid
         self.properties = properties
         self.subscribed = []  # list of (notify, indicate) tuples
+        self.notified_calls = 0
+        self.indicated_calls = 0
+        self._indicate_data = indicate_data
+        self._notify_data = notify_data
+        # Number of leading reads that raise asyncio.TimeoutError (10s idle)
+        # before data is delivered, mirroring aioble's DeviceTimeout (#248).
+        self._timeouts = timeouts_before_data
 
     async def subscribe(self, notify=True, indicate=False):
         self.subscribed.append((notify, indicate))
 
+    def _maybe_timeout(self):
+        if self._timeouts > 0:
+            self._timeouts -= 1
+            raise asyncio.TimeoutError
+
     async def notified(self, timeout_ms=None):
-        # Block forever; real firmware loops until cancelled/disconnected.
+        self.notified_calls += 1
+        if not (self.properties & _bt.FLAG_NOTIFY):
+            raise ValueError("Unsupported")
+        self._maybe_timeout()
+        if self._notify_data is not None:
+            data, self._notify_data = self._notify_data, None
+            return data
+        await asyncio.Event().wait()
+
+    async def indicated(self, timeout_ms=None):
+        self.indicated_calls += 1
+        if not (self.properties & _bt.FLAG_INDICATE):
+            raise ValueError("Unsupported")
+        self._maybe_timeout()
+        if self._indicate_data is not None:
+            data, self._indicate_data = self._indicate_data, None
+            return data
         await asyncio.Event().wait()
 
 
@@ -402,6 +436,105 @@ class TestStartNotifySubscribesCccd(unittest.IsolatedAsyncioTestCase):
         await bridge.start_notify(char.uuid, publish_fn)
         self.assertEqual(char.subscribed, [(False, True)])
         await bridge.disconnect()
+
+    async def test_indicate_only_char_read_via_indicated(self):
+        """An indicate-only char (Robi S9 FFB3 result) must be read with
+        indicated(); the old code called notified() which raises
+        Unsupported, killing the loop before the A3 frame arrived (#248)."""
+        bridge = ble_bridge.BleBridge()
+        char = _SubscribableFakeChar(
+            "0000ffb3-0000-1000-8000-00805f9b34fb",
+            _bt.FLAG_INDICATE,
+            indicate_data=b"\xaa\x02\x00\xa3\x30\x00\x00\x00",
+        )
+        bridge._chars[char.uuid] = char
+        bridge._conn = _FakeConn()
+
+        got = []
+        done = asyncio.Event()
+
+        async def publish_fn(uuid, data):
+            got.append((uuid, data))
+            done.set()
+
+        await bridge.start_notify(char.uuid, publish_fn)
+        await asyncio.wait_for(done.wait(), 1.0)
+        self.assertGreaterEqual(char.indicated_calls, 1)
+        self.assertEqual(char.notified_calls, 0)  # notify queue never touched
+        self.assertEqual(got, [(char.uuid, b"\xaa\x02\x00\xa3\x30\x00\x00\x00")])
+        await bridge.disconnect()
+
+    async def test_read_rearms_after_timeout(self):
+        """A 10s idle raises asyncio.TimeoutError; the loop must re-arm and keep
+        reading while connected, not die and drop a late final frame (#248)."""
+        bridge = ble_bridge.BleBridge()
+        char = _SubscribableFakeChar(
+            "0000ffb3-0000-1000-8000-00805f9b34fb",
+            _bt.FLAG_INDICATE,
+            indicate_data=b"\xaa\x02\x00\xa3\x30\x00\x00\x00",
+            timeouts_before_data=1,
+        )
+        bridge._chars[char.uuid] = char
+        bridge._conn = _FakeConn()
+
+        got = []
+        done = asyncio.Event()
+
+        async def publish_fn(uuid, data):
+            got.append((uuid, data))
+            done.set()
+
+        await bridge.start_notify(char.uuid, publish_fn)
+        await asyncio.wait_for(done.wait(), 1.0)
+        self.assertGreaterEqual(char.indicated_calls, 2)  # timed out once, then delivered
+        self.assertEqual(got, [(char.uuid, b"\xaa\x02\x00\xa3\x30\x00\x00\x00")])
+        await bridge.disconnect()
+
+    async def test_dual_notify_indicate_char_read_via_notified(self):
+        """A char exposing BOTH notify and indicate is drained via notified()
+        (streaming push, no per-frame ATT confirmation). Locks the design
+        choice so a refactor cannot silently flip it to indicated() (#248)."""
+        bridge = ble_bridge.BleBridge()
+        char = _SubscribableFakeChar(
+            "0000fff1-0000-1000-8000-00805f9b34fb",
+            _bt.FLAG_NOTIFY | _bt.FLAG_INDICATE,
+            notify_data=b"\x10\x20",
+        )
+        bridge._chars[char.uuid] = char
+        bridge._conn = _FakeConn()
+
+        got = []
+        done = asyncio.Event()
+
+        async def publish_fn(uuid, data):
+            got.append((uuid, data))
+            done.set()
+
+        await bridge.start_notify(char.uuid, publish_fn)
+        await asyncio.wait_for(done.wait(), 1.0)
+        self.assertGreaterEqual(char.notified_calls, 1)
+        self.assertEqual(char.indicated_calls, 0)
+        self.assertEqual(got, [(char.uuid, b"\x10\x20")])
+        await bridge.disconnect()
+
+    async def test_neither_flag_char_is_skipped(self):
+        """A char with neither notify nor indicate must not be subscribed and
+        must not spawn a read task that would raise Unsupported (#248 guard)."""
+        bridge = ble_bridge.BleBridge()
+        char = _SubscribableFakeChar(
+            "0000dead-0000-1000-8000-00805f9b34fb", _bt.FLAG_READ
+        )
+        bridge._chars[char.uuid] = char
+        bridge._conn = _FakeConn()
+
+        async def publish_fn(_uuid, _data):
+            pass
+
+        await bridge.start_notify(char.uuid, publish_fn)
+        self.assertEqual(char.subscribed, [])
+        self.assertEqual(bridge._notify_tasks, [])
+        # No disconnect() cleanup needed: the guard returns before any read task
+        # is spawned, so there is nothing to cancel.
 
     async def test_missing_char_is_noop(self):
         bridge = ble_bridge.BleBridge()

--- a/firmware/tests/test_session_guard.py
+++ b/firmware/tests/test_session_guard.py
@@ -179,8 +179,36 @@ class SessionGuardTest(unittest.TestCase):
 
     def test_guard_ends_the_session_when_the_host_never_engages(self):
         main.GATT_SESSION_IDLE_MS = 0  # any elapsed time counts as idle
+        main._host_engaged = False
         asyncio.run(main._gatt_session_guard())
         self.assertEqual(self.bridge.fired, 1)
+
+    def test_guard_never_touches_a_session_the_host_engaged_with(self):
+        # The host subscribes and writes its handshake, then listens in silence
+        # for the rest of the weigh-in. An idle timeout there would abort every
+        # working mqtt-proxy reading that takes longer than the idle window.
+        main.GATT_SESSION_IDLE_MS = 0
+        main._host_engaged = True
+
+        async def scenario():
+            task = asyncio.create_task(main._gatt_session_guard())
+            await asyncio.sleep(1.3)
+            self.assertEqual(self.bridge.fired, 0)
+            task.cancel()
+
+        asyncio.run(scenario())
+
+    def test_a_host_command_marks_the_armed_session_as_engaged(self):
+        main._gatt_session_armed = True
+        main._host_engaged = False
+        main.on_message(main.topic("subscribe/0000fff1").encode(), b"", False)
+        self.assertTrue(main._host_engaged)
+
+    def test_a_host_command_outside_a_session_does_not_mark_engagement(self):
+        main._gatt_session_armed = False
+        main._host_engaged = False
+        main.on_message(main.topic("connect").encode(), b"{}", False)
+        self.assertFalse(main._host_engaged)
 
     def test_guard_stays_armed_while_the_host_keeps_sending_commands(self):
         main.GATT_SESSION_IDLE_MS = 3000
@@ -240,6 +268,55 @@ class SessionGuardTest(unittest.TestCase):
 
     def test_host_disconnect_clears_the_armed_flag(self):
         asyncio.run(main.handle_disconnect())
+        self.assertFalse(main._gatt_session_armed)
+        self.assertFalse(main._scan_paused)
+
+    def test_resume_scanning_clears_scan_paused_and_armed_together(self):
+        # A resume path that cleared only _scan_paused left the scan loops
+        # believing a session was live: scanning then ran underneath the next
+        # GATT session and the backstop published a phantom disconnect.
+        main._scan_paused = True
+        main._gatt_session_armed = True
+        main._host_engaged = True
+        main._resume_scanning()
+        self.assertFalse(main._scan_paused)
+        self.assertFalse(main._gatt_session_armed)
+        self.assertFalse(main._host_engaged)
+        self.assertTrue(self.bridge.streaming)
+
+    def test_a_failed_host_connect_leaves_no_armed_session(self):
+        async def scenario():
+            self.bridge.connect = None  # attribute error inside handle_connect
+            main._gatt_session_armed = True
+            main._scan_paused = True
+            try:
+                await main.handle_connect(b'{"address": "AA:BB:CC:DD:EE:FF"}')
+            except Exception:
+                pass
+
+        asyncio.run(scenario())
+        self.assertFalse(main._gatt_session_armed)
+        self.assertFalse(main._scan_paused)
+
+    def test_a_busy_timeout_leaves_no_armed_session(self):
+        async def scenario():
+            main._busy = True
+            main._gatt_session_armed = True
+            main._scan_paused = True
+            await main.handle_connect(b'{"address": "AA:BB:CC:DD:EE:FF"}')
+
+        orig = main._wait_not_busy
+
+        async def never_free(*a, **k):
+            return False
+
+        main._wait_not_busy = never_free
+        try:
+            asyncio.run(scenario())
+        finally:
+            main._wait_not_busy = orig
+            main._busy = False
+
         self.assertFalse(main._gatt_session_armed)
         self.assertFalse(main._scan_paused)
 

--- a/firmware/tests/test_session_guard.py
+++ b/firmware/tests/test_session_guard.py
@@ -1,0 +1,276 @@
+"""Host-runnable tests for the GATT session guard in main.py (#296).
+
+Before this guard, a session the host never engaged with parked the scan loop
+until the ESP32 was reset: with lazy notify no notify reader runs, and that
+reader was the only producer of the disconnect callback.
+
+Run: python -m unittest discover -s firmware/tests
+"""
+
+import asyncio
+import os
+import sys
+import types
+import unittest
+
+_FIRMWARE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _FIRMWARE_DIR not in sys.path:
+    sys.path.insert(0, _FIRMWARE_DIR)
+
+# Stub MicroPython-only modules before importing anything from firmware.
+sys.modules.setdefault("aioble", types.ModuleType("aioble"))
+if "bluetooth" not in sys.modules:
+    _bt = types.ModuleType("bluetooth")
+    _bt.BLE = lambda: None
+    sys.modules["bluetooth"] = _bt
+
+if "board" not in sys.modules:
+    _board = types.ModuleType("board")
+    _board.HAS_BEEP = False
+    _board.HAS_DISPLAY = False
+    _board.CONTINUOUS_SCAN = True
+    _board.PUBLISH_INTERVAL_MS = 2000
+    _board.SCAN_INTERVAL_MS = 5000
+    _board.DEACTIVATE_BLE_AFTER_SCAN = False
+    _board.GC_INTERVAL = 100
+    _board.MAX_SCAN_ENTRIES = 500
+    _board.BOARD_NAME = "test"
+    _board.on_scan_complete = lambda *a: None
+    sys.modules["board"] = _board
+
+if "mqtt_as" not in sys.modules:
+    _mqtt_as = types.ModuleType("mqtt_as")
+    _mqtt_as.config = {}
+
+    class _FakeMQTTClient:
+        def __init__(self, cfg):
+            pass
+
+        async def connect(self):
+            raise RuntimeError("test stub: not connecting")
+
+    _mqtt_as.MQTTClient = _FakeMQTTClient
+    sys.modules["mqtt_as"] = _mqtt_as
+
+if "ble_bridge" not in sys.modules:
+    _ble_bridge = types.ModuleType("ble_bridge")
+    _ble_bridge.BleBridge = lambda: types.SimpleNamespace(
+        start_streaming=lambda: None,
+        stop_streaming=lambda: None,
+        has_pending_scale_mac=lambda macs: False,
+        drain_results=lambda: [],
+        _raw_results=[],
+    )
+    sys.modules["ble_bridge"] = _ble_bridge
+
+import json  # noqa: E402
+
+_config_path = os.path.join(_FIRMWARE_DIR, "config.json")
+_config_existed = os.path.exists(_config_path)
+_orig_cwd = os.getcwd()
+if not _config_existed:
+    with open(_config_path, "w") as f:
+        json.dump(
+            {
+                "topic_prefix": "test",
+                "device_id": "test",
+                "wifi_ssid": "",
+                "wifi_password": "",
+                "mqtt_broker": "localhost",
+                "mqtt_port": 1883,
+            },
+            f,
+        )
+
+os.chdir(_FIRMWARE_DIR)
+try:
+    import main  # noqa: E402
+finally:
+    os.chdir(_orig_cwd)
+    if not _config_existed:
+        os.remove(_config_path)
+
+if not hasattr(asyncio, "sleep_ms"):
+    asyncio.sleep_ms = lambda ms: asyncio.sleep(ms / 1000)
+
+# MicroPython's time.ticks_ms / ticks_diff are not in CPython's time module.
+import time as _time  # noqa: E402
+
+if not hasattr(_time, "ticks_ms"):
+    _time.ticks_ms = lambda: int(_time.monotonic() * 1000)
+    _time.ticks_diff = lambda a, b: a - b
+
+
+class _FakeBridge:
+    def __init__(self, connected=True):
+        self.connected = connected
+        self.disconnect_calls = 0
+        self.fired = 0
+        self._cb = None
+        self.streaming = False
+
+    def is_connected(self):
+        return self.connected
+
+    def set_on_disconnect(self, cb):
+        self._cb = cb
+
+    def notify_disconnected(self):
+        self.fired += 1
+        if self._cb:
+            self._cb()
+
+    def start_streaming(self):
+        self.streaming = True
+
+    def stop_streaming(self):
+        self.streaming = False
+
+    async def disconnect(self):
+        self.disconnect_calls += 1
+        self.connected = False
+
+
+class _FakeClient:
+    def __init__(self):
+        self.published = []
+
+    async def publish(self, topic, payload, qos=0):
+        self.published.append((topic, payload))
+
+    def isconnected(self):
+        return True
+
+    async def subscribe(self, *a):
+        return None
+
+
+class SessionGuardTest(unittest.TestCase):
+    def setUp(self):
+        self.bridge = _FakeBridge()
+        self.client = _FakeClient()
+        self._orig_bridge = main.bridge
+        self._orig_client = main.client
+        self._orig_idle = main.GATT_SESSION_IDLE_MS
+        self._orig_max = main.GATT_SESSION_MAX_MS
+        main.bridge = self.bridge
+        main.client = self.client
+        main._pending = []
+        main._scan_paused = True
+        main._busy = False
+        main._gatt_session_task = None
+        main._gatt_session_armed = True
+        main._last_host_activity = _time.ticks_ms()
+
+    def tearDown(self):
+        main.bridge = self._orig_bridge
+        main.client = self._orig_client
+        main.GATT_SESSION_IDLE_MS = self._orig_idle
+        main.GATT_SESSION_MAX_MS = self._orig_max
+        main._scan_paused = False
+        main._gatt_session_armed = False
+        main._gatt_session_task = None
+
+    def test_guard_ends_the_session_when_the_link_is_already_down(self):
+        self.bridge.connected = False
+        asyncio.run(main._gatt_session_guard())
+        self.assertEqual(self.bridge.fired, 1)
+        self.assertEqual(main._gatt_session_task, None)
+
+    def test_guard_ends_the_session_when_the_host_never_engages(self):
+        main.GATT_SESSION_IDLE_MS = 0  # any elapsed time counts as idle
+        asyncio.run(main._gatt_session_guard())
+        self.assertEqual(self.bridge.fired, 1)
+
+    def test_guard_stays_armed_while_the_host_keeps_sending_commands(self):
+        main.GATT_SESSION_IDLE_MS = 3000
+
+        async def scenario():
+            task = asyncio.create_task(main._gatt_session_guard())
+            for _ in range(3):
+                await asyncio.sleep(0.4)
+                main._last_host_activity = _time.ticks_ms()
+            self.assertEqual(self.bridge.fired, 0)
+            main._scan_paused = False
+            await asyncio.sleep(1.1)
+            task.cancel()
+
+        asyncio.run(scenario())
+        self.assertEqual(self.bridge.fired, 0)
+
+    def test_guard_exits_when_the_session_ends_normally(self):
+        async def scenario():
+            main._scan_paused = False
+            await main._gatt_session_guard()
+
+        asyncio.run(scenario())
+        self.assertEqual(self.bridge.fired, 0)
+        self.assertEqual(main._gatt_session_task, None)
+
+    def test_guard_does_not_act_while_a_ble_operation_is_in_flight(self):
+        main._busy = True
+        main.GATT_SESSION_IDLE_MS = 0
+        self.bridge.connected = False
+
+        async def scenario():
+            task = asyncio.create_task(main._gatt_session_guard())
+            await asyncio.sleep(1.3)
+            self.assertEqual(self.bridge.fired, 0)
+            task.cancel()
+
+        asyncio.run(scenario())
+
+    def test_arm_session_guard_starts_one_task_only(self):
+        async def scenario():
+            main._arm_session_guard()
+            first = main._gatt_session_task
+            main._arm_session_guard()
+            self.assertIs(main._gatt_session_task, first)
+            self.assertTrue(main._gatt_session_armed)
+            main._gatt_session_task.cancel()
+
+        asyncio.run(scenario())
+
+    def test_unexpected_disconnect_clears_the_armed_flag_and_resumes_scanning(self):
+        asyncio.run(main.handle_unexpected_disconnect())
+        self.assertFalse(main._gatt_session_armed)
+        self.assertFalse(main._scan_paused)
+        self.assertTrue(self.bridge.streaming)
+        self.assertIn((main.topic("disconnected"), ""), self.client.published)
+
+    def test_host_disconnect_clears_the_armed_flag(self):
+        asyncio.run(main.handle_disconnect())
+        self.assertFalse(main._gatt_session_armed)
+        self.assertFalse(main._scan_paused)
+
+
+class BridgeDisconnectTest(unittest.TestCase):
+    """BleBridge.notify_disconnected fires the callback at most once."""
+
+    def test_notify_disconnected_fires_once(self):
+        sys.path.insert(0, _FIRMWARE_DIR)
+        calls = []
+
+        class _Stub:
+            _disconnect_fired = False
+            _on_disconnect = None
+
+        from ble_bridge import BleBridge  # noqa: PLC0415
+
+        stub = _Stub()
+        stub._on_disconnect = lambda: calls.append(1)
+        BleBridge.notify_disconnected(stub)
+        BleBridge.notify_disconnected(stub)
+        self.assertEqual(len(calls), 1)
+
+    def test_is_connected_is_false_without_a_connection(self):
+        from ble_bridge import BleBridge  # noqa: PLC0415
+
+        class _Stub:
+            _conn = None
+
+        self.assertFalse(BleBridge.is_connected(_Stub()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "scan": "tsx src/scan.ts",
     "diagnose": "tsx src/diagnose.ts",
     "validate": "tsx src/config/validate-cli.ts",
+    "sync:addon-changelog": "tsx src/tools/sync-addon-changelog.ts",
+    "sync:addon-changelog:check": "tsx src/tools/sync-addon-changelog.ts check",
     "test": "vitest run",
     "lint": "eslint src tests",
     "lint:fix": "eslint src tests --fix",

--- a/src/ble/handler-esphome-proxy/client.ts
+++ b/src/ble/handler-esphome-proxy/client.ts
@@ -144,6 +144,15 @@ export interface EsphomeConnection {
     response: boolean,
   ): Promise<unknown>;
   notifyBluetoothGATTCharacteristicService(address: number, handle: number): Promise<unknown>;
+  /**
+   * ESPHome hardcodes response=true (ATT Write Request) for descriptor writes,
+   * so there is no `response` parameter here (#252).
+   */
+  writeBluetoothGATTDescriptorService(
+    address: number,
+    handle: number,
+    value: Uint8Array,
+  ): Promise<unknown>;
 }
 
 // ─── Client factory ──────────────────────────────────────────────────────────

--- a/src/ble/handler-esphome-proxy/esphome-gatt-proto.ts
+++ b/src/ble/handler-esphome-proxy/esphome-gatt-proto.ts
@@ -42,11 +42,20 @@ export function esphomeUuidToString(uuidList?: Array<string | number | bigint>):
  * with a pre-decoded `uuid` string. We prefer `uuid` and keep `uuidList` as a
  * fallback in case a different library version delivers the raw shape.
  */
+export interface EsphomeGattDescriptor {
+  uuid?: string;
+  uuidList?: Array<string | number | bigint>;
+  shortUuid?: number;
+  handle: number;
+}
+
 export interface EsphomeGattCharacteristic {
   uuid?: string;
   uuidList?: Array<string | number | bigint>;
   handle: number;
-  properties: number;
+  /** Optional so an unexpected library shape cannot break the whole session. */
+  properties?: number;
+  descriptorsList?: EsphomeGattDescriptor[];
 }
 
 export interface EsphomeGattService {
@@ -76,14 +85,61 @@ export interface EsphomeNotifyData {
  *
  * @2colors/esphome-native-api emits `message.toObject()` for GATT responses
  * unmapped, and protobuf-JS renders a `bytes` field as a base64 string named
- * `data` — never `dataList` (#291). Accept every shape the library could
+ * `data`, and never as `dataList` (#291). Accept every shape the library could
  * produce: base64 string, Uint8Array/Buffer, or a legacy `dataList` array.
+ *
+ * The empty-string guard matters: `data: ''` is a "field not used" sentinel in
+ * this library, not an empty payload. mapRawAdvertisement builds entries as
+ * `{ uuid, legacyDataList: [...], data: '' }`, so a `dataList` shape must still
+ * win over an empty `data` (the same precedence advert.ts already applies).
  */
 export function esphomeGattPayload(m: { data?: string | Uint8Array; dataList?: number[] }): Buffer {
-  if (typeof m.data === 'string') return Buffer.from(m.data, 'base64');
+  if (typeof m.data === 'string' && m.data.length > 0) return Buffer.from(m.data, 'base64');
   if (m.data instanceof Uint8Array) return Buffer.from(m.data);
   if (Array.isArray(m.dataList)) return Buffer.from(m.dataList);
   return Buffer.alloc(0);
+}
+
+/** Client Characteristic Configuration descriptor (CCCD). */
+export const CCCD_UUID = normalizeUuid('2902');
+/** CCCD value that enables notifications. */
+export const CCCD_NOTIFY = Uint8Array.from([0x01, 0x00]);
+/** CCCD value that enables indications. */
+export const CCCD_INDICATE = Uint8Array.from([0x02, 0x00]);
+
+const CHAR_PROP_NOTIFY = 0x10;
+const CHAR_PROP_INDICATE = 0x20;
+
+/**
+ * Find the handle of a characteristic's 0x2902 descriptor.
+ *
+ * ESPHome's bluetooth_proxy implements `bluetooth_gatt_notify` as
+ * `esp_ble_gattc_register_for_notify()`, which only tells the ESP32 to route
+ * notifications it receives. ESP-IDF leaves writing the CCC descriptor to the
+ * client, so without this handle the peripheral is never actually told to send
+ * anything (#252).
+ */
+export function findCccdHandle(ch: EsphomeGattCharacteristic): number | undefined {
+  for (const d of ch.descriptorsList ?? []) {
+    let uuid = d.uuid ? normalizeUuid(d.uuid) : esphomeUuidToString(d.uuidList);
+    if (!uuid && typeof d.shortUuid === 'number') uuid = esphomeUuidToString([d.shortUuid]);
+    if (uuid === CCCD_UUID) return d.handle;
+  }
+  return undefined;
+}
+
+/**
+ * CCCD payload for a characteristic's property bits, or undefined when it
+ * supports neither notify nor indicate. Notify wins when both bits are set,
+ * matching Home Assistant's own ESPHome BLE client.
+ */
+export function cccdValueFor(properties?: number): Uint8Array | undefined {
+  // Unknown library shape: notify is the safe default, it is what every
+  // notify-capable scale in the registry expects.
+  if (typeof properties !== 'number') return CCCD_NOTIFY;
+  if (properties & CHAR_PROP_NOTIFY) return CCCD_NOTIFY;
+  if (properties & CHAR_PROP_INDICATE) return CCCD_INDICATE;
+  return undefined;
 }
 
 export interface EsphomeDeviceConnection {

--- a/src/ble/handler-esphome-proxy/esphome-gatt-proto.ts
+++ b/src/ble/handler-esphome-proxy/esphome-gatt-proto.ts
@@ -64,7 +64,26 @@ export interface EsphomeGattServicesResponse {
 export interface EsphomeNotifyData {
   address: number;
   handle: number;
-  dataList: number[];
+  /** protobuf-JS `toObject()` renders the `bytes data = 3` field as a base64
+   * string named `data`; some historical library shapes used a `dataList`
+   * number array instead. Both are optional so either shape type-checks. */
+  data?: string | Uint8Array;
+  dataList?: number[];
+}
+
+/**
+ * Decode the payload of an ESPHome GATT read/notify response.
+ *
+ * @2colors/esphome-native-api emits `message.toObject()` for GATT responses
+ * unmapped, and protobuf-JS renders a `bytes` field as a base64 string named
+ * `data` — never `dataList` (#291). Accept every shape the library could
+ * produce: base64 string, Uint8Array/Buffer, or a legacy `dataList` array.
+ */
+export function esphomeGattPayload(m: { data?: string | Uint8Array; dataList?: number[] }): Buffer {
+  if (typeof m.data === 'string') return Buffer.from(m.data, 'base64');
+  if (m.data instanceof Uint8Array) return Buffer.from(m.data);
+  if (Array.isArray(m.dataList)) return Buffer.from(m.dataList);
+  return Buffer.alloc(0);
 }
 
 export interface EsphomeDeviceConnection {

--- a/src/ble/handler-esphome-proxy/gatt.ts
+++ b/src/ble/handler-esphome-proxy/gatt.ts
@@ -3,6 +3,7 @@ import { bleLog, errMsg, normalizeUuid } from '../types.js';
 import type { EsphomeClient, EsphomeConnection } from './client.js';
 import { macToInt } from './advert.js';
 import {
+  esphomeGattPayload,
   esphomeUuidToString,
   type EsphomeGattServicesResponse,
   type EsphomeNotifyData,
@@ -91,9 +92,10 @@ export async function openGattSession(
       const char: BleChar = {
         async read(): Promise<Buffer> {
           const r = (await conn.readBluetoothGATTCharacteristicService(addr, handle)) as {
-            dataList: number[];
+            data?: string | Uint8Array;
+            dataList?: number[];
           };
-          return Buffer.from(r.dataList ?? []);
+          return esphomeGattPayload(r);
         },
         async write(data: Buffer, withResponse: boolean): Promise<void> {
           if (closed) return;
@@ -114,7 +116,7 @@ export async function openGattSession(
             const m = raw as EsphomeNotifyData;
             if (m.address !== addr) return;
             if (m.handle === handle) {
-              const buf = Buffer.from(m.dataList ?? []);
+              const buf = esphomeGattPayload(m);
               bleLog.debug(
                 `ESPHome notify handle 0x${handle.toString(16)} (${buf.length}B): ${buf.toString('hex')}`,
               );

--- a/src/ble/handler-esphome-proxy/gatt.ts
+++ b/src/ble/handler-esphome-proxy/gatt.ts
@@ -82,7 +82,14 @@ export async function openGattSession(
   // session goes through one queue (#252).
   let queue: Promise<unknown> = Promise.resolve();
   const serial = <T>(fn: () => Promise<T>): Promise<T> => {
-    const next = queue.then(fn, fn);
+    // `closed` is checked when the unit actually runs, not when it is queued:
+    // close() does not drain the backlog, so anything still queued would
+    // otherwise be issued against a handle the session already disconnected,
+    // costing a 5 s library timeout each and stealing response events from the
+    // next session on the same shared connection.
+    const run = (): Promise<T> =>
+      closed ? Promise.reject(new Error('ESPHome GATT session closed')) : fn();
+    const next = queue.then(run, run);
     queue = next.then(
       () => undefined,
       () => undefined,
@@ -101,10 +108,17 @@ export async function openGattSession(
     };
   };
 
+  // A rejected GATT request is answered with BluetoothGATTErrorResponse, which
+  // the library never wires to the response it is awaiting, so the request only
+  // settles on its 5 s timeout. Waiters here turn that into an immediate
+  // rejection: five notify bindings on an unbonded proxy would otherwise be 25 s
+  // of dead air before the adapter handshake even starts.
+  const errorWaiters = new Map<number, (e: Error) => void>();
   track(GATT_ERROR_EVENT, (raw: unknown) => {
     const m = raw as { address: number; handle: number; error: number };
     if (m.address !== addr) return;
     bleLog.debug(`ESPHome GATT error: handle 0x${m.handle.toString(16)} status=${m.error}`);
+    errorWaiters.get(m.handle)?.(new Error(`ESPHome GATT status=${m.error}`));
   });
 
   // One log line per unexpected peer address for the whole session: every
@@ -154,33 +168,6 @@ export async function openGattSession(
           );
         },
         async subscribe(onData: (data: Buffer) => void): Promise<() => void> {
-          await serial(() => conn.notifyBluetoothGATTCharacteristicService(addr, handle));
-          // Registering with the proxy only routes notifications the ESP32
-          // receives; ESP-IDF requires the client to write the CCC descriptor
-          // before the peripheral sends any (#252). Register first so a
-          // notification fired the instant the CCCD lands is already routed.
-          const cccdValue = cccdValueFor(props);
-          if (cccdHandle !== undefined && cccdValue !== undefined) {
-            try {
-              await serial(() =>
-                conn.writeBluetoothGATTDescriptorService(addr, cccdHandle, cccdValue),
-              );
-              bleLog.debug(
-                `ESPHome CCCD write handle 0x${cccdHandle.toString(16)} = ${Buffer.from(
-                  cccdValue,
-                ).toString('hex')} for char 0x${handle.toString(16)}`,
-              );
-            } catch (e) {
-              // A scale that ignores the CCCD still gets the old behaviour.
-              bleLog.debug(
-                `ESPHome CCCD write failed for char 0x${handle.toString(16)}: ${errMsg(e)}`,
-              );
-            }
-          } else if (cccdHandle === undefined) {
-            bleLog.debug(
-              `ESPHome: no CCCD descriptor reported for char 0x${handle.toString(16)}; relying on the proxy registration alone`,
-            );
-          }
           const listener = (raw: unknown): void => {
             if (closed) return;
             const m = raw as EsphomeNotifyData;
@@ -213,7 +200,48 @@ export async function openGattSession(
               );
             }
           };
-          return track(NOTIFY_EVENT, listener);
+          // Register BEFORE anything that can make the peer notify. The library
+          // drains a whole TCP read synchronously, so a notification that shares
+          // a read with the CCCD write response is emitted before this function
+          // could resume: a scale that fires the instant its CCCD is written
+          // (QN 0x12, Robi S9, R-MSC04) would lose that first frame.
+          const untrack = track(NOTIFY_EVENT, listener);
+          try {
+            await serial(() => conn.notifyBluetoothGATTCharacteristicService(addr, handle));
+          } catch (e) {
+            untrack();
+            throw e;
+          }
+          // Registering with the proxy only routes notifications the ESP32
+          // receives; ESP-IDF requires the client to write the CCC descriptor
+          // before the peripheral sends any (#252).
+          const cccdValue = cccdValueFor(props);
+          if (cccdHandle !== undefined && cccdValue !== undefined) {
+            try {
+              await serial(() =>
+                Promise.race([
+                  conn.writeBluetoothGATTDescriptorService(addr, cccdHandle, cccdValue),
+                  new Promise<never>((_resolve, reject) => errorWaiters.set(cccdHandle, reject)),
+                ]).finally(() => errorWaiters.delete(cccdHandle)),
+              );
+              bleLog.debug(
+                `ESPHome CCCD write handle 0x${cccdHandle.toString(16)} = ${Buffer.from(
+                  cccdValue,
+                ).toString('hex')} for char 0x${handle.toString(16)}`,
+              );
+            } catch (e) {
+              // A scale that rejects or ignores the CCCD still gets the old
+              // behaviour: the proxy registration alone.
+              bleLog.debug(
+                `ESPHome CCCD write failed for char 0x${handle.toString(16)}: ${errMsg(e)}`,
+              );
+            }
+          } else if (cccdHandle === undefined) {
+            bleLog.debug(
+              `ESPHome: no CCCD descriptor reported for char 0x${handle.toString(16)}; relying on the proxy registration alone`,
+            );
+          }
+          return untrack;
         },
       };
       charMap.set(uuid, char);

--- a/src/ble/handler-esphome-proxy/gatt.ts
+++ b/src/ble/handler-esphome-proxy/gatt.ts
@@ -3,8 +3,10 @@ import { bleLog, errMsg, normalizeUuid } from '../types.js';
 import type { EsphomeClient, EsphomeConnection } from './client.js';
 import { macToInt } from './advert.js';
 import {
+  cccdValueFor,
   esphomeGattPayload,
   esphomeUuidToString,
+  findCccdHandle,
   type EsphomeGattServicesResponse,
   type EsphomeNotifyData,
   type EsphomeDeviceConnection,
@@ -12,6 +14,7 @@ import {
 
 const NOTIFY_EVENT = 'message.BluetoothGATTNotifyDataResponse';
 const CONNECTION_EVENT = 'message.BluetoothDeviceConnectionResponse';
+const GATT_ERROR_EVENT = 'message.BluetoothGATTErrorResponse';
 
 export interface GattSession {
   /** Normalized-UUID -> BleChar, the shape waitForRawReading() consumes. */
@@ -67,7 +70,26 @@ export async function openGattSession(
     addr,
   )) as EsphomeGattServicesResponse;
 
+  bleLog.debug(`ESPHome connected to ${mac} (mtu=${connResp.mtu ?? 'unknown'})`);
+
   let closed = false;
+
+  // The library's sendMessageAwaitResponse() resolves on the FIRST matching
+  // response event and does not correlate by address or handle, so two GATT
+  // requests in flight at once can swap replies (a descriptor write and a
+  // characteristic write both await BluetoothGATTWriteResponse). Adapters do run
+  // concurrently with subscribe during startInit, so every request for this
+  // session goes through one queue (#252).
+  let queue: Promise<unknown> = Promise.resolve();
+  const serial = <T>(fn: () => Promise<T>): Promise<T> => {
+    const next = queue.then(fn, fn);
+    queue = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return next;
+  };
+
   const registered: Array<{ event: string; fn: (m: unknown) => void }> = [];
   const track = (event: string, fn: (m: unknown) => void): (() => void) => {
     conn.on(event, fn);
@@ -79,6 +101,17 @@ export async function openGattSession(
     };
   };
 
+  track(GATT_ERROR_EVENT, (raw: unknown) => {
+    const m = raw as { address: number; handle: number; error: number };
+    if (m.address !== addr) return;
+    bleLog.debug(`ESPHome GATT error: handle 0x${m.handle.toString(16)} status=${m.error}`);
+  });
+
+  // One log line per unexpected peer address for the whole session: every
+  // listener sees every notify event, so a per-listener guard would multiply it
+  // by the number of subscribed characteristics.
+  const loggedForeignAddresses = new Set<number>();
+
   const charMap = new Map<string, BleChar>();
   for (const svc of services.servicesList ?? []) {
     for (const ch of svc.characteristicsList ?? []) {
@@ -88,10 +121,19 @@ export async function openGattSession(
       const uuid = ch.uuid ? normalizeUuid(ch.uuid) : esphomeUuidToString(ch.uuidList);
       if (!uuid) continue;
       const handle = ch.handle;
+      const props = ch.properties;
+      const cccdHandle = findCccdHandle(ch);
+      bleLog.debug(
+        `ESPHome GATT char ${uuid} handle=0x${handle.toString(16)} props=0x${(props ?? 0).toString(16)} cccd=${
+          cccdHandle === undefined ? 'none' : `0x${cccdHandle.toString(16)}`
+        }`,
+      );
 
       const char: BleChar = {
         async read(): Promise<Buffer> {
-          const r = (await conn.readBluetoothGATTCharacteristicService(addr, handle)) as {
+          const r = (await serial(() =>
+            conn.readBluetoothGATTCharacteristicService(addr, handle),
+          )) as {
             data?: string | Uint8Array;
             dataList?: number[];
           };
@@ -102,19 +144,55 @@ export async function openGattSession(
           // One atomic characteristic write, matching the native node-ble
           // handler. ESPHome's bluetooth_proxy handles ATT-level fragmentation;
           // splitting here would send N distinct values, not a long write.
-          await conn.writeBluetoothGATTCharacteristicService(
-            addr,
-            handle,
-            Uint8Array.from(data),
-            withResponse,
+          await serial(() =>
+            conn.writeBluetoothGATTCharacteristicService(
+              addr,
+              handle,
+              Uint8Array.from(data),
+              withResponse,
+            ),
           );
         },
         async subscribe(onData: (data: Buffer) => void): Promise<() => void> {
-          await conn.notifyBluetoothGATTCharacteristicService(addr, handle);
+          await serial(() => conn.notifyBluetoothGATTCharacteristicService(addr, handle));
+          // Registering with the proxy only routes notifications the ESP32
+          // receives; ESP-IDF requires the client to write the CCC descriptor
+          // before the peripheral sends any (#252). Register first so a
+          // notification fired the instant the CCCD lands is already routed.
+          const cccdValue = cccdValueFor(props);
+          if (cccdHandle !== undefined && cccdValue !== undefined) {
+            try {
+              await serial(() =>
+                conn.writeBluetoothGATTDescriptorService(addr, cccdHandle, cccdValue),
+              );
+              bleLog.debug(
+                `ESPHome CCCD write handle 0x${cccdHandle.toString(16)} = ${Buffer.from(
+                  cccdValue,
+                ).toString('hex')} for char 0x${handle.toString(16)}`,
+              );
+            } catch (e) {
+              // A scale that ignores the CCCD still gets the old behaviour.
+              bleLog.debug(
+                `ESPHome CCCD write failed for char 0x${handle.toString(16)}: ${errMsg(e)}`,
+              );
+            }
+          } else if (cccdHandle === undefined) {
+            bleLog.debug(
+              `ESPHome: no CCCD descriptor reported for char 0x${handle.toString(16)}; relying on the proxy registration alone`,
+            );
+          }
           const listener = (raw: unknown): void => {
             if (closed) return;
             const m = raw as EsphomeNotifyData;
-            if (m.address !== addr) return;
+            if (m.address !== addr) {
+              if (!loggedForeignAddresses.has(m.address)) {
+                loggedForeignAddresses.add(m.address);
+                bleLog.debug(
+                  `ESPHome notify for another device (address ${m.address}), ignored for ${mac}`,
+                );
+              }
+              return;
+            }
             if (m.handle === handle) {
               const buf = esphomeGattPayload(m);
               bleLog.debug(

--- a/src/ble/handler-mqtt-proxy/gatt.ts
+++ b/src/ble/handler-mqtt-proxy/gatt.ts
@@ -80,6 +80,14 @@ export class MqttBleDevice implements BleDevice {
     this.disconnectCb = callback;
   }
 
+  /**
+   * Abandon this session locally, as if the ESP32 had reported a disconnect.
+   * Used when a newer autonomous connect supersedes an in-flight one (#296).
+   */
+  fireDisconnect(): void {
+    this.disconnectCb?.();
+  }
+
   cleanup(): void {
     if (this.handler) this.client.removeListener('message', this.handler);
   }

--- a/src/ble/handler-mqtt-proxy/watcher.ts
+++ b/src/ble/handler-mqtt-proxy/watcher.ts
@@ -70,6 +70,9 @@ export class ReadingWatcher implements Watcher {
   private config: MqttProxyConfig;
   private profile?: UserProfile;
   private gattInProgress = false;
+  /** Monotonic id of the newest GATT session, so a superseded one cannot tear down its successor (#296). */
+  private gattSessionSeq = 0;
+  private currentDevice: MqttBleDevice | null = null;
   private gattStartedAt = 0;
   private readonly dedup = new DedupWindow(DEDUP_WINDOW_MS);
   /** Weight-only fallback timer per address; on elapse the held reading is queued. */
@@ -168,8 +171,14 @@ export class ReadingWatcher implements Watcher {
       // The ESP32 publishes the same `connected` payload with an extra
       // `autonomous: true` flag when it auto-connects to a known scale MAC.
       if (topic === t.connected) {
+        bleLog.debug(`Connected payload received (${payload.length} bytes)`);
         try {
           const data = JSON.parse(payload.toString());
+          if (!data.autonomous || !data.address) {
+            bleLog.debug(
+              'Connected payload is not an autonomous connect, ignoring (host-initiated response)',
+            );
+          }
           if (data.autonomous && data.address) {
             // The ESP32 fired its autonomous connect, so stop counting
             // deferrals for this MAC. This keeps the host fallback from racing
@@ -183,7 +192,7 @@ export class ReadingWatcher implements Watcher {
             });
           }
         } catch {
-          // Not JSON or missing fields — ignore (could be a host-initiated connect response)
+          bleLog.debug('Connected payload was not JSON, ignoring');
         }
         return;
       }
@@ -347,12 +356,13 @@ export class ReadingWatcher implements Watcher {
         bleLog.warn('gattInProgress stuck for >90s, auto-resetting');
         this.gattInProgress = false;
       } else {
-        bleLog.debug(`GATT connection already in progress, skipping ${entry.address}`);
+        bleLog.info(`GATT connection already in progress, skipping ${entry.address}`);
         return;
       }
     }
     this.gattInProgress = true;
     this.gattStartedAt = Date.now();
+    const seq = ++this.gattSessionSeq;
 
     const t = topics(this.config.topic_prefix, this.config.device_id);
     let client: MqttClient | undefined;
@@ -379,6 +389,7 @@ export class ReadingWatcher implements Watcher {
       bleLog.info(`Connecting via GATT proxy to ${adapter.name} (${entry.address})...`);
       const connected = await mqttGattConnect(client, t, entry.address, entry.addr_type ?? 0);
       device = connected.device;
+      this.currentDevice = device;
       const raw = await withTimeout(
         waitForRawReading(
           connected.charMap,
@@ -394,9 +405,13 @@ export class ReadingWatcher implements Watcher {
       this.queue.push(raw);
       this.deferCounts.delete(entry.address);
     } finally {
-      this.gattInProgress = false;
       device?.cleanup();
-      if (client) await mqttGattDisconnect(client, t).catch(() => {});
+      // A superseded session must not tear down the one that replaced it (#296).
+      if (seq === this.gattSessionSeq) {
+        this.gattInProgress = false;
+        this.currentDevice = null;
+        if (client) await mqttGattDisconnect(client, t).catch(() => {});
+      }
     }
   }
 
@@ -412,16 +427,19 @@ export class ReadingWatcher implements Watcher {
     chars: Array<{ uuid: string; properties: string[] }>;
   }): Promise<void> {
     if (this.gattInProgress) {
-      if (Date.now() - this.gattStartedAt > ReadingWatcher.GATT_STALE_MS) {
-        bleLog.warn('gattInProgress stuck for >90s, auto-resetting');
-        this.gattInProgress = false;
-      } else {
-        bleLog.debug(`GATT connection already in progress, skipping autonomous ${data.address}`);
-        return;
-      }
+      // Never skip an autonomous connect. The ESP32 holds exactly one BLE
+      // connection and disconnects before every auto-connect, so a newer
+      // autonomous event means the older session is already dead on the proxy;
+      // dropping it left the reporter with nothing happening for up to 90s
+      // while the stale-reset ran down (#296).
+      bleLog.warn(
+        `Newer autonomous connect for ${data.address} supersedes the in-flight GATT session`,
+      );
+      this.currentDevice?.fireDisconnect();
     }
     this.gattInProgress = true;
     this.gattStartedAt = Date.now();
+    const seq = ++this.gattSessionSeq;
 
     const t = topics(this.config.topic_prefix, this.config.device_id);
     let client: MqttClient | undefined;
@@ -480,6 +498,7 @@ export class ReadingWatcher implements Watcher {
       bleLog.info(`Autonomous GATT connect from ESP32: ${adapter.name} (${data.address})`);
       const { charMap, device: dev } = buildCharMapFromPayload(client, t, data.chars);
       device = dev;
+      this.currentDevice = device;
       bleLog.debug(
         `Autonomous connect: charMap built with ${charMap.size} chars, waiting for reading...`,
       );
@@ -501,9 +520,12 @@ export class ReadingWatcher implements Watcher {
       );
       this.queue.push(raw);
     } finally {
-      this.gattInProgress = false;
       device?.cleanup();
-      if (client) await mqttGattDisconnect(client, t).catch(() => {});
+      if (seq === this.gattSessionSeq) {
+        this.gattInProgress = false;
+        this.currentDevice = null;
+        if (client) await mqttGattDisconnect(client, t).catch(() => {});
+      }
     }
   }
 }

--- a/src/ble/handler-node-ble/connect.ts
+++ b/src/ble/handler-node-ble/connect.ts
@@ -46,6 +46,7 @@ export async function connectWithRecovery(ctx: ConnectRecoveryContext): Promise<
   // deleting the peer's Device1 object while discovery is stopped (#297). Off
   // by default, so every other node-ble user takes the identical code path.
   let keepDiscovery = ctx.keepDiscoveryDuringConnect === true;
+  let sawObjectGone = false;
   // Long-lived PropertiesChanged subscription on the current device proxy so
   // every received advertisement updates the freshness clock. The tracker is
   // rebound when the catch branch swaps the device reference.
@@ -105,15 +106,18 @@ export async function connectWithRecovery(ctx: ConnectRecoveryContext): Promise<
         return device;
       } catch (err: unknown) {
         const msg = errMsg(err);
-        const objectGone = isDeviceObjectGone(err);
-        if (objectGone && !keepDiscovery) {
+        if (isDeviceObjectGone(err)) sawObjectGone = true;
+        if (sawObjectGone && !keepDiscovery) {
           keepDiscovery = true;
           bleLog.warn(
             `BlueZ removed the org.bluez.Device1 object for ${formattedMac} while discovery was stopped, so this peer is only visible while scanning is active. Retrying with discovery left running (#297).`,
           );
         }
         if (attempt >= maxRetries) {
-          if (objectGone) {
+          // Latched, not just the last error: once BlueZ has been caught
+          // dropping the object, that is the story worth telling even if the
+          // final attempt happened to time out instead.
+          if (sawObjectGone) {
             throw new Error(
               `Connection failed after ${maxRetries + 1} attempts: BlueZ keeps removing the D-Bus object for ${formattedMac}, so no GATT connection can be opened. The scale advertises but does not accept connections (broadcast only or non-discoverable). Last error: ${msg}`,
             );

--- a/src/ble/handler-node-ble/connect.ts
+++ b/src/ble/handler-node-ble/connect.ts
@@ -11,6 +11,7 @@ import {
 import type { Adapter, Device } from './dbus.js';
 import { startDiscoverySafe, removeDevice, stopDiscoveryAndQuiesce } from './discovery.js';
 import { startPeerFreshnessTracker } from './freshness.js';
+import { isDeviceObjectGone } from './device-object.js';
 
 export interface ConnectRecoveryContext {
   btAdapter: Adapter;
@@ -18,6 +19,12 @@ export interface ConnectRecoveryContext {
   initialDevice: Device;
   maxRetries: number;
   bleAdapter?: string;
+  /**
+   * Do not stop BlueZ discovery between attempts: the peer's Device1 object
+   * only exists while a discovery session is active (#297). Normally left
+   * unset; the loop arms it by itself when it sees the object disappear.
+   */
+  keepDiscoveryDuringConnect?: boolean;
 }
 
 /**
@@ -35,6 +42,10 @@ export async function connectWithRecovery(ctx: ConnectRecoveryContext): Promise<
   // burns the budget on a peer that never came back; let the outer loop pick
   // the next cooldown instead.
   let rssiRediscoverUsed = false;
+  // Armed either by the caller or, reactively, the first time BlueZ is caught
+  // deleting the peer's Device1 object while discovery is stopped (#297). Off
+  // by default, so every other node-ble user takes the identical code path.
+  let keepDiscovery = ctx.keepDiscoveryDuringConnect === true;
   // Long-lived PropertiesChanged subscription on the current device proxy so
   // every received advertisement updates the freshness clock. The tracker is
   // rebound when the catch branch swaps the device reference.
@@ -67,7 +78,11 @@ export async function connectWithRecovery(ctx: ConnectRecoveryContext): Promise<
               `Device ${formattedMac} not found during RSSI re-discovery`,
             );
             tracker = startPeerFreshnessTracker(device);
-            await stopDiscoveryAndQuiesce(btAdapter);
+            if (keepDiscovery) {
+              await sleep(POST_DISCOVERY_QUIESCE_MS);
+            } else {
+              await stopDiscoveryAndQuiesce(btAdapter);
+            }
           } catch (rssiErr: unknown) {
             throw new Error(`Skipped connect to dying peer ${formattedMac}: ${errMsg(rssiErr)}`);
           }
@@ -80,10 +95,29 @@ export async function connectWithRecovery(ctx: ConnectRecoveryContext): Promise<
         bleLog.debug(`Connect attempt ${attempt + 1}/${maxRetries + 1}...`);
         await withTimeout(device.connect(), CONNECT_TIMEOUT_MS, 'Connection timed out');
         bleLog.debug(`Connected (took ${Date.now() - t0}ms)`);
+        if (keepDiscovery) {
+          // Restore the "no discovery during GATT" invariant the callers rely
+          // on. Safe now: BlueZ does not drop a device object while it is
+          // Connected, which is what let this peer be reached at all (#297).
+          bleLog.debug('Connected with discovery active; stopping discovery for the GATT phase');
+          await stopDiscoveryAndQuiesce(btAdapter);
+        }
         return device;
       } catch (err: unknown) {
         const msg = errMsg(err);
+        const objectGone = isDeviceObjectGone(err);
+        if (objectGone && !keepDiscovery) {
+          keepDiscovery = true;
+          bleLog.warn(
+            `BlueZ removed the org.bluez.Device1 object for ${formattedMac} while discovery was stopped, so this peer is only visible while scanning is active. Retrying with discovery left running (#297).`,
+          );
+        }
         if (attempt >= maxRetries) {
+          if (objectGone) {
+            throw new Error(
+              `Connection failed after ${maxRetries + 1} attempts: BlueZ keeps removing the D-Bus object for ${formattedMac}, so no GATT connection can be opened. The scale advertises but does not accept connections (broadcast only or non-discoverable). Last error: ${msg}`,
+            );
+          }
           throw new Error(`Connection failed after ${maxRetries + 1} attempts: ${msg}`);
         }
 
@@ -118,10 +152,14 @@ export async function connectWithRecovery(ctx: ConnectRecoveryContext): Promise<
             `Device ${formattedMac} not found during retry`,
           );
 
-          try {
-            await btAdapter.stopDiscovery();
-          } catch {
-            bleLog.debug('stopDiscovery failed during retry (ignored)');
+          if (keepDiscovery) {
+            bleLog.debug('Leaving discovery running for the next connect attempt (#297)');
+          } else {
+            try {
+              await btAdapter.stopDiscovery();
+            } catch {
+              bleLog.debug('stopDiscovery failed during retry (ignored)');
+            }
           }
           await sleep(POST_DISCOVERY_QUIESCE_MS);
         } catch (retryErr: unknown) {

--- a/src/ble/handler-node-ble/device-object.ts
+++ b/src/ble/handler-node-ble/device-object.ts
@@ -1,0 +1,81 @@
+import { bleLog, errMsg } from '../types.js';
+import { isDebugEnabled } from '../../logger.js';
+import { helperOf, type Device } from './dbus.js';
+import { extractDbusBytes } from './broadcast.js';
+
+/**
+ * True when a D-Bus error means the peer's `org.bluez.Device1` object is gone
+ * rather than that the connection itself failed.
+ *
+ * BlueZ scopes the Device object of a peer that is not connectable (or not
+ * discoverable) to the lifetime of a discovery session, so `StopDiscovery`
+ * followed by `Connect()` can hit an object that no longer exists (#297). Two
+ * different producers word that the same situation differently:
+ *
+ * - dbus-next, when a freshly introspected path carries no such interface:
+ *   `interface not found in proxy object: org.bluez.Device1`
+ * - bluetoothd, when a cached interface proxy calls a method on a dead object:
+ *   `Method "Connect" with signature "" on interface "org.bluez.Device1" doesn't exist`
+ *
+ * Both branches key on the literal interface name so a GattService1 or
+ * GattCharacteristic1 error can never match.
+ */
+export function isDeviceObjectGone(err: unknown): boolean {
+  const msg = errMsg(err);
+  if (!msg.includes('org.bluez.Device1')) return false;
+  return msg.includes('interface not found in proxy object') || msg.includes("doesn't exist");
+}
+
+/**
+ * Log the advertised payload of a freshly discovered device at debug level.
+ *
+ * This is the only window in which BlueZ still holds the advertisement for a
+ * peer whose Device object does not survive `StopDiscovery`, and it is what
+ * identifies a scale as, say, a Tuya 0xFD50 device that will never accept a
+ * GATT connection (#266, #297). Never throws: every property is Optional on
+ * org.bluez.Device1.
+ */
+export async function logAdvertisementSnapshot(device: Device): Promise<void> {
+  if (!isDebugEnabled()) return;
+  const helper = helperOf(device);
+  const read = async (name: string): Promise<unknown> => {
+    try {
+      return await helper.prop(name);
+    } catch {
+      return undefined;
+    }
+  };
+
+  const [addrType, flags, uuids, serviceData, manufacturerData] = await Promise.all([
+    read('AddressType'),
+    read('AdvertisingFlags'),
+    read('UUIDs'),
+    read('ServiceData'),
+    read('ManufacturerData'),
+  ]);
+
+  const parts: string[] = [];
+  if (typeof addrType === 'string') parts.push(`addrType=${addrType}`);
+  const flagBytes = extractDbusBytes(flags);
+  if (flagBytes) parts.push(`flags=${flagBytes.toString('hex')}`);
+  if (Array.isArray(uuids) && uuids.length > 0) parts.push(`uuids=[${uuids.join(', ')}]`);
+  const dict = (val: unknown, keyFmt: (k: string) => string): string | undefined => {
+    if (!val || typeof val !== 'object') return undefined;
+    const entries = val instanceof Map ? [...val.entries()] : Object.entries(val);
+    const pairs = entries
+      .map(([k, v]) => {
+        const bytes = extractDbusBytes(v);
+        return bytes ? `${keyFmt(String(k))}: ${bytes.toString('hex')}` : undefined;
+      })
+      .filter((p): p is string => p !== undefined);
+    return pairs.length > 0 ? `{${pairs.join(', ')}}` : undefined;
+  };
+  const sd = dict(serviceData, (k) => k);
+  if (sd) parts.push(`serviceData=${sd}`);
+  const md = dict(manufacturerData, (k) => `0x${Number(k).toString(16).padStart(4, '0')}`);
+  if (md) parts.push(`manufacturerData=${md}`);
+
+  bleLog.debug(
+    `Advert: ${parts.length > 0 ? parts.join(' ') : 'no advertised properties exposed'}`,
+  );
+}

--- a/src/ble/handler-node-ble/device-object.ts
+++ b/src/ble/handler-node-ble/device-object.ts
@@ -19,11 +19,21 @@ import { extractDbusBytes } from './broadcast.js';
  *
  * Both branches key on the literal interface name so a GattService1 or
  * GattCharacteristic1 error can never match.
+ *
+ * A third shape comes from bluetoothd itself when the whole object path is
+ * gone: `org.freedesktop.DBus.Error.UnknownObject` naming a `/org/bluez/hciN/
+ * dev_XX_..` path. Bleak's BlueZ backend treats exactly that as "removed from
+ * BlueZ when scanning stopped", which is independent confirmation of the
+ * mechanism, so it is matched on the device path rather than the interface.
  */
 export function isDeviceObjectGone(err: unknown): boolean {
   const msg = errMsg(err);
-  if (!msg.includes('org.bluez.Device1')) return false;
-  return msg.includes('interface not found in proxy object') || msg.includes("doesn't exist");
+  if (msg.includes('org.bluez.Device1')) {
+    return msg.includes('interface not found in proxy object') || msg.includes("doesn't exist");
+  }
+  // Path-shaped variant: only ever a device node, never an adapter or a GATT
+  // child object, so it cannot swallow an unrelated failure.
+  return /UnknownObject/i.test(msg) && /\/org\/bluez\/hci\d+\/dev_[0-9A-Fa-f_]+/.test(msg);
 }
 
 /**

--- a/src/ble/handler-node-ble/discovery.ts
+++ b/src/ble/handler-node-ble/discovery.ts
@@ -161,6 +161,9 @@ export async function removeDevice(btAdapter: Adapter, mac: string): Promise<voi
       bleLog.debug(`Skipping RemoveDevice: bond state unknown (${errMsg(err)})`);
       return;
     }
+    // Worth a line: an absent node here means BlueZ already dropped the peer's
+    // object, which is the signature of #297.
+    bleLog.debug('Device not in BlueZ cache; RemoveDevice is a no-op');
     paired = false;
   }
   if (paired) {

--- a/src/ble/handler-node-ble/freshness.ts
+++ b/src/ble/handler-node-ble/freshness.ts
@@ -1,5 +1,6 @@
-import { RSSI_UNAVAILABLE, RSSI_FRESHNESS_MS } from '../types.js';
+import { bleLog, RSSI_UNAVAILABLE, RSSI_FRESHNESS_MS } from '../types.js';
 import { helperOf, type PropsChangedHandler, type Device } from './dbus.js';
+import { isDeviceObjectGone } from './device-object.js';
 
 /**
  * Tracks whether a BlueZ peer is still actively advertising.
@@ -46,10 +47,21 @@ export function startPeerFreshnessTracker(device: Device): PeerFreshnessTracker 
       let rssi: unknown;
       try {
         rssi = await helper.prop('RSSI');
-      } catch {
+      } catch (err) {
         // RSSI is Optional on org.bluez.Device1 and BlueZ may not expose it
         // after StopDiscovery or on some controllers (#167). PropertiesChanged
         // remains the authoritative freshness signal via lastRssiUpdateTs.
+        //
+        // The swallow is deliberate even when the whole interface is gone:
+        // returning "not fresh" would push the loop into RSSI re-discovery,
+        // which stops discovery again and replaces the useful #297 error with
+        // "still not advertising after re-discovery". connect.ts owns the
+        // strategy switch; this only names the condition.
+        if (isDeviceObjectGone(err)) {
+          bleLog.debug(
+            'Peer D-Bus object no longer exports org.bluez.Device1; BlueZ dropped it after StopDiscovery (#297)',
+          );
+        }
         rssi = undefined;
       }
       if (typeof rssi === 'number' && rssi === RSSI_UNAVAILABLE) return false;

--- a/src/ble/handler-node-ble/scan.ts
+++ b/src/ble/handler-node-ble/scan.ts
@@ -43,6 +43,7 @@ import {
   stopDiscoveryAndQuiesce,
 } from './discovery.js';
 import { connectWithRecovery } from './connect.js';
+import { logAdvertisementSnapshot } from './device-object.js';
 import { wrapDevice, buildCharMap } from './gatt.js';
 import { broadcastScanNodeBle } from './broadcast.js';
 import { tagBleFailure, bleFailureKind } from '../failure-kind.js';
@@ -254,6 +255,9 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
 
       const name = await device.getName().catch(() => '');
       bleLog.debug(`Found device: ${name} [${mac}]`);
+      // Only chance to capture the advertisement: BlueZ drops it (and for some
+      // peers the whole Device object) once discovery stops (#297).
+      await logAdvertisementSnapshot(device);
 
       // Pre-connection adapter match (by name only). Needed for preferPassive adapters
       // so we can skip the GATT connect entirely and go straight to broadcast scanning.
@@ -341,6 +345,7 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
       device = result.device;
       matchedAdapter = result.adapter;
       deviceMac = result.mac;
+      await logAdvertisementSnapshot(device);
 
       // Passive-mode adapters: read from service-data advertisements without connecting.
       if (matchedAdapter.preferPassive && matchedAdapter.parseServiceData) {

--- a/src/ble/shared.ts
+++ b/src/ble/shared.ts
@@ -218,11 +218,16 @@ function initializeAdapter(
       };
 
       sendUnlock();
-      // The `?? 5000` is a defensive default for the impossible-in-practice
-      // case of unlockCommands set without unlockIntervalMs; every real adapter
-      // that keeps Unlockable declares both. 5000 ms mirrors the predominant
-      // existing interval.
-      unlockInterval = setInterval(() => void sendUnlock(), adapter.unlockIntervalMs ?? 5000);
+      // `unlockIntervalMs: 0` means "send the unlock once", and four adapters
+      // declare exactly that (Active Era, ES-CS20M, Hesley, 1byone new). `??`
+      // does not catch 0, so they used to arm setInterval(fn, 0), which clamps
+      // to about 1 ms on Linux: a write flood for the whole session on every
+      // transport. The 5000 ms fallback stays for an adapter that declares
+      // unlockCommands without an interval at all.
+      const interval = adapter.unlockIntervalMs ?? 5000;
+      if (interval > 0) {
+        unlockInterval = setInterval(() => void sendUnlock(), interval);
+      }
     }
   };
 
@@ -260,6 +265,18 @@ async function subscribeAndInit(
         unsubscribers.push(unsub);
         subscribed += 1;
       } catch (err) {
+        // A characteristic being present says nothing about it being
+        // notifiable: the char map holds every discovered characteristic
+        // regardless of its properties. An optional binding must therefore
+        // tolerate a rejected subscribe exactly as it tolerates absence,
+        // otherwise one vendor characteristic that turns out to be write-only
+        // on a sibling model fails every reading on that model.
+        if (binding.optional) {
+          bleLog.debug(
+            `Optional notify binding ${binding.uuid} could not be enabled: ${errMsg(err)}`,
+          );
+          continue;
+        }
         // Name the exact characteristic that failed and surface the underlying
         // BlueZ error. Enabling notifications/indications on a SIG service that
         // mandates an encrypted link (e.g. Beurer BF720 User Data 0x181C) fails

--- a/src/ble/shared.ts
+++ b/src/ble/shared.ts
@@ -384,6 +384,16 @@ export function waitForRawReading(
     const handleNotification = (sourceUuid: string, data: Buffer): void => {
       if (resolved) return;
 
+      // Every frame the scale sends, before any adapter gate can discard it.
+      // Without this a silent cycle cannot be told apart from one where frames
+      // arrived and were rejected, which is the question every stalled-scale
+      // report ends up asking (#229).
+      bleLog.debug(
+        `Notification ${sourceUuid}: [${[...data.subarray(0, 32)]
+          .map((b) => b.toString(16).padStart(2, '0'))
+          .join(' ')}]${data.length > 32 ? ` (+${data.length - 32} bytes)` : ''}`,
+      );
+
       if (adapter.buildAck && ackWriteChar) {
         const ack = adapter.buildAck(data);
         if (ack) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,6 +169,17 @@ async function main(): Promise<void> {
     // Attach the display capability; the getter reads the hot-swappable
     // ctx.mqttProxy live so config reloads take effect (#183).
     ctx.display = createMqttProxyDisplayNotifier(() => ctx.mqttProxy);
+    if (!initialResolved.continuousMode) {
+      // The ESP32 connects to a known scale on its own and publishes the
+      // session once. Only the continuous-mode watcher subscribes to that
+      // topic, so in a single run the event lands while nothing is listening
+      // and the weigh-in is silently lost (#296).
+      log.warn(
+        'mqtt-proxy without continuous mode: the ESP32 connects to known scales on its own, ' +
+          'and a single run only listens during its own scan window. ' +
+          'Set runtime.continuous_mode: true (or CONTINUOUS_MODE=true) so autonomous connects are never missed.',
+      );
+    }
   }
   if (ctx.scaleMac) {
     log.info(`Scanning for scale ${ctx.scaleMac}...`);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -12,6 +12,15 @@ export function setLogLevel(level: LogLevel): void {
   currentLevel = level;
 }
 
+/**
+ * Whether debug output is on. Lets a caller skip work whose only purpose is a
+ * debug line (for example extra D-Bus property reads), which the per-message
+ * level check inside the logger cannot avoid.
+ */
+export function isDebugEnabled(): boolean {
+  return currentLevel <= LogLevel.DEBUG;
+}
+
 export interface Logger {
   debug(msg: string): void;
   info(msg: string): void;

--- a/src/scales/beurer-bf720.ts
+++ b/src/scales/beurer-bf720.ts
@@ -260,16 +260,28 @@ export class BeurerBf720Adapter implements ScaleAdapterCore, GattWiring, MultiCh
     if (!ctx || session !== this.session || this.profileSyncDone) return;
     this.profileSyncDone = true;
     try {
+      // Every read and write is isolated: only the BF788 is proven from a
+      // capture, and on a sibling model one locked-down or read-only
+      // characteristic must not cost us the increment below, which is the step
+      // the scale actually waits for.
       const values = new Map<string, Buffer>();
       for (const uuid of PROFILE_CHARS) {
         if (!ctx.availableChars.has(uuid)) continue;
         if (session !== this.session) return;
-        const value = await ctx.read(uuid);
-        if (value.length > 0) values.set(uuid, value);
+        try {
+          const value = await ctx.read(uuid);
+          if (value.length > 0) values.set(uuid, value);
+        } catch (err) {
+          bleLog.debug(`Beurer BF720: profile read ${uuid} rejected: ${String(err)}`);
+        }
       }
       for (const [uuid, value] of values) {
         if (session !== this.session) return;
-        await ctx.write(uuid, value, true);
+        try {
+          await ctx.write(uuid, value, true);
+        } catch (err) {
+          bleLog.debug(`Beurer BF720: profile write ${uuid} rejected: ${String(err)}`);
+        }
       }
       if (ctx.availableChars.has(CHR_DB_CHANGE_INCREMENT)) {
         if (session !== this.session) return;

--- a/src/scales/beurer-bf720.ts
+++ b/src/scales/beurer-bf720.ts
@@ -21,6 +21,19 @@ const CHR_BODY_COMPOSITION = uuid16(0x2a9c); // Body Composition Service 0x181B
 const CHR_USER_CONTROL_POINT = uuid16(0x2a9f); // User Data Service 0x181C
 const CHR_DB_CHANGE_INCREMENT = uuid16(0x2a99); // User Data Service 0x181C
 const CHR_CURRENT_TIME = uuid16(0x2a2b); // Current Time Service 0x1805
+const CHR_DATE_OF_BIRTH = uuid16(0x2a85); // User Data Service 0x181C
+const CHR_GENDER = uuid16(0x2a8c); // User Data Service 0x181C
+const CHR_HEIGHT = uuid16(0x2a8e); // User Data Service 0x181C
+
+// Beurer vendor characteristics on service 0xFFF0, proven from the #229 capture.
+const CHR_VENDOR_USER_LIST = uuid16(0xfff2); // notify: one frame per user slot
+const CHR_VENDOR_ACTIVITY = uuid16(0xfff3); // read/write: activity level
+
+/**
+ * User Data characteristics the scale expects to be committed after consent,
+ * in the order the Beurer app writes them (#229 capture, att.txt 1571-1579).
+ */
+const PROFILE_CHARS = [CHR_DATE_OF_BIRTH, CHR_GENDER, CHR_HEIGHT, CHR_VENDOR_ACTIVITY];
 
 // SIG service UUIDs (normalized 128-bit lowercase form, same as the BLE layer
 // produces via normalizeUuid). Used to corroborate a bare Beurer company id so
@@ -94,12 +107,23 @@ export class BeurerBf720Adapter implements ScaleAdapterCore, GattWiring, MultiCh
     { uuid: CHR_BODY_COMPOSITION, type: 'notify' },
     { uuid: CHR_USER_CONTROL_POINT, type: 'notify' },
     { uuid: CHR_DB_CHANGE_INCREMENT, type: 'notify', optional: true },
+    // Vendor user-slot list. The scale answers the FFF2=00 command with one
+    // frame per stored user, which the app requests on every connection (#229).
+    { uuid: CHR_VENDOR_USER_LIST, type: 'notify', optional: true },
     { uuid: CHR_CURRENT_TIME, type: 'write' },
   ];
 
   private cachedWeight = 0;
   private cachedTimestamp: Date | undefined;
   private cachedComp: CachedComp = {};
+  /**
+   * The adapter instance is shared across GATT sessions, so the post-consent
+   * profile sync is keyed on a session counter: a late consent response must
+   * never write into a ConnectionContext that has already been torn down.
+   */
+  private ctx: ConnectionContext | undefined;
+  private session = 0;
+  private profileSyncDone = false;
   /**
    * Composition as it stood when each reading was emitted. Weak so buffered
    * history readings do not pin memory once the processor drops them.
@@ -194,14 +218,88 @@ export class BeurerBf720Adapter implements ScaleAdapterCore, GattWiring, MultiCh
     this.cachedWeight = 0;
     this.cachedTimestamp = undefined;
     this.cachedComp = {};
+    this.session += 1;
+    this.ctx = ctx;
+    this.profileSyncDone = false;
 
     await ctx.write(CHR_CURRENT_TIME, this.buildCurrentTime(), true);
+
+    // Vendor user-slot query. The app sends this on every connection, between
+    // the time write and the consent write, and the scale answers with one
+    // frame per stored user (#229 capture). Purely informational for us, but it
+    // keeps our sequence identical to the app's and names the slots in the log.
+    if (ctx.availableChars.has(CHR_VENDOR_USER_LIST)) {
+      try {
+        await ctx.write(CHR_VENDOR_USER_LIST, [0x00], true);
+      } catch (err) {
+        bleLog.debug(`Beurer BF720: vendor user-list query failed: ${String(err)}`);
+      }
+    }
+
     await ctx.write(
       CHR_USER_CONTROL_POINT,
       [UCP_CONSENT, userIndex & 0xff, pin & 0xff, (pin >> 8) & 0xff],
       true,
     );
     bleLog.debug(`Beurer BF720: consent sent for user index ${userIndex}`);
+  }
+
+  /**
+   * Read the scale's stored user data back and commit it unchanged, then bump
+   * the Database Change Increment.
+   *
+   * The #229 capture shows the Beurer app doing exactly this immediately after
+   * the consent is accepted, and only afterwards does the scale send a real
+   * body-composition frame: every frame before the commit carries zeroed
+   * composition fields. Writing back the bytes we just read keeps the user's
+   * on-scale profile intact; we are signalling "profile confirmed", not
+   * changing it.
+   */
+  private async syncUserProfile(session: number): Promise<void> {
+    const ctx = this.ctx;
+    if (!ctx || session !== this.session || this.profileSyncDone) return;
+    this.profileSyncDone = true;
+    try {
+      const values = new Map<string, Buffer>();
+      for (const uuid of PROFILE_CHARS) {
+        if (!ctx.availableChars.has(uuid)) continue;
+        if (session !== this.session) return;
+        const value = await ctx.read(uuid);
+        if (value.length > 0) values.set(uuid, value);
+      }
+      for (const [uuid, value] of values) {
+        if (session !== this.session) return;
+        await ctx.write(uuid, value, true);
+      }
+      if (ctx.availableChars.has(CHR_DB_CHANGE_INCREMENT)) {
+        if (session !== this.session) return;
+        await ctx.write(CHR_DB_CHANGE_INCREMENT, [0x01, 0x00, 0x00, 0x00], true);
+      }
+      bleLog.debug(
+        `Beurer BF720: user profile committed (${values.size} characteristics); scale can complete the measurement`,
+      );
+    } catch (err) {
+      // Never fail the reading over this: on firmware that does not need the
+      // commit, the measurement arrives regardless.
+      bleLog.debug(`Beurer BF720: user profile sync failed: ${String(err)}`);
+    }
+  }
+
+  /** Decode one vendor user-slot frame (diagnostics only, never a reading). */
+  private handleUserListFrame(data: Buffer): void {
+    if (data.length === 0) return;
+    if (data[0] === 0x01) {
+      bleLog.debug('Beurer BF720: end of user-slot list');
+      return;
+    }
+    if (data[0] !== 0x00 || data.length < 12) return;
+    const slot = data[1];
+    const year = data.readUInt16LE(5);
+    const height = data[9];
+    const gender = data[10] === 0 ? 'male' : 'female';
+    bleLog.debug(
+      `Beurer BF720: user slot ${slot} (born ${year}-${data[7]}-${data[8]}, ${height} cm, ${gender}, activity ${data[11]})`,
+    );
   }
 
   /** Current Time Service 0x2A2B payload (10 bytes). */
@@ -227,6 +325,10 @@ export class BeurerBf720Adapter implements ScaleAdapterCore, GattWiring, MultiCh
       this.handleUcpResponse(data);
       return null;
     }
+    if (charUuid === CHR_VENDOR_USER_LIST) {
+      this.handleUserListFrame(data);
+      return null;
+    }
     if (charUuid === CHR_WEIGHT_MEASUREMENT) {
       this.parseWeightMeasurement(data);
       return this.buildReading();
@@ -249,6 +351,7 @@ export class BeurerBf720Adapter implements ScaleAdapterCore, GattWiring, MultiCh
     const result = data[2];
     if (result === UCP_RESULT_SUCCESS) {
       bleLog.debug('Beurer BF720: consent accepted, awaiting measurement');
+      void this.syncUserProfile(this.session);
     } else if (result === UCP_RESULT_NOT_AUTHORIZED) {
       bleLog.warn(
         'Beurer BF720: consent rejected (USER_NOT_AUTHORIZED). Check `users[].beurer_pin` ' +

--- a/src/tools/sync-addon-changelog.ts
+++ b/src/tools/sync-addon-changelog.ts
@@ -25,8 +25,13 @@ The add-on version always matches the application version, so every entry below
 applies to this add-on.
 `;
 
-export const ROOT_CHANGELOG_PATH = 'CHANGELOG.md';
-export const ADDON_CHANGELOG_PATH = path.join('ble-scale-sync-addon', 'CHANGELOG.md');
+// Anchored to the module rather than the cwd, so the CLI and the vitest guard
+// behave identically wherever they are invoked from.
+const REPO_ROOT = fileURLToPath(new URL('../../', import.meta.url));
+export const ADDON_CHANGELOG_NAME = 'ble-scale-sync-addon/CHANGELOG.md';
+export const ROOT_CHANGELOG_PATH = path.join(REPO_ROOT, 'CHANGELOG.md');
+export const ADDON_CHANGELOG_PATH = path.join(REPO_ROOT, 'ble-scale-sync-addon', 'CHANGELOG.md');
+export const ADDON_CONFIG_PATH = path.join(REPO_ROOT, 'ble-scale-sync-addon', 'config.yaml');
 
 /** Strip the Keep a Changelog preamble and keep every release section verbatim. */
 export function buildAddonChangelog(rootChangelog: string): string {
@@ -39,23 +44,22 @@ export function buildAddonChangelog(rootChangelog: string): string {
 }
 
 function main(argv: string[]): void {
-  const root = readFileSync(path.resolve(process.cwd(), ROOT_CHANGELOG_PATH), 'utf8');
+  const root = readFileSync(ROOT_CHANGELOG_PATH, 'utf8');
   const generated = buildAddonChangelog(root);
-  const addonPath = path.resolve(process.cwd(), ADDON_CHANGELOG_PATH);
 
   if (argv.includes('check')) {
-    const current = readFileSync(addonPath, 'utf8').replace(/\r\n/g, '\n');
+    const current = readFileSync(ADDON_CHANGELOG_PATH, 'utf8').replace(/\r\n/g, '\n');
     if (current !== generated) {
-      console.error(`${ADDON_CHANGELOG_PATH} is stale. Run: npm run sync:addon-changelog`);
+      console.error(`${ADDON_CHANGELOG_NAME} is stale. Run: npm run sync:addon-changelog`);
       process.exitCode = 1;
       return;
     }
-    console.log(`${ADDON_CHANGELOG_PATH} is up to date`);
+    console.log(`${ADDON_CHANGELOG_NAME} is up to date`);
     return;
   }
 
-  writeFileSync(addonPath, generated, 'utf8');
-  console.log(`Wrote ${ADDON_CHANGELOG_PATH}`);
+  writeFileSync(ADDON_CHANGELOG_PATH, generated, 'utf8');
+  console.log(`Wrote ${ADDON_CHANGELOG_NAME}`);
 }
 
 // Only run as a CLI, so importing this module in tests has no side effects.

--- a/src/tools/sync-addon-changelog.ts
+++ b/src/tools/sync-addon-changelog.ts
@@ -1,0 +1,64 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Generate the Home Assistant add-on changelog from the project changelog.
+ *
+ * The add-on file used to be maintained by hand and drifted 16 releases behind
+ * (#294): Home Assistant renders it verbatim in the add-on page, so users saw
+ * release notes that stopped at 1.10.2 while running 1.21.1. The add-on version
+ * always equals the application version, so every entry in the root changelog
+ * applies to the add-on and a generated copy is the honest representation.
+ *
+ * Run `npm run sync:addon-changelog` after the root changelog changes.
+ * `npm run sync:addon-changelog:check` (and a vitest guard) fails when the copy
+ * is stale, so it cannot silently fall behind again.
+ */
+export const ADDON_CHANGELOG_HEADER = `# Changelog
+
+<!-- GENERATED FILE. Do not edit by hand. Produced from the root CHANGELOG.md by
+     src/tools/sync-addon-changelog.ts. Run \`npm run sync:addon-changelog\` after
+     the root changelog changes. -->
+
+The add-on version always matches the application version, so every entry below
+applies to this add-on.
+`;
+
+export const ROOT_CHANGELOG_PATH = 'CHANGELOG.md';
+export const ADDON_CHANGELOG_PATH = path.join('ble-scale-sync-addon', 'CHANGELOG.md');
+
+/** Strip the Keep a Changelog preamble and keep every release section verbatim. */
+export function buildAddonChangelog(rootChangelog: string): string {
+  const match = /^## \[/m.exec(rootChangelog);
+  if (!match) {
+    throw new Error('Root CHANGELOG.md has no "## [x.y.z]" release heading');
+  }
+  const body = rootChangelog.slice(match.index).replace(/\r\n/g, '\n').trimEnd();
+  return `${ADDON_CHANGELOG_HEADER}\n${body}\n`;
+}
+
+function main(argv: string[]): void {
+  const root = readFileSync(path.resolve(process.cwd(), ROOT_CHANGELOG_PATH), 'utf8');
+  const generated = buildAddonChangelog(root);
+  const addonPath = path.resolve(process.cwd(), ADDON_CHANGELOG_PATH);
+
+  if (argv.includes('check')) {
+    const current = readFileSync(addonPath, 'utf8').replace(/\r\n/g, '\n');
+    if (current !== generated) {
+      console.error(`${ADDON_CHANGELOG_PATH} is stale. Run: npm run sync:addon-changelog`);
+      process.exitCode = 1;
+      return;
+    }
+    console.log(`${ADDON_CHANGELOG_PATH} is up to date`);
+    return;
+  }
+
+  writeFileSync(addonPath, generated, 'utf8');
+  console.log(`Wrote ${ADDON_CHANGELOG_PATH}`);
+}
+
+// Only run as a CLI, so importing this module in tests has no side effects.
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main(process.argv.slice(2));
+}

--- a/tests/addon-changelog-sync.test.ts
+++ b/tests/addon-changelog-sync.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import {
+  ADDON_CHANGELOG_PATH,
+  ROOT_CHANGELOG_PATH,
+  buildAddonChangelog,
+} from '../src/tools/sync-addon-changelog.js';
+
+/**
+ * Guard for #294. The add-on changelog is what Home Assistant shows on the
+ * add-on page, and while it was maintained by hand it fell 16 releases behind
+ * without anything failing. It is now generated, and this test is what keeps it
+ * that way: a release that updates CHANGELOG.md without regenerating the copy
+ * fails CI instead of shipping stale notes.
+ *
+ * Line endings are normalized on both sides: Windows checkouts have core.autocrlf
+ * on, so the working-tree files are CRLF while the generator emits LF.
+ */
+const lf = (s: string): string => s.replace(/\r\n/g, '\n');
+
+const root = lf(readFileSync(ROOT_CHANGELOG_PATH, 'utf8'));
+const addon = lf(readFileSync(ADDON_CHANGELOG_PATH, 'utf8'));
+
+describe('add-on changelog sync (#294)', () => {
+  it('is the generated copy of the root changelog', () => {
+    expect(addon, `${ADDON_CHANGELOG_PATH} is stale. Run: npm run sync:addon-changelog`).toBe(
+      buildAddonChangelog(root),
+    );
+  });
+
+  it('documents the version the add-on config reports', () => {
+    const config = lf(readFileSync('ble-scale-sync-addon/config.yaml', 'utf8'));
+    const version = /^version:\s*["']?([\d.]+)["']?\s*$/m.exec(config)?.[1];
+    expect(version, 'no version in ble-scale-sync-addon/config.yaml').toBeDefined();
+    const escaped = version!.replace(/\./g, '\\.');
+    expect(addon).toMatch(new RegExp(`^## \\[${escaped}\\]`, 'm'));
+  });
+
+  it('keeps every release heading', () => {
+    const rootHeadings = root.match(/^## \[/gm)?.length ?? 0;
+    const generated = buildAddonChangelog(root).match(/^## \[/gm)?.length ?? 0;
+    expect(rootHeadings).toBeGreaterThan(0);
+    expect(generated).toBe(rootHeadings);
+  });
+
+  it('drops the Keep a Changelog preamble', () => {
+    const generated = buildAddonChangelog(root);
+    expect(generated.startsWith('# Changelog')).toBe(true);
+    expect(generated).not.toContain('All notable changes to this project');
+    expect(generated).not.toContain('keepachangelog.com');
+  });
+
+  it('throws when the root changelog has no release heading', () => {
+    expect(() => buildAddonChangelog('# Changelog\n\nnothing here\n')).toThrow(/release heading/);
+  });
+});

--- a/tests/addon-changelog-sync.test.ts
+++ b/tests/addon-changelog-sync.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import {
+  ADDON_CHANGELOG_NAME,
   ADDON_CHANGELOG_PATH,
+  ADDON_CONFIG_PATH,
   ROOT_CHANGELOG_PATH,
   buildAddonChangelog,
 } from '../src/tools/sync-addon-changelog.js';
@@ -23,13 +25,13 @@ const addon = lf(readFileSync(ADDON_CHANGELOG_PATH, 'utf8'));
 
 describe('add-on changelog sync (#294)', () => {
   it('is the generated copy of the root changelog', () => {
-    expect(addon, `${ADDON_CHANGELOG_PATH} is stale. Run: npm run sync:addon-changelog`).toBe(
+    expect(addon, `${ADDON_CHANGELOG_NAME} is stale. Run: npm run sync:addon-changelog`).toBe(
       buildAddonChangelog(root),
     );
   });
 
   it('documents the version the add-on config reports', () => {
-    const config = lf(readFileSync('ble-scale-sync-addon/config.yaml', 'utf8'));
+    const config = lf(readFileSync(ADDON_CONFIG_PATH, 'utf8'));
     const version = /^version:\s*["']?([\d.]+)["']?\s*$/m.exec(config)?.[1];
     expect(version, 'no version in ble-scale-sync-addon/config.yaml').toBeDefined();
     const escaped = version!.replace(/\./g, '\\.');

--- a/tests/ble/device-object-gone.test.ts
+++ b/tests/ble/device-object-gone.test.ts
@@ -46,6 +46,26 @@ describe('isDeviceObjectGone() (#297)', () => {
     expect(isDeviceObjectGone(new Error(BLUETOOTHD_UNKNOWN_METHOD))).toBe(true);
   });
 
+  it('matches the bluetoothd UnknownObject shape naming a device path', () => {
+    // Bleak's BlueZ backend maps this exact error to "removed from BlueZ when
+    // scanning stopped", which is the same mechanism from another client.
+    expect(
+      isDeviceObjectGone(
+        new Error(
+          'org.freedesktop.DBus.Error.UnknownObject: Method "Connect" ... object path /org/bluez/hci0/dev_A0_85_61_91_E9_4F',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not match an UnknownObject error for an adapter or GATT child path', () => {
+    expect(
+      isDeviceObjectGone(
+        new Error('org.freedesktop.DBus.Error.UnknownObject: path /org/bluez/hci0'),
+      ),
+    ).toBe(false);
+  });
+
   it('does not match a GATT interface proxy error', () => {
     expect(
       isDeviceObjectGone(new Error('interface not found in proxy object: org.bluez.GattService1')),

--- a/tests/ble/device-object-gone.test.ts
+++ b/tests/ble/device-object-gone.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+// Suppress log output during tests.
+vi.spyOn(console, 'log').mockImplementation(() => {});
+vi.spyOn(console, 'warn').mockImplementation(() => {});
+vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+vi.mock('dbus-next', () => ({
+  Variant: class {
+    constructor(
+      public signature: string,
+      public value: unknown,
+    ) {}
+  },
+  interface: {
+    Interface: class {
+      constructor(_name?: string) {}
+      static configureMembers(): void {}
+    },
+    ACCESS_READWRITE: 'readwrite',
+  },
+  DBusError: class extends Error {},
+}));
+
+vi.mock('node-ble', () => ({
+  default: { createBluetooth: vi.fn() },
+}));
+
+const { isDeviceObjectGone, logAdvertisementSnapshot } =
+  await import('../../src/ble/handler-node-ble/device-object.js');
+const { _internals } = await import('../../src/ble/handler-node-ble/index.js');
+const { setLogLevel, LogLevel } = await import('../../src/logger.js');
+
+/** Exact text bluetoothd returned in the #297 log, trailing newline included. */
+const BLUETOOTHD_UNKNOWN_METHOD =
+  'Method "Connect" with signature "" on interface "org.bluez.Device1" doesn\'t exist\n';
+const DBUS_NEXT_MISSING_IFACE = 'interface not found in proxy object: org.bluez.Device1';
+
+describe('isDeviceObjectGone() (#297)', () => {
+  it('matches the dbus-next missing-interface shape', () => {
+    expect(isDeviceObjectGone(new Error(DBUS_NEXT_MISSING_IFACE))).toBe(true);
+  });
+
+  it('matches the bluetoothd UnknownMethod shape including the trailing newline', () => {
+    expect(isDeviceObjectGone(new Error(BLUETOOTHD_UNKNOWN_METHOD))).toBe(true);
+  });
+
+  it('does not match a GATT interface proxy error', () => {
+    expect(
+      isDeviceObjectGone(new Error('interface not found in proxy object: org.bluez.GattService1')),
+    ).toBe(false);
+  });
+
+  it('does not match an ordinary connect failure', () => {
+    expect(isDeviceObjectGone(new Error('le-connection-abort-by-local'))).toBe(false);
+    expect(isDeviceObjectGone(new Error('Connection timed out'))).toBe(false);
+  });
+});
+
+interface MockHelper extends EventEmitter {
+  prop: ReturnType<typeof vi.fn>;
+  callMethod: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  object: string;
+}
+
+function makeHelper(props: Record<string, unknown> = {}): MockHelper {
+  const ee = new EventEmitter() as MockHelper;
+  ee.prop = vi.fn(async (name: string) => {
+    if (name in props) {
+      const v = props[name];
+      if (v instanceof Error) throw v;
+      return v;
+    }
+    if (name === 'RSSI') return -55;
+    return undefined;
+  });
+  ee.callMethod = vi.fn(async () => undefined);
+  ee.set = vi.fn(async () => undefined);
+  ee.object = '/org/bluez/hci0';
+  return ee;
+}
+
+interface MockDevice {
+  helper: MockHelper;
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  isPaired?: ReturnType<typeof vi.fn>;
+}
+
+function makeDevice(connectImpl: () => Promise<void>): MockDevice {
+  return {
+    helper: makeHelper(),
+    connect: vi.fn(connectImpl),
+    disconnect: vi.fn(async () => undefined),
+    isPaired: vi.fn(async () => false),
+  };
+}
+
+function makeAdapter(reDiscovered: MockDevice) {
+  return {
+    helper: makeHelper(),
+    isDiscovering: vi.fn(async () => false),
+    startDiscovery: vi.fn(async () => undefined),
+    stopDiscovery: vi.fn(async () => undefined),
+    waitDevice: vi.fn(async () => reDiscovered),
+    getDevice: vi.fn(async () => reDiscovered),
+  };
+}
+
+describe('connectWithRecovery: vanishing org.bluez.Device1 (#297)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('arms the discovery-active strategy and connects on the retry', async () => {
+    const initial = makeDevice(async () => {
+      throw new Error(BLUETOOTHD_UNKNOWN_METHOD);
+    });
+    const reDiscovered = makeDevice(async () => undefined);
+    const btAdapter = makeAdapter(reDiscovered);
+
+    const result = await _internals.connectWithRecovery({
+      btAdapter: btAdapter as never,
+      mac: 'A0:85:61:91:E9:4F',
+      initialDevice: initial as never,
+      maxRetries: 1,
+    });
+
+    expect(result).toBe(reDiscovered);
+    expect(btAdapter.startDiscovery).toHaveBeenCalled();
+    expect(reDiscovered.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not stop discovery between retries once armed', async () => {
+    const initial = makeDevice(async () => {
+      throw new Error(DBUS_NEXT_MISSING_IFACE);
+    });
+    const reDiscovered = makeDevice(async () => undefined);
+    const btAdapter = makeAdapter(reDiscovered);
+
+    await _internals.connectWithRecovery({
+      btAdapter: btAdapter as never,
+      mac: 'A0:85:61:91:E9:4F',
+      initialDevice: initial as never,
+      maxRetries: 1,
+    });
+
+    // Only the post-connect stop that restores the no-discovery-during-GATT
+    // invariant; never the between-retries stop that kills the device object.
+    expect(btAdapter.stopDiscovery).toHaveBeenCalledTimes(1);
+    const stopOrder = btAdapter.stopDiscovery.mock.invocationCallOrder[0] ?? 0;
+    const connectOrder = reDiscovered.connect.mock.invocationCallOrder[0] ?? 0;
+    expect(connectOrder).toBeLessThan(stopOrder);
+  });
+
+  it('still stops discovery between retries for an ordinary connect failure', async () => {
+    const initial = makeDevice(async () => {
+      throw new Error('le-connection-abort-by-local');
+    });
+    const reDiscovered = makeDevice(async () => undefined);
+    const btAdapter = makeAdapter(reDiscovered);
+
+    await _internals.connectWithRecovery({
+      btAdapter: btAdapter as never,
+      mac: 'AA:BB:CC:DD:EE:FF',
+      initialDevice: initial as never,
+      maxRetries: 1,
+    });
+
+    expect(btAdapter.stopDiscovery).toHaveBeenCalledTimes(1);
+    const stopOrder = btAdapter.stopDiscovery.mock.invocationCallOrder[0] ?? 0;
+    const connectOrder = reDiscovered.connect.mock.invocationCallOrder[0] ?? 0;
+    expect(stopOrder).toBeLessThan(connectOrder);
+  });
+
+  it('explains the vanishing device object when every attempt fails that way', async () => {
+    const initial = makeDevice(async () => {
+      throw new Error(BLUETOOTHD_UNKNOWN_METHOD);
+    });
+    const reDiscovered = makeDevice(async () => {
+      throw new Error(DBUS_NEXT_MISSING_IFACE);
+    });
+    const btAdapter = makeAdapter(reDiscovered);
+
+    await expect(
+      _internals.connectWithRecovery({
+        btAdapter: btAdapter as never,
+        mac: 'A0:85:61:91:E9:4F',
+        initialDevice: initial as never,
+        maxRetries: 1,
+      }),
+    ).rejects.toThrow(/keeps removing the D-Bus object/);
+  });
+
+  it('honours keepDiscoveryDuringConnect passed by the caller', async () => {
+    const initial = makeDevice(async () => {
+      throw new Error('Connection timed out');
+    });
+    const reDiscovered = makeDevice(async () => undefined);
+    const btAdapter = makeAdapter(reDiscovered);
+
+    await _internals.connectWithRecovery({
+      btAdapter: btAdapter as never,
+      mac: 'A0:85:61:91:E9:4F',
+      initialDevice: initial as never,
+      maxRetries: 1,
+      keepDiscoveryDuringConnect: true,
+    });
+
+    // Only the post-connect stop.
+    expect(btAdapter.stopDiscovery).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('logAdvertisementSnapshot() (#297)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setLogLevel(LogLevel.DEBUG);
+  });
+
+  it('logs advertised UUIDs, service data and manufacturer data as hex', async () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const device = {
+      helper: makeHelper({
+        AddressType: 'public',
+        UUIDs: ['0000fd50-0000-1000-8000-00805f9b34fb'],
+        ServiceData: { '0000fd50-0000-1000-8000-00805f9b34fb': Buffer.from([0xac, 0x02]) },
+        ManufacturerData: { 2409: Buffer.from([0x01, 0x02]) },
+      }),
+    };
+
+    await logAdvertisementSnapshot(device as never);
+
+    const line = spy.mock.calls.map((c) => String(c[0])).find((l) => l.includes('Advert:'));
+    expect(line).toBeDefined();
+    expect(line).toContain('0000fd50-0000-1000-8000-00805f9b34fb');
+    expect(line).toContain('ac02');
+    expect(line).toContain('0x0969');
+    expect(line).toContain('addrType=public');
+  });
+
+  it('never rejects when every property is missing', async () => {
+    const device = {
+      helper: makeHelper({
+        AddressType: new Error('No such property'),
+        UUIDs: new Error('No such property'),
+        ServiceData: new Error('No such property'),
+        ManufacturerData: new Error('No such property'),
+        AdvertisingFlags: new Error('No such property'),
+      }),
+    };
+    await expect(logAdvertisementSnapshot(device as never)).resolves.toBeUndefined();
+  });
+
+  it('reads nothing at all when debug logging is off', async () => {
+    setLogLevel(LogLevel.INFO);
+    const helper = makeHelper({ UUIDs: ['0000181d-0000-1000-8000-00805f9b34fb'] });
+    await logAdvertisementSnapshot({ helper } as never);
+    expect(helper.prop).not.toHaveBeenCalled();
+    setLogLevel(LogLevel.DEBUG);
+  });
+});

--- a/tests/ble/device-object-gone.test.ts
+++ b/tests/ble/device-object-gone.test.ts
@@ -209,8 +209,30 @@ describe('connectWithRecovery: vanishing org.bluez.Device1 (#297)', () => {
       keepDiscoveryDuringConnect: true,
     });
 
-    // Only the post-connect stop.
+    // Only the post-connect stop, never the between-retries one.
     expect(btAdapter.stopDiscovery).toHaveBeenCalledTimes(1);
+    const stopOrder = btAdapter.stopDiscovery.mock.invocationCallOrder[0] ?? 0;
+    const connectOrder = reDiscovered.connect.mock.invocationCallOrder[0] ?? 0;
+    expect(connectOrder).toBeLessThan(stopOrder);
+  });
+
+  it('reports the vanished device object even when the last attempt failed differently', async () => {
+    const initial = makeDevice(async () => {
+      throw new Error(BLUETOOTHD_UNKNOWN_METHOD);
+    });
+    const reDiscovered = makeDevice(async () => {
+      throw new Error('Connection timed out');
+    });
+    const btAdapter = makeAdapter(reDiscovered);
+
+    await expect(
+      _internals.connectWithRecovery({
+        btAdapter: btAdapter as never,
+        mac: 'A0:85:61:91:E9:4F',
+        initialDevice: initial as never,
+        maxRetries: 1,
+      }),
+    ).rejects.toThrow(/keeps removing the D-Bus object/);
   });
 });
 

--- a/tests/ble/esphome-proxy/esphome-gatt-proto.test.ts
+++ b/tests/ble/esphome-proxy/esphome-gatt-proto.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { esphomeUuidToString } from '../../../src/ble/handler-esphome-proxy/esphome-gatt-proto.js';
+import {
+  CCCD_INDICATE,
+  CCCD_NOTIFY,
+  cccdValueFor,
+  esphomeUuidToString,
+  findCccdHandle,
+} from '../../../src/ble/handler-esphome-proxy/esphome-gatt-proto.js';
 import { normalizeUuid } from '../../../src/ble/types.js';
 
 describe('esphomeUuidToString', () => {
@@ -35,5 +41,63 @@ describe('esphomeUuidToString', () => {
   it('returns empty string for a missing/empty uuidList (no throw)', () => {
     expect(esphomeUuidToString(undefined)).toBe('');
     expect(esphomeUuidToString([])).toBe('');
+  });
+});
+
+describe('findCccdHandle (#252)', () => {
+  it('returns the handle of a pre-decoded 0x2902 descriptor', () => {
+    expect(
+      findCccdHandle({
+        handle: 7,
+        descriptorsList: [{ uuid: '00002902-0000-1000-8000-00805f9b34fb', handle: 8 }],
+      }),
+    ).toBe(8);
+  });
+
+  it('resolves a raw [high, low] uuidList descriptor pair', () => {
+    expect(
+      findCccdHandle({
+        handle: 7,
+        descriptorsList: [{ uuidList: [0x0000290200001000n, 0x800000805f9b34fbn], handle: 8 }],
+      }),
+    ).toBe(8);
+  });
+
+  it('falls back to shortUuid when uuid and uuidList are absent', () => {
+    expect(findCccdHandle({ handle: 7, descriptorsList: [{ shortUuid: 0x2902, handle: 8 }] })).toBe(
+      8,
+    );
+  });
+
+  it('skips a non-CCCD descriptor such as 0x2901', () => {
+    expect(
+      findCccdHandle({
+        handle: 7,
+        descriptorsList: [{ uuid: '00002901-0000-1000-8000-00805f9b34fb', handle: 8 }],
+      }),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for a missing or empty descriptorsList (no throw)', () => {
+    expect(findCccdHandle({ handle: 7 })).toBeUndefined();
+    expect(findCccdHandle({ handle: 7, descriptorsList: [] })).toBeUndefined();
+  });
+});
+
+describe('cccdValueFor (#252)', () => {
+  it('prefers notify when both notify and indicate bits are set', () => {
+    expect(cccdValueFor(0x30)).toEqual(CCCD_NOTIFY);
+  });
+
+  it('returns the indicate payload for an indicate-only characteristic', () => {
+    expect(cccdValueFor(0x20)).toEqual(CCCD_INDICATE);
+  });
+
+  it('returns undefined when neither bit is set', () => {
+    expect(cccdValueFor(0x02)).toBeUndefined();
+  });
+
+  it('defaults to notify when the library reports no properties', () => {
+    expect(cccdValueFor(undefined)).toEqual(CCCD_NOTIFY);
   });
 });

--- a/tests/ble/esphome-proxy/gatt-payload.test.ts
+++ b/tests/ble/esphome-proxy/gatt-payload.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'node:module';
+import { openGattSession } from '../../../src/ble/handler-esphome-proxy/gatt.js';
+import { esphomeGattPayload } from '../../../src/ble/handler-esphome-proxy/esphome-gatt-proto.js';
+import { normalizeUuid } from '../../../src/ble/types.js';
+
+const nodeRequire = createRequire(import.meta.url);
+
+/**
+ * Regression guard for #291.
+ *
+ * Every GATT notification and read over the ESPHome proxy decoded to zero bytes
+ * from v1.14.0 to v1.21.1, because the bridge read `dataList` while the library
+ * emits a base64 string named `data`. The old unit tests hand-rolled the
+ * `dataList` shape, so they passed against the broken code.
+ *
+ * This suite therefore builds its fixtures from the REAL library: protobuf
+ * messages round-tripped through serializeBinary and pushed through the same
+ * mapMessageByType() call the connection makes. A library upgrade that changes
+ * the emitted shape fails here instead of silently zeroing every frame again.
+ */
+const { pb } = nodeRequire('@2colors/esphome-native-api/lib/utils/messages.js');
+const { mapMessageByType } = nodeRequire(
+  '@2colors/esphome-native-api/lib/utils/mapMessageByType.js',
+);
+
+// macToInt('00:00:00:00:00:01') === 1
+const ADDR = 1;
+
+/** Reproduces connection.js: mapMessageByType(type, message.toObject()). */
+function libraryShape(msg: {
+  constructor: { type: string };
+  toObject: () => unknown;
+}): Record<string, unknown> {
+  return mapMessageByType(msg.constructor.type, msg.toObject()) as Record<string, unknown>;
+}
+
+function notifyShape(handle: number, hex: string): Record<string, unknown> {
+  const msg = new pb.BluetoothGATTNotifyDataResponse();
+  msg.setAddress(ADDR);
+  msg.setHandle(handle);
+  msg.setData(Uint8Array.from(Buffer.from(hex, 'hex')));
+  // Round-trip so the bytes field is stored exactly as a received frame stores it.
+  const wire = pb.BluetoothGATTNotifyDataResponse.deserializeBinary(msg.serializeBinary());
+  return libraryShape(wire);
+}
+
+function readShape(hex: string): Record<string, unknown> {
+  const msg = new pb.BluetoothGATTReadResponse();
+  msg.setAddress(ADDR);
+  msg.setHandle(7);
+  msg.setData(Uint8Array.from(Buffer.from(hex, 'hex')));
+  const wire = pb.BluetoothGATTReadResponse.deserializeBinary(msg.serializeBinary());
+  return libraryShape(wire);
+}
+
+function fakeConnection(readHex = '010203') {
+  const listeners: Record<string, Array<(a: unknown) => void>> = {};
+  return {
+    connected: true,
+    on(ev: string, fn: (a: unknown) => void) {
+      (listeners[ev] ??= []).push(fn);
+    },
+    off(ev: string, fn: (a: unknown) => void) {
+      listeners[ev] = (listeners[ev] ?? []).filter((f) => f !== fn);
+    },
+    removeListener(ev: string, fn: (a: unknown) => void) {
+      this.off(ev, fn);
+    },
+    emit(ev: string, a: unknown) {
+      (listeners[ev] ?? []).forEach((f) => f(a));
+    },
+    connectBluetoothDeviceService: vi.fn(async () => ({ address: ADDR, connected: true, mtu: 23 })),
+    disconnectBluetoothDeviceService: vi.fn(async () => ({ address: ADDR, connected: false })),
+    listBluetoothGATTServicesService: vi.fn(async () => ({
+      address: ADDR,
+      servicesList: [
+        {
+          uuid: '0000ffb0-0000-1000-8000-00805f9b34fb',
+          handle: 1,
+          characteristicsList: [
+            {
+              uuid: '0000ffb2-0000-1000-8000-00805f9b34fb',
+              handle: 7,
+              properties: 0x10,
+              descriptorsList: [{ uuid: '00002902-0000-1000-8000-00805f9b34fb', handle: 8 }],
+            },
+          ],
+        },
+      ],
+    })),
+    readBluetoothGATTCharacteristicService: vi.fn(async () => readShape(readHex)),
+    writeBluetoothGATTCharacteristicService: vi.fn(async () => ({})),
+    notifyBluetoothGATTCharacteristicService: vi.fn(async () => ({})),
+    writeBluetoothGATTDescriptorService: vi.fn(async () => ({})),
+  };
+}
+
+describe('ESPHome GATT payload decoding (#291)', () => {
+  it('library internals still render GATT payloads as a base64 `data` field', () => {
+    const shape = notifyShape(24, 'ac0203');
+    expect(typeof shape.data).toBe('string');
+    expect(shape.data).toBe('rAID');
+    // The field the bridge used to read does not exist in this library version.
+    expect(shape.dataList).toBeUndefined();
+    expect(readShape('010203').data).toBe('AQID');
+  });
+
+  it('decodes a real 8-byte Hutbit weight frame end to end', async () => {
+    const conn = fakeConnection();
+    const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01');
+    const char = session.charMap.get(normalizeUuid('ffb2'))!;
+    const got: Buffer[] = [];
+    await char.subscribe((d) => got.push(d));
+    conn.emit('message.BluetoothGATTNotifyDataResponse', notifyShape(7, 'ac0203470000ca14'));
+    expect(got).toHaveLength(1);
+    expect(got[0].toString('hex')).toBe('ac0203470000ca14');
+    await session.close();
+  });
+
+  it('decodes a fragmented 1-byte notification', async () => {
+    const conn = fakeConnection();
+    const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01');
+    const char = session.charMap.get(normalizeUuid('ffb2'))!;
+    const got: Buffer[] = [];
+    await char.subscribe((d) => got.push(d));
+    conn.emit('message.BluetoothGATTNotifyDataResponse', notifyShape(7, 'ac'));
+    expect(got[0]).toEqual(Buffer.from([0xac]));
+    await session.close();
+  });
+
+  it('decodes a characteristic read', async () => {
+    const conn = fakeConnection('55aa03');
+    const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01');
+    const char = session.charMap.get(normalizeUuid('ffb2'))!;
+    expect((await char.read()).toString('hex')).toBe('55aa03');
+    await session.close();
+  });
+
+  it('yields an empty buffer for a genuinely empty payload', async () => {
+    const conn = fakeConnection();
+    const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01');
+    const char = session.charMap.get(normalizeUuid('ffb2'))!;
+    const got: Buffer[] = [];
+    await char.subscribe((d) => got.push(d));
+    conn.emit('message.BluetoothGATTNotifyDataResponse', notifyShape(7, ''));
+    expect(got[0]).toEqual(Buffer.alloc(0));
+    await session.close();
+  });
+});
+
+describe('esphomeGattPayload()', () => {
+  it('prefers a legacy dataList over an empty `data` sentinel', () => {
+    // mapRawAdvertisement builds entries as { data: '', legacyDataList: [...] },
+    // so an empty `data` must not shadow a populated list.
+    expect(esphomeGattPayload({ data: '', dataList: [0xac, 0x02] })).toEqual(
+      Buffer.from([0xac, 0x02]),
+    );
+  });
+
+  it('accepts a Uint8Array payload', () => {
+    expect(esphomeGattPayload({ data: Uint8Array.from([1, 2]) })).toEqual(Buffer.from([1, 2]));
+  });
+
+  it('returns an empty buffer when no payload field is present', () => {
+    expect(esphomeGattPayload({})).toEqual(Buffer.alloc(0));
+  });
+});

--- a/tests/ble/esphome-proxy/gatt.test.ts
+++ b/tests/ble/esphome-proxy/gatt.test.ts
@@ -280,6 +280,72 @@ describe('openGattSession', () => {
     await session.close();
   });
 
+  it('routes a notification emitted during the CCCD write round trip (#252)', async () => {
+    const conn = fakeConnection();
+    // The peer answers the CCCD write and notifies in the same drain: the
+    // library emits both synchronously, so a listener registered after the
+    // write would never see the first frame (QN 0x12, Robi S9, R-MSC04).
+    conn.writeBluetoothGATTDescriptorService = vi.fn(async () => {
+      conn.emit('message.BluetoothGATTNotifyDataResponse', {
+        address: ADDR,
+        handle: 7,
+        data: 'Eg==', // 0x12
+      });
+      return {};
+    });
+    const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01');
+    const char = session.charMap.get(normalizeUuid('2a9d'))!;
+    const got: Buffer[] = [];
+    await char.subscribe((d) => got.push(d));
+    expect(got).toEqual([Buffer.from([0x12])]);
+    await session.close();
+  });
+
+  it('fails a rejected CCCD write immediately on the GATT error response (#252)', async () => {
+    const conn = fakeConnection();
+    // The library never resolves a descriptor write on an error response, so
+    // without the correlation it would only settle on its own 5s timeout.
+    conn.writeBluetoothGATTDescriptorService = vi.fn(() => {
+      setTimeout(
+        () =>
+          conn.emit('message.BluetoothGATTErrorResponse', { address: ADDR, handle: 8, error: 5 }),
+        0,
+      );
+      return new Promise(() => {});
+    });
+    const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01');
+    const char = session.charMap.get(normalizeUuid('2a9d'))!;
+    const started = Date.now();
+    await expect(char.subscribe(() => {})).resolves.toBeTypeOf('function');
+    expect(Date.now() - started).toBeLessThan(1000);
+    await session.close();
+  });
+
+  it('does not issue queued requests after the session closed (#252)', async () => {
+    const conn = fakeConnection();
+    let release: (() => void) | undefined;
+    conn.writeBluetoothGATTCharacteristicService = vi.fn(async () => {
+      if (!release) {
+        await new Promise<void>((resolve) => {
+          release = resolve;
+        });
+      }
+      return {};
+    });
+    const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01');
+    const char = session.charMap.get(normalizeUuid('2a9d'))!;
+    const first = char.write(Buffer.from([1]), true);
+    const queued = [2, 3, 4].map((b) => char.write(Buffer.from([b]), true).catch(() => 'rejected'));
+    await new Promise((r) => setTimeout(r, 5));
+    await session.close();
+    release?.();
+    await first.catch(() => undefined);
+    await Promise.all(queued);
+    // Only the in-flight write reached the connection; the backlog rejected
+    // instead of being issued against a disconnected handle.
+    expect(conn.writeBluetoothGATTCharacteristicService).toHaveBeenCalledTimes(1);
+  });
+
   it('fires BleDevice.onDisconnect when the peer reports disconnected', async () => {
     const conn = fakeConnection();
     const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01');

--- a/tests/ble/esphome-proxy/gatt.test.ts
+++ b/tests/ble/esphome-proxy/gatt.test.ts
@@ -38,15 +38,38 @@ function fakeConnection() {
               uuid: '00002a9d-0000-1000-8000-00805f9b34fb',
               handle: 7,
               properties: 0x10,
+              descriptorsList: [{ uuid: '00002902-0000-1000-8000-00805f9b34fb', handle: 8 }],
+            },
+            // Indicate-only, with a CCCD (Robi S9 FFB3 / R-MSC04 0x2A12 shape).
+            {
+              uuid: '00002a9c-0000-1000-8000-00805f9b34fb',
+              handle: 9,
+              properties: 0x20,
+              descriptorsList: [{ uuid: '00002902-0000-1000-8000-00805f9b34fb', handle: 10 }],
+            },
+            // Notify-capable but the proxy reports no descriptors at all.
+            {
+              uuid: '00002a9e-0000-1000-8000-00805f9b34fb',
+              handle: 11,
+              properties: 0x10,
               descriptorsList: [],
+            },
+            // Read-only: must never get a CCCD write even though one exists.
+            {
+              uuid: '00002a9b-0000-1000-8000-00805f9b34fb',
+              handle: 13,
+              properties: 0x02,
+              descriptorsList: [{ uuid: '00002902-0000-1000-8000-00805f9b34fb', handle: 14 }],
             },
           ],
         },
       ],
     })),
-    readBluetoothGATTCharacteristicService: vi.fn(async () => ({ dataList: [1, 2, 3] })),
+    // Real library shape: protobuf-JS renders `bytes data` as base64 (#291).
+    readBluetoothGATTCharacteristicService: vi.fn(async () => ({ data: 'AQID' })),
     writeBluetoothGATTCharacteristicService: vi.fn(async () => ({})),
     notifyBluetoothGATTCharacteristicService: vi.fn(async () => ({})),
+    writeBluetoothGATTDescriptorService: vi.fn(async () => ({})),
   };
 }
 
@@ -118,12 +141,12 @@ describe('openGattSession', () => {
     conn.emit('message.BluetoothGATTNotifyDataResponse', {
       address: ADDR,
       handle: 7,
-      dataList: [0xaa],
+      data: 'qg==', // 0xaa
     });
     conn.emit('message.BluetoothGATTNotifyDataResponse', {
       address: ADDR,
       handle: 99,
-      dataList: [0xbb],
+      data: 'uw==', // 0xbb
     });
     expect(got).toHaveLength(1);
     expect(got[0]).toEqual(Buffer.from([0xaa]));
@@ -131,9 +154,129 @@ describe('openGattSession', () => {
     conn.emit('message.BluetoothGATTNotifyDataResponse', {
       address: ADDR,
       handle: 7,
-      dataList: [0xcc],
+      data: 'zA==', // 0xcc
     });
     expect(got).toHaveLength(1);
+    await session.close();
+  });
+
+  it('still decodes a legacy dataList notification shape', async () => {
+    const conn = fakeConnection();
+    const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01');
+    const char = session.charMap.get(normalizeUuid('2a9d'))!;
+    const got: Buffer[] = [];
+    await char.subscribe((d) => got.push(d));
+    conn.emit('message.BluetoothGATTNotifyDataResponse', {
+      address: ADDR,
+      handle: 7,
+      dataList: [0xaa, 0xbb],
+    });
+    expect(got[0]).toEqual(Buffer.from([0xaa, 0xbb]));
+    await session.close();
+  });
+
+  it('writes the CCCD after registering notifications, registration first (#252)', async () => {
+    const conn = fakeConnection();
+    const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01');
+    const char = session.charMap.get(normalizeUuid('2a9d'))!;
+    await char.subscribe(() => {});
+    expect(conn.notifyBluetoothGATTCharacteristicService).toHaveBeenCalledWith(ADDR, 7);
+    expect(conn.writeBluetoothGATTDescriptorService).toHaveBeenCalledTimes(1);
+    expect(conn.writeBluetoothGATTDescriptorService).toHaveBeenCalledWith(
+      ADDR,
+      8,
+      Uint8Array.from([0x01, 0x00]),
+    );
+    const notifyOrder =
+      conn.notifyBluetoothGATTCharacteristicService.mock.invocationCallOrder[0] ?? 0;
+    const cccdOrder = conn.writeBluetoothGATTDescriptorService.mock.invocationCallOrder[0] ?? 0;
+    expect(notifyOrder).toBeLessThan(cccdOrder);
+    await session.close();
+  });
+
+  it('writes 0x0002 to the CCCD for an indicate-only characteristic (#252)', async () => {
+    const conn = fakeConnection();
+    const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01');
+    const char = session.charMap.get(normalizeUuid('2a9c'))!;
+    await char.subscribe(() => {});
+    expect(conn.writeBluetoothGATTDescriptorService).toHaveBeenCalledWith(
+      ADDR,
+      10,
+      Uint8Array.from([0x02, 0x00]),
+    );
+    await session.close();
+  });
+
+  it('skips the CCCD write when the proxy reports no descriptors (#252)', async () => {
+    const conn = fakeConnection();
+    const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01');
+    const char = session.charMap.get(normalizeUuid('2a9e'))!;
+    const got: Buffer[] = [];
+    await char.subscribe((d) => got.push(d));
+    expect(conn.writeBluetoothGATTDescriptorService).not.toHaveBeenCalled();
+    conn.emit('message.BluetoothGATTNotifyDataResponse', {
+      address: ADDR,
+      handle: 11,
+      data: 'qg==',
+    });
+    expect(got[0]).toEqual(Buffer.from([0xaa]));
+    await session.close();
+  });
+
+  it('does not write a CCCD for a characteristic with neither notify nor indicate (#252)', async () => {
+    const conn = fakeConnection();
+    const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01');
+    const char = session.charMap.get(normalizeUuid('2a9b'))!;
+    await char.subscribe(() => {});
+    expect(conn.writeBluetoothGATTDescriptorService).not.toHaveBeenCalled();
+    await session.close();
+  });
+
+  it('keeps the subscription when the CCCD write fails (#252)', async () => {
+    const conn = fakeConnection();
+    conn.writeBluetoothGATTDescriptorService = vi.fn(async () => {
+      throw new Error('gatt error status=5');
+    });
+    const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01');
+    const char = session.charMap.get(normalizeUuid('2a9d'))!;
+    const got: Buffer[] = [];
+    await expect(char.subscribe((d) => got.push(d))).resolves.toBeTypeOf('function');
+    conn.emit('message.BluetoothGATTNotifyDataResponse', {
+      address: ADDR,
+      handle: 7,
+      data: 'qg==',
+    });
+    expect(got[0]).toEqual(Buffer.from([0xaa]));
+    await session.close();
+  });
+
+  it('serializes GATT requests so replies cannot be swapped (#252)', async () => {
+    const conn = fakeConnection();
+    const order: string[] = [];
+    let releaseWrite: (() => void) | undefined;
+    conn.writeBluetoothGATTCharacteristicService = vi.fn(async () => {
+      order.push('write:start');
+      await new Promise<void>((resolve) => {
+        releaseWrite = resolve;
+      });
+      order.push('write:end');
+      return {};
+    });
+    conn.writeBluetoothGATTDescriptorService = vi.fn(async () => {
+      order.push('cccd');
+      return {};
+    });
+    const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01');
+    const char = session.charMap.get(normalizeUuid('2a9d'))!;
+    const writing = char.write(Buffer.from([1]), true);
+    const subscribing = char.subscribe(() => {});
+    await new Promise((r) => setTimeout(r, 5));
+    // The subscribe path must not have issued anything while the write is open.
+    expect(order).toEqual(['write:start']);
+    releaseWrite?.();
+    await writing;
+    await subscribing;
+    expect(order).toEqual(['write:start', 'write:end', 'cccd']);
     await session.close();
   });
 

--- a/tests/ble/handler-mqtt-proxy.test.ts
+++ b/tests/ble/handler-mqtt-proxy.test.ts
@@ -1824,7 +1824,7 @@ describe('handler-mqtt-proxy', () => {
       expect(disconnectCalls.length).toBeGreaterThanOrEqual(1);
     });
 
-    it('ReadingWatcher skips autonomous connect when gattInProgress', async () => {
+    it('ReadingWatcher supersedes the in-flight session on a newer autonomous connect (#296)', async () => {
       const adapter = createGattAdapter();
       const config = { ...MQTT_PROXY_CONFIG, auto_connect: false };
       const watcher = new ReadingWatcher(config, [adapter], undefined, PROFILE);
@@ -1854,23 +1854,29 @@ describe('handler-mqtt-proxy', () => {
       // Clear mock call history before the autonomous connect attempt
       (mockClient.publishAsync as ReturnType<typeof vi.fn>).mockClear();
 
-      // Now simulate autonomous connect while GATT is in progress — should be skipped
+      // Autonomous connect while the previous GATT session is still open. The
+      // ESP32 holds one connection and disconnects before every auto-connect,
+      // so the older session is already dead on the proxy: the newer one must
+      // take over rather than be dropped (#296).
       mockClient._simulateMessage(
         `${PREFIX}/connected`,
         JSON.stringify({
           autonomous: true,
           address: 'BB:CC:DD:EE:FF:00',
-          chars: [{ uuid: GATT_NOTIFY_UUID, properties: ['notify'] }],
+          chars: [
+            { uuid: GATT_NOTIFY_UUID, properties: ['notify'] },
+            { uuid: GATT_WRITE_UUID, properties: ['write'] },
+          ],
         }),
       );
 
       await new Promise((r) => setTimeout(r, 50));
 
-      // No disconnect should have been published for the skipped autonomous connect
-      const disconnectCalls = (
+      // The new session engaged: it subscribed to the notify characteristic.
+      const subscribeCalls = (
         mockClient.publishAsync as ReturnType<typeof vi.fn>
-      ).mock.calls.filter((c: unknown[]) => c[0] === `${PREFIX}/disconnect`);
-      expect(disconnectCalls).toHaveLength(0);
+      ).mock.calls.filter((c: unknown[]) => String(c[0]).startsWith(`${PREFIX}/subscribe/`));
+      expect(subscribeCalls.length).toBeGreaterThanOrEqual(1);
     });
 
     it('combined scan/results then autonomous connected succeeds without race (#201)', async () => {

--- a/tests/ble/shared.test.ts
+++ b/tests/ble/shared.test.ts
@@ -539,6 +539,56 @@ describe('waitForReading() — multi-char mode (characteristics[])', () => {
     await expect(promise).resolves.toEqual(SAMPLE_BODY_COMP);
   });
 
+  it('continues when an optional notify binding cannot be subscribed (#229)', async () => {
+    // A characteristic being discovered says nothing about it being notifiable:
+    // the char map holds every discovered characteristic. A vendor char that is
+    // write-only on a sibling model must not fail the whole reading.
+    const char1 = createMockChar();
+    const optional = createMockChar();
+    optional.subscribe = async (): Promise<() => void> => {
+      throw new Error('Not permitted');
+    };
+    const device = createMockDevice();
+
+    const OPTIONAL_UUID = '0000fff200001000800000805f9b34fb';
+    const { charMap } = createCharMap([
+      [NOTIFY_UUID, char1],
+      [OPTIONAL_UUID, optional],
+    ]);
+
+    const adapter = createLegacyAdapter({
+      characteristics: [
+        { uuid: NOTIFY_UUID, type: 'notify' },
+        { uuid: OPTIONAL_UUID, type: 'notify', optional: true },
+      ],
+      onConnected: vi.fn(),
+      parseNotification: vi.fn(() => ({ weight: 75, impedance: 500 })),
+    });
+
+    const promise = waitForReading(charMap, device, adapter, PROFILE, '');
+    await vi.waitFor(() => expect(char1.subscribeCalled).toBe(true));
+    char1.triggerData(Buffer.from([0x01]));
+    await expect(promise).resolves.toEqual(SAMPLE_BODY_COMP);
+  });
+
+  it('still fails when a REQUIRED notify binding cannot be subscribed', async () => {
+    const char1 = createMockChar();
+    char1.subscribe = async (): Promise<() => void> => {
+      throw new Error('Not permitted');
+    };
+    const device = createMockDevice();
+    const { charMap } = createCharMap([[NOTIFY_UUID, char1]]);
+
+    const adapter = createLegacyAdapter({
+      characteristics: [{ uuid: NOTIFY_UUID, type: 'notify' }],
+      onConnected: vi.fn(),
+    });
+
+    await expect(waitForReading(charMap, device, adapter, PROFILE, '')).rejects.toThrow(
+      /Failed to enable notifications/,
+    );
+  });
+
   it('uses parseCharNotification when defined', async () => {
     const char1 = createMockChar();
     const device = createMockDevice();
@@ -1309,6 +1359,34 @@ describe('waitForReading() — adapter with no unlock wiring (#244)', () => {
     expect(result).toEqual(SAMPLE_BODY_COMP);
     // No legacy unlock write was issued.
     expect(writeChar.writtenData.length).toBe(0);
+  });
+
+  it('sends the unlock exactly once when unlockIntervalMs is 0', async () => {
+    // `?? 5000` does not catch 0, so this used to arm setInterval(fn, 0), which
+    // clamps to about 1 ms on Linux and floods the link for the whole session.
+    // Four adapters declare 0 (Active Era, ES-CS20M, Hesley, 1byone new).
+    const notifyChar = createMockChar();
+    const writeChar = createMockChar();
+    const device = createMockDevice();
+    const { charMap } = createCharMap([
+      [NOTIFY_UUID, notifyChar],
+      [WRITE_UUID, writeChar],
+    ]);
+
+    const adapter = createLegacyAdapter({
+      unlockCommand: [0xa5, 0x01],
+      unlockIntervalMs: 0,
+      parseNotification: (data: Buffer) =>
+        data[0] === 0x10 ? { weight: 75.5, impedance: 500 } : null,
+    });
+
+    const promise = waitForReading(charMap, device, adapter, PROFILE, '');
+    await vi.waitFor(() => expect(writeChar.writtenData.length).toBe(1));
+    await new Promise((r) => setTimeout(r, 60));
+    expect(writeChar.writtenData.length).toBe(1);
+
+    notifyChar.triggerData(Buffer.from([0x10]));
+    await expect(promise).resolves.toEqual(SAMPLE_BODY_COMP);
   });
 });
 

--- a/tests/scales/beurer-bf720.test.ts
+++ b/tests/scales/beurer-bf720.test.ts
@@ -355,4 +355,181 @@ describe('BeurerBf720Adapter', () => {
       });
     });
   });
+
+  // #229: the Beurer app queries the vendor user list before the consent write
+  // and, once consent is accepted, reads the user data back, writes it
+  // unchanged and bumps the database change increment. Only after that commit
+  // does the scale send a body-composition frame with real values.
+  describe('post-consent user profile commit (#229)', () => {
+    const CHR_FFF2 = uuid16(0xfff2);
+    const CHR_FFF3 = uuid16(0xfff3);
+    const CHR_DOB = uuid16(0x2a85);
+    const CHR_GENDER = uuid16(0x2a8c);
+    const CHR_HEIGHT = uuid16(0x2a8e);
+    const CHR_DBINC = uuid16(0x2a99);
+
+    /** Characteristic set and stored values from the #229 BF788 capture. */
+    function bf788Ctx(over: Partial<ConnectionContext> = {}): ConnectionContext {
+      const stored: Record<string, Buffer> = {
+        [CHR_DBINC]: Buffer.from('06000000', 'hex'),
+        [CHR_DOB]: Buffer.from('bf070808', 'hex'),
+        [CHR_GENDER]: Buffer.from('00', 'hex'),
+        [CHR_HEIGHT]: Buffer.from('c000', 'hex'),
+        [CHR_FFF3]: Buffer.from('03', 'hex'),
+      };
+      return makeCtx({
+        availableChars: new Set([
+          CHR_WEIGHT,
+          CHR_BODYCOMP,
+          CHR_UCP,
+          CHR_FFF2,
+          CHR_FFF3,
+          CHR_DOB,
+          CHR_GENDER,
+          CHR_HEIGHT,
+          CHR_DBINC,
+        ]),
+        read: vi.fn(async (uuid: string) => stored[uuid] ?? Buffer.alloc(0)),
+        ...over,
+      });
+    }
+
+    const flush = async (): Promise<void> => {
+      for (let i = 0; i < 20; i++) await Promise.resolve();
+    };
+
+    it('queries the vendor user list between the time write and the consent write', async () => {
+      const a = makeAdapter();
+      const ctx = bf788Ctx();
+      await a.onConnected(ctx);
+
+      const write = ctx.write as ReturnType<typeof vi.fn>;
+      expect(write.mock.calls.map((c) => c[0])).toEqual([CHR_TIME, CHR_FFF2, CHR_UCP]);
+      expect(write.mock.calls[1][1]).toEqual([0x00]);
+    });
+
+    it('skips the vendor query when 0xFFF2 is absent', async () => {
+      const a = makeAdapter();
+      const ctx = makeCtx();
+      await a.onConnected(ctx);
+      const write = ctx.write as ReturnType<typeof vi.fn>;
+      expect(write.mock.calls.map((c) => c[0])).toEqual([CHR_TIME, CHR_UCP]);
+    });
+
+    it('still sends consent when the vendor query is rejected', async () => {
+      const a = makeAdapter();
+      const ctx = bf788Ctx({
+        write: vi.fn(async (uuid: string) => {
+          if (uuid === uuid16(0xfff2)) throw new Error('not permitted');
+        }),
+      });
+      await a.onConnected(ctx);
+      const write = ctx.write as ReturnType<typeof vi.fn>;
+      expect(write.mock.calls.map((c) => c[0])).toContain(CHR_UCP);
+    });
+
+    it('reads the user data back, writes it unchanged, then bumps the increment', async () => {
+      const a = makeAdapter();
+      const ctx = bf788Ctx();
+      await a.onConnected(ctx);
+      const write = ctx.write as ReturnType<typeof vi.fn>;
+      write.mockClear();
+
+      // Consent accepted: `20 02 01` on the User Control Point.
+      a.parseCharNotification(CHR_UCP, Buffer.from('200201', 'hex'));
+      await flush();
+
+      expect(
+        write.mock.calls.map((c) => [c[0], Buffer.from(c[1] as Buffer | number[]).toString('hex')]),
+      ).toEqual([
+        [CHR_DOB, 'bf070808'],
+        [CHR_GENDER, '00'],
+        [CHR_HEIGHT, 'c000'],
+        [CHR_FFF3, '03'],
+        [CHR_DBINC, '01000000'],
+      ]);
+    });
+
+    it('does not commit anything when consent is rejected', async () => {
+      const a = makeAdapter();
+      const ctx = bf788Ctx();
+      await a.onConnected(ctx);
+      const write = ctx.write as ReturnType<typeof vi.fn>;
+      write.mockClear();
+
+      a.parseCharNotification(CHR_UCP, Buffer.from('200205', 'hex'));
+      await flush();
+      expect(write).not.toHaveBeenCalled();
+    });
+
+    it('commits at most once per session', async () => {
+      const a = makeAdapter();
+      const ctx = bf788Ctx();
+      await a.onConnected(ctx);
+      const write = ctx.write as ReturnType<typeof vi.fn>;
+      write.mockClear();
+
+      a.parseCharNotification(CHR_UCP, Buffer.from('200201', 'hex'));
+      a.parseCharNotification(CHR_UCP, Buffer.from('200201', 'hex'));
+      a.parseCharNotification(CHR_UCP, Buffer.from('200201', 'hex'));
+      await flush();
+
+      const increments = write.mock.calls.filter((c) => c[0] === CHR_DBINC);
+      expect(increments).toHaveLength(1);
+    });
+
+    it('never writes into the previous session after a reconnect', async () => {
+      const a = makeAdapter();
+      const ctxA = bf788Ctx();
+      await a.onConnected(ctxA);
+      const ctxB = bf788Ctx();
+      await a.onConnected(ctxB);
+      (ctxA.write as ReturnType<typeof vi.fn>).mockClear();
+      (ctxB.write as ReturnType<typeof vi.fn>).mockClear();
+
+      a.parseCharNotification(CHR_UCP, Buffer.from('200201', 'hex'));
+      await flush();
+
+      expect(ctxA.write as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+      expect(ctxB.write as ReturnType<typeof vi.fn>).toHaveBeenCalled();
+    });
+
+    it('skips characteristics the scale does not expose', async () => {
+      const a = makeAdapter();
+      const ctx = bf788Ctx({
+        availableChars: new Set([CHR_WEIGHT, CHR_BODYCOMP, CHR_UCP, CHR_DOB, CHR_DBINC]),
+      });
+      await a.onConnected(ctx);
+      const write = ctx.write as ReturnType<typeof vi.fn>;
+      write.mockClear();
+
+      a.parseCharNotification(CHR_UCP, Buffer.from('200201', 'hex'));
+      await flush();
+
+      expect(write.mock.calls.map((c) => c[0])).toEqual([CHR_DOB, CHR_DBINC]);
+    });
+
+    it('a read failure never breaks the session', async () => {
+      const a = makeAdapter();
+      const ctx = bf788Ctx({
+        read: vi.fn(async () => {
+          throw new Error('Not authorized');
+        }),
+      });
+      await a.onConnected(ctx);
+
+      expect(() => a.parseCharNotification(CHR_UCP, Buffer.from('200201', 'hex'))).not.toThrow();
+      await flush();
+    });
+
+    it('decodes a vendor user-slot frame and emits no reading', () => {
+      const a = makeAdapter();
+      expect(
+        a.parseCharNotification(CHR_FFF2, Buffer.from('0001ffffffbf070808c00103', 'hex')),
+      ).toBeNull();
+      expect(a.parseCharNotification(CHR_FFF2, Buffer.from('01', 'hex'))).toBeNull();
+      expect(a.parseCharNotification(CHR_FFF2, Buffer.from('0001ff', 'hex'))).toBeNull();
+      expect(a.parseCharNotification(CHR_FFF2, Buffer.alloc(0))).toBeNull();
+    });
+  });
 });

--- a/tests/scales/beurer-bf720.test.ts
+++ b/tests/scales/beurer-bf720.test.ts
@@ -509,6 +509,46 @@ describe('BeurerBf720Adapter', () => {
       expect(write.mock.calls.map((c) => c[0])).toEqual([CHR_DOB, CHR_DBINC]);
     });
 
+    it('still bumps the increment when one profile write is rejected', async () => {
+      // The increment is the step the scale actually waits for, so a read-only
+      // vendor characteristic on a sibling model must not cost us it.
+      const a = makeAdapter();
+      const ctx = bf788Ctx({
+        write: vi.fn(async (uuid: string) => {
+          if (uuid === uuid16(0xfff3)) throw new Error('write not permitted');
+        }),
+      });
+      await a.onConnected(ctx);
+      const write = ctx.write as ReturnType<typeof vi.fn>;
+      write.mockClear();
+
+      a.parseCharNotification(CHR_UCP, Buffer.from('200201', 'hex'));
+      await flush();
+
+      const last = write.mock.calls[write.mock.calls.length - 1];
+      expect(last[0]).toBe(CHR_DBINC);
+      expect(Buffer.from(last[1] as Buffer | number[]).toString('hex')).toBe('01000000');
+    });
+
+    it('still bumps the increment when one profile read is rejected', async () => {
+      const a = makeAdapter();
+      const ctx = bf788Ctx({
+        read: vi.fn(async (uuid: string) => {
+          if (uuid === uuid16(0x2a8e)) throw new Error('read not permitted');
+          return Buffer.from('00', 'hex');
+        }),
+      });
+      await a.onConnected(ctx);
+      const write = ctx.write as ReturnType<typeof vi.fn>;
+      write.mockClear();
+
+      a.parseCharNotification(CHR_UCP, Buffer.from('200201', 'hex'));
+      await flush();
+
+      expect(write.mock.calls.map((c) => c[0])).toContain(CHR_DBINC);
+      expect(write.mock.calls.map((c) => c[0])).not.toContain(uuid16(0x2a8e));
+    });
+
     it('a read failure never breaks the session', async () => {
       const a = makeAdapter();
       const ctx = bf788Ctx({


### PR DESCRIPTION
Promotes the 2026-07-27 issue sweep to main. Nine fixes plus docs, all confirmed by CI on dev.

## Fixes

- **#291** esphome-proxy GATT payloads decoded as base64 `data` rather than the non-existent `dataList`. Every GATT notification and read over that transport had decoded to zero bytes since v1.14.0. Root-caused and patched by @bondesen in #295.
- **#252** the CCC descriptor (0x2902) was never written over the esphome proxy, so scales that honour it strictly (QN, Renpho) were never told to notify at all. Adds the descriptor write, per-session request serialization, and immediate failure on a rejected CCCD instead of a 5 second stall.
- **#297** BlueZ deletes a non-connectable peer's `org.bluez.Device1` object when discovery stops, so the connect hit a dead object every cycle. Recovery now connects with discovery active once that error is seen.
- **#296** the ESP32 parked its scan after one autonomous connect: with lazy notify no notify reader runs, and that reader was the only producer of the disconnect signal. Adds a session guard, plus host-side supersede of a stale in-flight session and a warning when mqtt-proxy runs without continuous mode.
- **#229** the Beurer app reads the user profile back off the scale, writes it back and bumps the database change increment after consent. Decoded from the reporter's capture: every body-composition frame before that commit is zeroed, the real one arrives after it.
- **#294** the Home Assistant add-on changelog was hand-maintained and 16 releases behind. It is now generated from the project changelog, backfilled, guarded by a test, and synced automatically on the release PR.

## Also

- `unlockIntervalMs ?? 5000` never caught a declared `0`, so four adapters armed `setInterval(fn, 0)`, roughly a 1 ms write flood for a whole session on every transport. Pre-existing, unrelated to the above.
- An optional notify binding whose subscribe was rejected used to abort the entire reading.

## Verification

2010 vitest tests, 113 firmware tests, tsc / eslint / prettier clean, CI green on 943bc81.

Merge with a merge commit, not squash, so release-please sees each Conventional Commit separately.