### PR TITLE
feat(qn): decode extended-dialect b4/b1 result frames so weight reaches the exporters (#235)

### DIFF
--- a/src/scales/qn-scale.ts
+++ b/src/scales/qn-scale.ts
@@ -176,6 +176,42 @@ const EXTENDED_MEASUREMENT_TRIGGER = [0xa2, 0x06, 0x01, 0x1e, 0x23, 0xea];
 const TRIGGER_REPEATS = 2;
 const TRIGGER_GAP_MS = 150;
 
+/**
+ * Completed-weigh-in result frames on the extended dialect (#235).
+ *
+ * The 20-byte GE CS 10 G / "Fit Plus" does NOT stream 0x10 live frames after a
+ * full body-composition weigh-in. Once the impedance sweep finishes it sends a
+ * burst of result frames the adapter had been dropping at the ignore branch, so
+ * the handshake succeeded end to end yet nothing ever reached the exporters:
+ *
+ *   0xB4 .. 04 01 : consolidated result, 44 bytes. Authoritative final weight.
+ *       [7-10]  measurement timestamp, LE uint32 (scale 2000-epoch)
+ *       [11-12] final weight, LE uint16, /100 kg   (matches the scale display)
+ *       [13..]  multi-frequency / segmental impedance channels, LE uint16 each
+ *   0xB1 .. 03 01 : first multi-part record, 44 bytes. Fallback weight source.
+ *       [5-6]   in-progress weight, LE uint16, /100 kg
+ *       [7..]   impedance channels
+ *
+ * @hedoric hardware-verified both against the scale's own display: weight
+ * 75.20 kg, and BMI 20.2 in the 0xB1 03 03 tail, cross-checked as
+ * 75.20 / 1.93^2 = 20.19. Every frame carries the standard QN trailing sum
+ * checksum. The 0xB4 value is the scale's final averaged weight; the 0xB1 03 01
+ * sample reads a few hundred grams high, so 0xB4 is preferred and 0xB1 03 01 is
+ * only used when no 0xB4 arrives.
+ *
+ * Impedance is deliberately NOT forwarded to the BIA estimator yet. The channels
+ * are a proprietary multi-frequency segmental sweep in raw units (~2,300-3,050),
+ * not the single ~500 ohm whole-body value computeBiaFat expects (it divides
+ * height^2 / impedance), and feeding one in raw yields a ~57% fat nonsense.
+ * Until the channels are calibrated the reading is emitted weight-only, so body
+ * composition falls back to the same profile-based estimate broadcast-only
+ * scales already use. Weight and BMI are the parts this decode is sure of.
+ */
+const RESULT_OPCODE_B4 = 0xb4;
+const RESULT_OPCODE_B1 = 0xb1;
+const RESULT_MIN_WEIGHT_KG = 5;
+const RESULT_MAX_WEIGHT_KG = 300;
+
 export class QnScaleAdapter
   implements ScaleAdapterCore, GattWiring, BroadcastSource, MultiCharNotify
 {
@@ -253,6 +289,14 @@ export class QnScaleAdapter
    * it, unlike the 18-byte ES-26M frame which needs 0x00.
    */
   private isExtendedLongFrame = false;
+
+  /**
+   * Whether a completed-weigh-in result frame (0xB4/0xB1) has already produced a
+   * reading this session. The scale repeats the 0xB4 frame ~3x and then sends
+   * the 0xB1 records, all describing the one weigh-in, so the reading is emitted
+   * exactly once and the repeats are suppressed (#235).
+   */
+  private extendedResultEmitted = false;
 
   /**
    * Timestamp (Date.now()) of the first stable R1=R2=0 frame seen on a
@@ -365,6 +409,7 @@ export class QnScaleAdapter
     this.ae00ResponsesSent = 0;
     this.isLongFrameVariant = false;
     this.isExtendedLongFrame = false;
+    this.extendedResultEmitted = false;
     this.firstStableNoImpedanceAt = null;
     this.sessionStartedScaleSeconds = Math.floor(Date.now() / 1000) - SCALE_EPOCH_OFFSET;
     this.configSent = false;
@@ -752,6 +797,19 @@ export class QnScaleAdapter
       return { weight, impedance: r1 > 0 ? r1 : r2 };
     }
 
+    // Extended-dialect completed-weigh-in result frames (#235). Gated to the
+    // 20-byte dialect so no other QN variant is touched. On this firmware the
+    // scale never streams 0x10 after a full body-composition weigh-in; it sends
+    // these 0xB4/0xB1 frames instead, which were dropped at the ignore branch
+    // below, so nothing reached MQTT even though the whole handshake succeeded.
+    if (this.isExtendedLongFrame && (opcode === RESULT_OPCODE_B4 || opcode === RESULT_OPCODE_B1)) {
+      const reading = this.parseExtendedResultFrame(data);
+      // Return null (not fall through) for the non-weight parts of the burst —
+      // the repeated 0xB4s, the 0xB1 03 02/03 records — so they are consumed
+      // quietly instead of re-logged as ignored frames.
+      return reading;
+    }
+
     // 0x10: live weight frame.
     // Anything else lands here and used to be discarded in silence, which is why
     // #75 read as a decode bug: the AE00 challenge frames the scale sends on AE02
@@ -841,6 +899,50 @@ export class QnScaleAdapter
     }
 
     return { weight, impedance };
+  }
+
+  /**
+   * Decode an extended-dialect completed-weigh-in result frame (#235).
+   *
+   * Accepts the consolidated 0xB4 (weight at [11]) or, as a fallback, the first
+   * multi-part 0xB1 03 01 record (weight at [5]). Returns a weight-only reading
+   * (impedance 0 — see RESULT_OPCODE_* for why the raw channels are not used
+   * yet), or null when the frame is not a recognised result frame, fails its
+   * trailing sum checksum, carries an out-of-range weight, or a reading was
+   * already emitted this session.
+   */
+  private parseExtendedResultFrame(data: Buffer): ScaleReading | null {
+    if (this.extendedResultEmitted) return null;
+
+    // Standard QN trailing checksum: sum of every byte but the last, mod 256.
+    // Verified against every captured 0xB4/0xB1 frame; a cheap guard against a
+    // truncated or mis-framed notification being read as a weight.
+    let sum = 0;
+    for (let i = 0; i < data.length - 1; i++) sum = (sum + data[i]) & 0xff;
+    if (sum !== data[data.length - 1]) return null;
+
+    let rawWeight: number | null = null;
+    if (data[0] === RESULT_OPCODE_B4 && data.length >= 13 && data[2] === 0x04 && data[3] === 0x01) {
+      rawWeight = data.readUInt16LE(11);
+    } else if (
+      data[0] === RESULT_OPCODE_B1 &&
+      data.length >= 7 &&
+      data[2] === 0x03 &&
+      data[3] === 0x01
+    ) {
+      rawWeight = data.readUInt16LE(5);
+    }
+    if (rawWeight === null) return null;
+
+    const weight = rawWeight / 100;
+    if (weight <= RESULT_MIN_WEIGHT_KG || weight >= RESULT_MAX_WEIGHT_KG) return null;
+
+    this.extendedResultEmitted = true;
+    bleLog.debug(
+      `QN: extended result 0x${data[0].toString(16)} decoded ${weight}kg ` +
+        '(impedance sweep not yet calibrated, emitting weight-only) #235',
+    );
+    return { weight, impedance: 0 };
   }
 
   // ── State machine handlers (fire-and-forget from parseNotification) ─────

--- a/tests/scales/qn-scale.test.ts
+++ b/tests/scales/qn-scale.test.ts
@@ -716,6 +716,67 @@ describe('QnScaleAdapter', () => {
     });
   });
 
