### PR TITLE
fix(firmware): use current esptool commands

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,13 @@ updates:
       prefix: "ci:"
     labels:
       - ci
+
+  - package-ecosystem: pip
+    directory: /firmware
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "deps:"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,13 +18,3 @@ updates:
       prefix: "ci:"
     labels:
       - ci
-
-  - package-ecosystem: pip
-    directory: /firmware
-    schedule:
-      interval: monthly
-    commit-message:
-      prefix: "deps:"
-    open-pull-requests-limit: 5
-    labels:
-      - dependencies

--- a/docs/guide/esp32-proxy.md
+++ b/docs/guide/esp32-proxy.md
@@ -92,14 +92,13 @@ BLE Scale Sync now ships with an embedded MQTT broker. If you don't already run 
 
 ### Host tools (install once)
 
-From the `firmware/` directory, create or activate the virtual environment and install the tested host-tool versions:
+Install the tested host-tool versions:
 
 ```bash
-cd firmware
-python3 -m venv venv  # first time only
-source venv/bin/activate
-pip3 install -r requirements-flash.txt
+pip install -r firmware/requirements-flash.txt
 ```
+
+esptool 5.x needs Python 3.10 or newer. If you prefer a virtual environment, create it inside `firmware/` first with `python -m venv venv`, then activate it: `source venv/bin/activate` on macOS and Linux, `source venv/Scripts/activate` in Git Bash on Windows, or `venv\Scripts\Activate.ps1` in PowerShell.
 
 ## Flashing the Firmware
 
@@ -160,7 +159,7 @@ The script auto-detects the serial port. Override with `PORT=/dev/ttyACM0 ./flas
   ```powershell
   # 1. Erase + flash MicroPython (download the .bin from micropython.org for your board first)
   esptool --chip esp32s3 --port COM3 erase-flash
-  esptool --chip esp32s3 --port COM3 --baud 460800 write-flash -z 0x0 ESP32_GENERIC_S3-SPIRAM_OCT-v1.27.0.bin
+  esptool --chip esp32s3 --port COM3 --baud 460800 write-flash 0x0 ESP32_GENERIC_S3-SPIRAM_OCT-v1.27.0.bin
 
   # 2. Install MicroPython libraries
   mpremote connect COM3 mip install aioble
