### PR TITLE
fix(ci): fetch the release branch with a refspec so the add-on changelog sync can check it out

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,7 +55,9 @@ jobs:
             echo "No release-please branch, nothing to sync."
             exit 0
           fi
-          git fetch --depth 1 origin "$BRANCH"
+          # Explicit refspec: a shallow clone has no remote-tracking ref for
+          # this branch, and a plain `fetch <branch>` only writes FETCH_HEAD.
+          git fetch --depth 1 origin "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
           git switch --track "origin/$BRANCH"
           node src/tools/sync-addon-changelog.ts
           if git diff --quiet -- ble-scale-sync-addon/CHANGELOG.md; then


### PR DESCRIPTION
Follow-up to the #294 automation, which failed on its first live run.

The step does a shallow `git clone`, which gives no remote-tracking ref for the release branch, and `git fetch --depth 1 origin <branch>` only writes `FETCH_HEAD`. So `git switch --track origin/<branch>` aborted with `fatal: invalid reference`.

Fetching with an explicit refspec creates the tracking ref, so the checkout works.

Pushing this to main re-runs release-please, which is also how the fix verifies itself: the corrected step should sync `ble-scale-sync-addon/CHANGELOG.md` onto the open release PR (#299) automatically.