+  describe('extended-dialect result frames (#235)', () => {
+    // Real 20-byte extended scale-info frame from @hedoric's GE CS 10 G capture.
+    // byte[1] == 0x14 (20) marks the long frame; length 20 sets the extended
+    // dialect, which is what gates the 0xB4/0xB1 decode.
+    const EXT_INFO = Buffer.from('1214ff4ec70e0007ff140f4200020503e06f2b37', 'hex');
+    // Real result frames from the same weigh-in the scale displayed as 75.20 kg.
+    const B4_RESULT = Buffer.from(
+      'b42c040101020178ac1832601dd20b7c0ab50b560a0c0ad608bd099f0828015a01530bfa092a0bc6099a0a45',
+      'hex',
+    );
+    const B1_0301 = Buffer.from(
+      'b12c030101651ddd0b6c0a720b140acb0a8209760a32090c01f200650b090a350bd009900a5b091b0ad30811',
+      'hex',
+    );
+
+    function extendedAdapter() {
+      const adapter = makeAdapter();
+      expect(adapter.parseNotification(EXT_INFO)).toBeNull(); // sets isExtendedLongFrame
+      return adapter;
+    }
+
+    it('decodes the 0xB4 result frame to the displayed weight', () => {
+      const adapter = extendedAdapter();
+      const reading = adapter.parseNotification(B4_RESULT);
+      expect(reading).not.toBeNull();
+      expect(reading!.weight).toBe(75.2);
+      // Impedance intentionally 0: raw sweep channels are not BIA-calibrated yet.
+      expect(reading!.impedance).toBe(0);
+    });
+
+    it('emits the result exactly once across the repeated burst', () => {
+      const adapter = extendedAdapter();
+      expect(adapter.parseNotification(B4_RESULT)).not.toBeNull();
+      // The scale repeats 0xB4 ~3x and then sends 0xB1 records for the same
+      // weigh-in; none of the repeats should produce a second reading.
+      expect(adapter.parseNotification(B4_RESULT)).toBeNull();
+      expect(adapter.parseNotification(B1_0301)).toBeNull();
+    });
+
+    it('falls back to 0xB1 03 01 when no 0xB4 arrives', () => {
+      const adapter = extendedAdapter();
+      const reading = adapter.parseNotification(B1_0301);
+      expect(reading).not.toBeNull();
+      expect(reading!.weight).toBe(75.25);
+    });
+
+    it('rejects a result frame with a corrupted checksum', () => {
+      const adapter = extendedAdapter();
+      const bad = Buffer.from(B4_RESULT);
+      bad[bad.length - 1] ^= 0xff; // break the trailing sum checksum
+      expect(adapter.parseNotification(bad)).toBeNull();
+    });
+
+    it('does not decode result frames on a non-extended dialect', () => {
+      const adapter = makeAdapter(); // no extended 0x12 seen → classic dialect
+      // Same bytes, but the gate is closed, so it falls through to the ignore
+      // branch and returns null rather than a spurious weight.
+      expect(adapter.parseNotification(B4_RESULT)).toBeNull();
+    });
+  });
+
   describe('parseBroadcast()', () => {
     it('parses stable reading', () => {
       const adapter = makeAdapter();


### PR DESCRIPTION
Closes the last gap in #235. Auth (E1), the proto=0xff dialect fix and the a2 06 01 1e 23 ea trigger all shipped in v1.23.0, and my GE CS 10 G runs the whole handshake correctly — but on a completed weigh-in it never streams 0x10. It sends a burst of 0xb4/0xb1 frames that the adapter dropped at the ignoring frame opcode=… branch, so the MQTT exporter had nothing to publish even though the healthcheck passed and the session looked healthy.

What this does. Decodes the 0xb4 consolidated result frame (weight = uint16LE(bytes[11:13]) / 100), with 0xb1 03 01 (weight = uint16LE(bytes[5:7]) / 100) as a fallback when no 0xb4 arrives, and returns a ScaleReading so a reading completes and publishes. The decode is:

gated on isExtendedLongFrame — no other QN dialect is touched;
checksum-validated — the standard QN trailing sum guards against a truncated/mis-framed notification being read as a weight;
emitted once per session — the scale repeats 0xb4 ~3× then sends the 0xb1 records for the same weigh-in, so a session flag suppresses the repeats.

Verified. Weight and BMI are hardware-verified against the scale's own display: 75.20 kg, BMI 20.2 (from the 0xb1 03 03 tail), cross-checked as 75.20 / 1.93² = 20.19. Both of my connects in the attached log decode to 75.20 kg and every frame's trailing checksum validates. Tests are built from those real frames; vitest, tsc, eslint and prettier are all green.

Deliberately out of scope: impedance / body composition. The 0xb4/0xb1 frames carry a proprietary multi-frequency segmental sweep (~2,300–3,050 raw units per channel), not the single ~500 Ω whole-body value computeBiaFat expects — it divides height² / impedance, and feeding a raw channel in produces ~57 % fat. So this PR emits the reading weight-only (impedance: 0), which routes body composition through the same profile-based estimate the broadcast-only scales already use. Weight and BMI are exact; that's the part this decode is sure of. I'm happy to follow up on calibrating the impedance channels against my display values (fat 10.5 %, water 64.5 %, muscle 85 %, bone 4.5 %, visceral 3 at 75.20 kg / 193 cm) in a separate PR if useful.