@@ -332,7 +331,7 @@ Compare this to the standard [Docker deployment](/guide/getting-started#docker) 
 | `board_guition_4848.py`      | Guition 4848 config (LVGL display)          |
 | `panel_init_guition_4848.py` | ST7701S panel init sequence data            |
 | `ui.py`                      | LVGL display UI (boards with `HAS_DISPLAY`) |
-| `requirements.txt`           | MicroPython library dependencies (via `mip`) |
+| `requirements.txt`           | MicroPython libraries installed via `mip`   |
 | `requirements-flash.txt`     | Pinned host tools for `flash.sh`            |
 
 :::

--- a/docs/guide/esp32-proxy.md
+++ b/docs/guide/esp32-proxy.md
@@ -92,8 +92,13 @@ BLE Scale Sync now ships with an embedded MQTT broker. If you don't already run 
 
 ### Host tools (install once)
 
+From the `firmware/` directory, create or activate the virtual environment and install the tested host-tool versions:
+
 ```bash
-pip install esptool mpremote
+cd firmware
+python3 -m venv venv  # first time only
+source venv/bin/activate
+pip3 install -r requirements-flash.txt
 ```
 
 ## Flashing the Firmware
@@ -154,8 +159,8 @@ The script auto-detects the serial port. Override with `PORT=/dev/ttyACM0 ./flas
 
   ```powershell
   # 1. Erase + flash MicroPython (download the .bin from micropython.org for your board first)
-  esptool.py --chip esp32s3 --port COM3 erase_flash
-  esptool.py --chip esp32s3 --port COM3 --baud 460800 write_flash -z 0x0 ESP32_GENERIC_S3-SPIRAM_OCT-v1.27.0.bin
+  esptool --chip esp32s3 --port COM3 erase-flash
+  esptool --chip esp32s3 --port COM3 --baud 460800 write-flash -z 0x0 ESP32_GENERIC_S3-SPIRAM_OCT-v1.27.0.bin
 
   # 2. Install MicroPython libraries
   mpremote connect COM3 mip install aioble
@@ -327,7 +332,8 @@ Compare this to the standard [Docker deployment](/guide/getting-started#docker) 
 | `board_guition_4848.py`      | Guition 4848 config (LVGL display)          |
 | `panel_init_guition_4848.py` | ST7701S panel init sequence data            |
 | `ui.py`                      | LVGL display UI (boards with `HAS_DISPLAY`) |
-| `requirements.txt`           | MicroPython library dependencies            |
+| `requirements.txt`           | MicroPython library dependencies (via `mip`) |
+| `requirements-flash.txt`     | Pinned host tools for `flash.sh`            |
 
 :::
 

--- a/drivers/build.sh
+++ b/drivers/build.sh
@@ -160,7 +160,7 @@ main() {
     green "  1. Flash:  cd ../firmware && ./flash.sh --board ${board_name}"
     green "  2. Or manually:"
     green "     esptool --chip esp32s3 --port /dev/ttyUSB0 --baud 460800 \\"
-    green "       write-flash -z 0x0 ${FIRMWARE_DIR}/firmware_${board_name}.bin"
+    green "       write-flash 0x0 ${FIRMWARE_DIR}/firmware_${board_name}.bin"
     green "═══════════════════════════════════════════════════"
 }
 

--- a/drivers/build.sh
+++ b/drivers/build.sh
@@ -159,8 +159,8 @@ main() {
     green "  Next steps:"
     green "  1. Flash:  cd ../firmware && ./flash.sh --board ${board_name}"
     green "  2. Or manually:"
-    green "     esptool.py --chip esp32s3 --port /dev/ttyUSB0 --baud 460800 \\"
-    green "       write_flash -z 0x0 ${FIRMWARE_DIR}/firmware_${board_name}.bin"
+    green "     esptool --chip esp32s3 --port /dev/ttyUSB0 --baud 460800 \\"
+    green "       write-flash -z 0x0 ${FIRMWARE_DIR}/firmware_${board_name}.bin"
     green "═══════════════════════════════════════════════════"
 }
 

--- a/firmware/flash.sh
+++ b/firmware/flash.sh
@@ -3,9 +3,8 @@
 # Flash MicroPython + BLE-MQTT bridge firmware to an ESP32 / ESP32-S3.
 #
 # Prerequisites (install once, from this directory):
-#   python3 -m venv venv
-#   source venv/bin/activate
-#   pip3 install -r requirements-flash.txt
+#   pip install -r requirements-flash.txt
+# esptool 5.x needs Python 3.10 or newer.
 #
 # Usage:
 #   ./flash.sh                          # full flash (auto-detect board)
@@ -53,7 +52,7 @@ blue()  { printf '\033[0;34m%s\033[0m\n' "$*"; }
 die() { red "Error: $*" >&2; exit 1; }
 
 check_tool() {
-  command -v "$1" >/dev/null 2>&1 || die "$1 not found. Activate firmware/venv and install with: pip3 install -r requirements-flash.txt"
+  command -v "$1" >/dev/null 2>&1 || die "$1 not found. Install with: pip install -r firmware/requirements-flash.txt"
 }
 
 # ─── Board configuration ─────────────────────────────────────────────────────
@@ -184,7 +183,7 @@ erase_and_flash() {
   esptool --chip "$CHIP" --port "$port" erase-flash
 
   blue "Flashing MicroPython v${MICROPYTHON_VERSION} (${CHIP})..."
-  esptool --chip "$CHIP" --port "$port" --baud "$BAUD" write-flash -z "$FLASH_OFFSET" "$FIRMWARE_FILE"
+  esptool --chip "$CHIP" --port "$port" --baud "$BAUD" write-flash "$FLASH_OFFSET" "$FIRMWARE_FILE"
   green "MicroPython flashed successfully"
 
   blue "Waiting for device to reboot..."

--- a/firmware/flash.sh
+++ b/firmware/flash.sh
@@ -52,7 +52,8 @@ blue()  { printf '\033[0;34m%s\033[0m\n' "$*"; }
 die() { red "Error: $*" >&2; exit 1; }
 
 check_tool() {
-  command -v "$1" >/dev/null 2>&1 || die "$1 not found. Install with: pip install -r firmware/requirements-flash.txt"
+  # The script cd's to its own directory above, so the path is relative to firmware/.
+  command -v "$1" >/dev/null 2>&1 || die "$1 not found. Install with: pip install -r requirements-flash.txt"
 }
 
 # ─── Board configuration ─────────────────────────────────────────────────────

--- a/firmware/flash.sh
+++ b/firmware/flash.sh
@@ -2,8 +2,10 @@
 #
 # Flash MicroPython + BLE-MQTT bridge firmware to an ESP32 / ESP32-S3.
 #
-# Prerequisites (install once):
-#   pip install esptool mpremote
+# Prerequisites (install once, from this directory):
+#   python3 -m venv venv
+#   source venv/bin/activate
+#   pip3 install -r requirements-flash.txt
 #
 # Usage:
 #   ./flash.sh                          # full flash (auto-detect board)
@@ -51,7 +53,7 @@ blue()  { printf '\033[0;34m%s\033[0m\n' "$*"; }
 die() { red "Error: $*" >&2; exit 1; }
 
 check_tool() {
-  command -v "$1" >/dev/null 2>&1 || die "$1 not found. Install with: pip install $1"
+  command -v "$1" >/dev/null 2>&1 || die "$1 not found. Activate firmware/venv and install with: pip3 install -r requirements-flash.txt"
 }
 
 # ─── Board configuration ─────────────────────────────────────────────────────
@@ -106,7 +108,7 @@ detect_board() {
   local port="$1"
   blue "Auto-detecting board..."
   local chip_info
-  chip_info=$(esptool.py --port "$port" chip_id 2>&1) || die "Could not identify chip. Is the ESP32 in download mode?"
+  chip_info=$(esptool --port "$port" chip-id 2>&1) || die "Could not identify chip. Is the ESP32 in download mode?"
 
   if echo "$chip_info" | grep -qi "ESP32-S3"; then
     green "Detected: ESP32-S3"
@@ -179,10 +181,10 @@ download_firmware() {
 erase_and_flash() {
   local port="$1"
   blue "Erasing flash..."
-  esptool.py --chip "$CHIP" --port "$port" erase_flash
+  esptool --chip "$CHIP" --port "$port" erase-flash
 
   blue "Flashing MicroPython v${MICROPYTHON_VERSION} (${CHIP})..."
-  esptool.py --chip "$CHIP" --port "$port" --baud "$BAUD" write_flash -z "$FLASH_OFFSET" "$FIRMWARE_FILE"
+  esptool --chip "$CHIP" --port "$port" --baud "$BAUD" write-flash -z "$FLASH_OFFSET" "$FIRMWARE_FILE"
   green "MicroPython flashed successfully"
 
   blue "Waiting for device to reboot..."
@@ -257,7 +259,7 @@ main() {
     esac
   done
 
-  check_tool esptool.py
+  check_tool esptool
   check_tool mpremote
 
   local port

--- a/firmware/requirements-flash.txt
+++ b/firmware/requirements-flash.txt
@@ -1,0 +1,4 @@
+# Host tools used by flash.sh.
+# Install with: pip3 install -r requirements-flash.txt
+esptool==5.2.0
+mpremote==1.28.0

--- a/firmware/requirements-flash.txt
+++ b/firmware/requirements-flash.txt
@@ -1,4 +1,4 @@
-# Host tools used by flash.sh.
-# Install with: pip3 install -r requirements-flash.txt
+# Host tools used by flash.sh. Requires Python 3.10 or newer (esptool 5.x).
+# Install with: pip install -r requirements-flash.txt
 esptool==5.2.0
 mpremote==1.28.0


### PR DESCRIPTION
Update the ESP32 flashing workflow to use the supported esptool v5 executable and hyphenated subcommands instead of the removed `esptool.py` entry point and legacy underscore command names.

The host flashing tools are pinned in `firmware/requirements-flash.txt`, and the firmware guide and display-board build instructions now use the same commands. This prevents fresh installations from failing because the documented commands no longer match the installed esptool version, while keeping tool and library versions reproducible and avoiding unexpected upgrades that could introduce compatibility issues or bugs.

The ESP32-S3 hardware flash completed successfully, and the current `flash.sh` passes `bash -n` syntax validation.

Verification evidence:

- `bash -n firmware/flash.sh`
- `bash -n drivers/build.sh`
- `git diff --check`
- `npm run format:check`
- `npm run build`
- `npm run docs:build`
- Firmware unit tests: 113 passed
- Host tools installed and checked: esptool 5.2.0, mpremote 1.28.0

Complete successful ESP32-S3 hardware flash log from `/dev/cu.usbmodem5B8F0010671`:

```text
(venv) ➜  firmware git:(main) ✗ PORT=/dev/cu.usbmodem5B8F0010671 ./flash.sh
Using port: /dev/cu.usbmodem5B8F0010671
Auto-detecting board...
Detected: ESP32-S3
Board: esp32_s3 (chip: esp32s3, baud: 460800)
Firmware already downloaded: ESP32_GENERIC_S3-SPIRAM_OCT-v1.27.0.bin
Erasing flash...
esptool v5.2.0
Connected to ESP32-S3 on /dev/cu.usbmodem5B8F0010671:
Chip type:          ESP32-S3 (QFN56) (revision v0.2)
Features:           Wi-Fi, BT 5 (LE), Dual Core + LP Core, 240MHz, Embedded PSRAM 8MB (AP_3v3)
Crystal frequency:  40MHz
MAC:                84:fc:e6:53:06:1c

Stub flasher running.

Flash memory erased successfully in 6.8 seconds.

Hard resetting via RTS pin...
Flashing MicroPython v1.27.0 (esp32s3)...
esptool v5.2.0
Connected to ESP32-S3 on /dev/cu.usbmodem5B8F0010671:
Chip type:          ESP32-S3 (QFN56) (revision v0.2)
Features:           Wi-Fi, BT 5 (LE), Dual Core + LP Core, 240MHz, Embedded PSRAM 8MB (AP_3v3)
Crystal frequency:  40MHz
MAC:                84:fc:e6:53:06:1c

Stub flasher running.
Changing baud rate to 460800...
Changed.

Configuring flash size...
Flash will be erased from 0x00000000 to 0x001adfff...
Wrote 1757376 bytes (1150313 compressed) at 0x00000000 in 26.9 seconds (523.6 kbit/s).
Hash of data verified.

Hard resetting via RTS pin...
MicroPython flashed successfully
Waiting for device to reboot...
Installing aioble...
Install aioble
Installing aioble (latest) from https://micropython.org/pi/v2 to /lib
Installing: /lib/aioble/__init__.mpy
Installing: /lib/aioble/core.mpy
Installing: /lib/aioble/device.mpy
Installing: /lib/aioble/peripheral.mpy
Installing: /lib/aioble/server.mpy
Installing: /lib/aioble/central.mpy
Installing: /lib/aioble/client.mpy
Installing: /lib/aioble/l2cap.mpy
Installing: /lib/aioble/security.mpy
Done
Installing mqtt_as (Peter Hinch)...
Install github:peterhinch/micropython-mqtt
Installing github:peterhinch/micropython-mqtt/package.json to /lib
Installing: /lib/mqtt_as/__init__.py
Installing: /lib/mqtt_as/mqtt_v5_properties.py
Installing: /lib/mqtt_as/range.py
Installing: /lib/mqtt_as/range_ex.py
Installing: /lib/mqtt_as/clean.py
Installing: /lib/mqtt_local_example.py
Done
Installing async primitives (mqtt_as dependency)...
Install github:peterhinch/micropython-async/v3/primitives
Installing: /lib/primitives/__init__.py
Installing: /lib/primitives/aadc.py
Installing: /lib/primitives/barrier.py
Installing: /lib/primitives/condition.py
Installing: /lib/primitives/delay_ms.py
Installing: /lib/primitives/encoder.py
Installing: /lib/primitives/events.py
Installing: /lib/primitives/pushbutton.py
Installing: /lib/primitives/queue.py
Installing: /lib/primitives/ringbuf_queue.py
Installing: /lib/primitives/semaphore.py
Installing: /lib/primitives/switch.py
Installing: /lib/primitives/sw_array.py
Done
Libraries installed
Uploading application files for esp32_s3...
cp config.json :config.json
cp boot.py :boot.py
cp board.py :board.py
cp board_esp32_s3.py :board_esp32_s3.py
cp ble_bridge.py :ble_bridge.py
cp beep.py :beep.py
cp main.py :main.py
Application uploaded (board: esp32_s3)
Resetting device...
Done! The ESP32 should now connect to WiFi and MQTT.

═══════════════════════════════════════════════════
  ESP32 BLE-MQTT bridge flashed successfully!
  Board: esp32_s3 (esp32s3)
═══════════════════════════════════════════════════

  Next steps:
  1. Check serial output:  mpremote connect /dev/cu.usbmodem5B8F0010671 repl
  2. Verify MQTT status:   mosquitto_sub -t 'ble-proxy/+/status'
  3. Configure ble-scale-sync:
     ble:
       handler: mqtt-proxy
       mqtt_proxy:
         broker_url: mqtt://<your-broker>:1883
```