### PR TITLE
fix(ble): tear down the replacement client when an ESPHome rebuild fails (#303)

### DIFF
--- a/src/ble/handler-esphome-proxy/pool.ts
+++ b/src/ble/handler-esphome-proxy/pool.ts
@@ -208,6 +208,17 @@ export class EsphomeProxyPool {
 
   private async rebuildClient(ep: ProxyEndpoint): Promise<void> {
     this.rebuilding.add(ep.id);
+    // Hoisted so the catch can tear the replacement down. Left inside the try
+    // they were unreachable on the failure path, and a half-built client does
+    // not stay quietly broken: the library is constructed with reconnect:true,
+    // so it revives on its own, re-runs subscribeBluetoothAdvertisementService
+    // and starts emitting 'ble' into a handler for an endpoint that is no
+    // longer in this.clients. onAd would then refresh liveness forever (so the
+    // watchdog never fires again) while connectGatt skips the endpoint for
+    // having no client (so every GATT read fails), and stop() would never
+    // disconnect it because it iterates this.clients.
+    let client: EsphomeClient | undefined;
+    let handler: ((ad: EsphomeBleAdvertisement) => void) | undefined;
     try {
       const old = this.clients.get(ep.id);
       const oldHandler = this.adHandlers.get(ep.id);
@@ -221,7 +232,7 @@ export class EsphomeProxyPool {
       this.adHandlers.delete(ep.id);
       if (!this.started) return;
 
-      const client = await createEsphomeClient({
+      client = await createEsphomeClient({
         host: ep.host,
         port: ep.port,
         encryption_key: ep.encryption_key,
@@ -230,7 +241,7 @@ export class EsphomeProxyPool {
         additional_proxies: [],
         advertisement_timeout: 0,
       } as EsphomeProxyConfig);
-      const handler = (ad: EsphomeBleAdvertisement): void => this.onAd(ep.id, ad);
+      handler = (ad: EsphomeBleAdvertisement): void => this.onAd(ep.id, ad);
       client.on('ble', handler);
       await waitForConnected(client, ep.id);
       if (!this.started) {
@@ -254,6 +265,18 @@ export class EsphomeProxyPool {
       }
       bleLog.info(`ESPHome proxy ${ep.id} rebuilt after advertisement silence`);
     } catch (err) {
+      // Tear the half-built replacement down before anything else, so it cannot
+      // revive behind our back and masquerade as a healthy endpoint.
+      if (client) {
+        if (handler) {
+          try {
+            client.removeListener('ble', handler as (...args: unknown[]) => void);
+          } catch {
+            /* ignore */
+          }
+        }
+        await safeDisconnect(client);
+      }
       this.rebuildAttempts.set(ep.id, (this.rebuildAttempts.get(ep.id) ?? 0) + 1);
       bleLog.warn(
         `ESPHome proxy ${ep.id} rebuild failed: ${errMsg(err)}. Will retry with backoff.`,

--- a/tests/ble/esphome-proxy/liveness-watchdog.test.ts
+++ b/tests/ble/esphome-proxy/liveness-watchdog.test.ts
@@ -142,3 +142,59 @@ describe('ESPHome advertisement liveness watchdog (#303)', () => {
     expect(createEsphomeClient).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('a failed rebuild must not leave an orphan client (#303)', () => {
+  beforeEach(() => {
+    created = [];
+    createEsphomeClient.mockClear();
+    safeDisconnect.mockClear();
+    waitForConnected.mockReset();
+    waitForConnected.mockImplementation(async () => {});
+    vi.spyOn(bleLog, 'info').mockImplementation(() => {});
+    vi.spyOn(bleLog, 'warn').mockImplementation(() => {});
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    waitForConnected.mockImplementation(async () => {});
+  });
+
+  it('disconnects the half-built client and detaches its listener', async () => {
+    const pool = new EsphomeProxyPool(cfg(180));
+    await pool.start();
+    expect(created).toHaveLength(1);
+
+    // The rebuild's connect fails, which is the normal case when the watchdog
+    // fires because the proxy is actually unreachable.
+    waitForConnected.mockRejectedValueOnce(new Error('Timed out connecting'));
+    await vi.advanceTimersByTimeAsync(200_000);
+
+    const replacement = created[1];
+    expect(replacement).toBeDefined();
+    // The replacement must have been torn down, not abandoned. Left attached it
+    // revives on its own (the library is built with reconnect:true) and starts
+    // feeding onAd for an endpoint that is no longer in this.clients.
+    expect(safeDisconnect).toHaveBeenCalledWith(replacement);
+    expect(replacement.listenerCount('ble')).toBe(0);
+  });
+
+  it('an orphan cannot masquerade as a healthy endpoint', async () => {
+    const pool = new EsphomeProxyPool(cfg(180));
+    await pool.start();
+
+    waitForConnected.mockRejectedValueOnce(new Error('Timed out connecting'));
+    await vi.advanceTimersByTimeAsync(200_000);
+    const orphan = created[1];
+    const callsAfterFirstRebuild = createEsphomeClient.mock.calls.length;
+
+    // If the orphan's listener were still attached, this advertisement would
+    // refresh lastAdAt and the watchdog would never fire again.
+    orphan.emit('ble', { address: 0x03b3ec93b87e, name: 'Hutbit', rssi: -60 });
+    await vi.advanceTimersByTimeAsync(400_000);
+
+    expect(createEsphomeClient.mock.calls.length).toBeGreaterThan(callsAfterFirstRebuild);
+    await pool.stop();
+  });
+});


### PR DESCRIPTION
Single fix found by the post-release adversarial review of v1.22.0.

`rebuildClient` declared the new client and handler with `const` inside the `try`, so the `catch` could not reach them. When `waitForConnected` rejected (the normal case when the watchdog fires *because* the proxy is unreachable) the half-built client was abandoned with its `ble` listener attached. Since it is built with `reconnect: true` it revived on its own, re-subscribed, and fed `onAd` for an endpoint already deleted from `this.clients` — so the pool believed it healthy and never rebuilt again, while `connectGatt` skipped it and every GATT read failed permanently. `stop()` never disconnected it either.

Same leak class the `safeDisconnect` change was meant to close, and worse than doing nothing: without the rebuild the library's own reconnect would have healed the still-registered original.

Reachable only with `advertisement_timeout` set; the default of 0 disables the watchdog entirely, so v1.22.0 installs on defaults are unaffected.

Two regression tests added. 2073 tests passing, tsc/eslint/prettier clean.