### PR TITLE
fix(qn): apply the protocol byte override to the classic dialect and the pre-0x12 phases

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -62,18 +62,18 @@ ble:
   # qn_protocol_byte: 0
 ```
 
-| Field                 | Required                    | Default        | Description                                                                                                                                                                                          |
-| --------------------- | --------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `scale_mac`           | Recommended                 | Auto-discovery | MAC address, or a CoreBluetooth UUID on macOS (bare 32-hex as the wizard writes it, or the dashed form). Prevents connecting to a neighbor's scale.                                                  |
-| `bind_key`            | Xiaomi S800 only            | (none)         | 32-char hex per-device MiBeacon key from the Mi cloud (extract with the community Xiaomi-cloud-tokens-extractor). Decrypts only the device's own FE95 broadcast. Keep it secret; it is a credential. |
-| `handler`             | No                          | `auto`         | Transport: `auto` (local radio), `mqtt-proxy` (ESP32 over MQTT), `esphome-proxy` (ESPHome Native API). See below.                                                                                    |
-| `noble_driver`        | No                          | OS default     | `abandonware` or `stoprocent`. Overrides the default BLE driver. Only applies when `handler: auto`.                                                                                                  |
-| `adapter`             | No                          | System default | Linux only. Select a specific Bluetooth adapter (e.g., `hci0`, `hci1`). See below.                                                                                                                   |
-| `force_scale_adapter` | No                          | Auto-detect    | Name of the scale protocol adapter to use, bypassing auto-detection. Requires `scale_mac`. See below.                                                                                                |
-| `session_timeout_sec` | No                          | `120`          | Seconds one GATT session may wait for a complete reading (5 to 600). Native BLE handlers only; ignored on `mqtt-proxy` and `esphome-proxy`. See below.                                               |
-| `qn_protocol_byte`    | No                          | Auto           | QN-family scales only. Protocol byte the handshake echoes back to the scale (0 to 255). Set it only when a QN scale runs the whole handshake and then reports nothing. See below.                    |
-| `mqtt_proxy`          | If `handler: mqtt-proxy`    | (none)         | MQTT proxy connection (`broker_url`, `device_id`, `topic_prefix`, `username`, `password`, `auto_connect`, `embedded_broker_*`). See [ESP32 BLE Proxy](./esp32-proxy).                                |
-| `esphome_proxy`       | If `handler: esphome-proxy` | (none)         | ESPHome Native API connection (`host`, `port`, `encryption_key` or `password`, `client_info`). See [ESPHome Bluetooth Proxy](./esphome-proxy).                                                       |
+| Field                 | Required                    | Default        | Description                                                                                                                                                                                                                                        |
+| --------------------- | --------------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scale_mac`           | Recommended                 | Auto-discovery | MAC address, or a CoreBluetooth UUID on macOS (bare 32-hex as the wizard writes it, or the dashed form). Prevents connecting to a neighbor's scale.                                                                                                |
+| `bind_key`            | Xiaomi S800 only            | (none)         | 32-char hex per-device MiBeacon key from the Mi cloud (extract with the community Xiaomi-cloud-tokens-extractor). Decrypts only the device's own FE95 broadcast. Keep it secret; it is a credential.                                               |
+| `handler`             | No                          | `auto`         | Transport: `auto` (local radio), `mqtt-proxy` (ESP32 over MQTT), `esphome-proxy` (ESPHome Native API). See below.                                                                                                                                  |
+| `noble_driver`        | No                          | OS default     | `abandonware` or `stoprocent`. Overrides the default BLE driver. Only applies when `handler: auto`.                                                                                                                                                |
+| `adapter`             | No                          | System default | Linux only. Select a specific Bluetooth adapter (e.g., `hci0`, `hci1`). See below.                                                                                                                                                                 |
+| `force_scale_adapter` | No                          | Auto-detect    | Name of the scale protocol adapter to use, bypassing auto-detection. Requires `scale_mac`. See below.                                                                                                                                              |
+| `session_timeout_sec` | No                          | `120`          | Seconds one GATT session may wait for a complete reading (5 to 600). Native BLE handlers only; ignored on `mqtt-proxy` and `esphome-proxy`. See below.                                                                                             |
+| `qn_protocol_byte`    | No                          | Auto           | QN-family scales only. Protocol byte the handshake echoes back to the scale (0 to 255). Set it when a QN scale runs the whole handshake and then reports nothing, or when its scale-info frame is lost in transit on a proxy transport. See below. |
+| `mqtt_proxy`          | If `handler: mqtt-proxy`    | (none)         | MQTT proxy connection (`broker_url`, `device_id`, `topic_prefix`, `username`, `password`, `auto_connect`, `embedded_broker_*`). See [ESP32 BLE Proxy](./esp32-proxy).                                                                              |
+| `esphome_proxy`       | If `handler: esphome-proxy` | (none)         | ESPHome Native API connection (`host`, `port`, `encryption_key` or `password`, `client_info`). See [ESPHome Bluetooth Proxy](./esphome-proxy).                                                                                                     |
 
 ::: warning Forcing a scale adapter
 `force_scale_adapter` is an escape hatch for when auto-detection routes your scale to the wrong protocol adapter, which happens with rebadged OEM hardware that shares a vendor service with another brand.
@@ -95,20 +95,26 @@ If you need this, please [open an issue](https://github.com/KristianP26/ble-scal
 
 The QN protocol family (Renpho, Arboleaf, FITINDEX, GE and several rebadges) echoes a protocol byte back to the scale in every configuration command, and the firmware revisions disagree about which value they accept. The wrong value is not an error: the scale acknowledges the entire handshake and then simply never streams a weight, which looks exactly like nobody standing on it.
 
-The scale-info frame length picks the default, and it is right for every unit reported so far. If your QN scale connects, completes the handshake in the debug log and then goes quiet, try the other value:
+The scale-info frame length picks the default, and it is right for every unit reported so far. Some firmware wants its own byte rather than 0 or 255: an ES-CS20M that reports 21 needs 21, and the full 0 to 255 range is accepted, so try the value your scale reports before assuming it is a binary choice.
 
 ```yaml
 ble:
-  qn_protocol_byte: 0 # or 255
+  qn_protocol_byte: 0 # or 255; if neither works, the byte your scale reports (an ES-CS20M reporting 21 needs 21)
 ```
 
-The debug log states which value is in use:
+The debug log states which value is in use. When the scale-info frame arrives:
 
 ```
 QN: scale info (19B, dialect=es26m), factor=10, proto=0xff
 ```
 
-If one of the two makes your scale work, please say so in an issue with the model and that line: the default is set from the models we have evidence for, and yours may change it.
+On a proxy transport that loses the scale-info frame, that line never prints; look for the fallback line instead, which shows the byte the handshake ran with:
+
+```
+QN: fallback: no 0x12 received, running handshake with proto=0x15
+```
+
+If a value makes your scale work, please say so in an issue with the model and that line: the default is set from the models we have evidence for, and yours may change it.
 
 :::
 
@@ -194,7 +200,7 @@ users:
 | `last_known_weight` | No       | `null`         | Auto-updated after each measurement                                      |
 | `exporters`         | No       | (none)         | [Per-user exporter](/multi-user#per-user-exporters) overrides            |
 | `beurer_pin`        | Beurer   | (none)         | Consent code the Beurer BF7xx / BF9xx scale was paired with              |
-| `beurer_user_index` | No       | `1`            | Scale user slot the consent code belongs to                             |
+| `beurer_user_index` | No       | `1`            | Scale user slot the consent code belongs to                              |
 | `beurer_provision`  | No       | `false`        | Write this profile into a Beurer scale that has no stored user           |
 
 ### Exporters

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -135,8 +135,9 @@ export const BleSchema = z
      * wrong one is silent rather than an error: the scale acknowledges the whole
      * handshake and never streams a weight. The scale-info frame length picks a
      * default (0 for the 18-byte variant, the value the scale itself sent for
-     * anything longer); set this only when a scale runs the full handshake and
-     * then reports nothing.
+     * anything longer); set this when a scale runs the full handshake and then
+     * reports nothing, or when its scale-info frame is unreliable in transit
+     * (proxy transports) and sessions without it open on the wrong byte.
      */
     qn_protocol_byte: z.number().int().min(0).max(255).optional().nullable(),
     mqtt_proxy: MqttProxySchema.optional(),

--- a/src/scales/qn-scale.ts
+++ b/src/scales/qn-scale.ts
@@ -492,7 +492,11 @@ export class QnScaleAdapter
       const config = [
         0x13,
         0x09,
-        this.seenProtocolType,
+        // Stay deterministic when the override is unset: seenProtocolType can be
+        // seeded by a 0x12 that races the AE02 subscribe on native BLE, and this
+        // fixed frame must not depend on that timing. The override, when set, is
+        // applied before onConnected runs, so every targeted case is unchanged.
+        this.forcedProtocolType ?? 0x00,
         this.unitFlag(),
         0x10,
         0x00,
@@ -810,10 +814,18 @@ export class QnScaleAdapter
         : this.isLongFrameVariant
           ? 'es26m'
           : 'classic';
+      // The byte the frame actually carried, for triage. Not seenProtocolType:
+      // on the 18-byte variant that is forced to 0x00 for the handshake, but the
+      // log should still report the 0xff the scale sent.
+      const reported = data[2];
+      const forcedNote =
+        this.forcedProtocolType !== null && this.forcedProtocolType !== reported
+          ? ` (forced, scale reported 0x${reported.toString(16).padStart(2, '0')})`
+          : '';
       bleLog.debug(
         `QN: scale info (${data.length}B, dialect=${dialect}), ` +
           `factor=${this.weightScaleFactor}, ` +
-          `proto=0x${this.seenProtocolType.toString(16).padStart(2, '0')}`,
+          `proto=0x${this.seenProtocolType.toString(16).padStart(2, '0')}${forcedNote}`,
       );
       void this.handleScaleInfo();
       return null;

--- a/src/scales/qn-scale.ts
+++ b/src/scales/qn-scale.ts
@@ -326,7 +326,11 @@ export class QnScaleAdapter
 
   /**
    * Protocol byte forced by `ble.qn_protocol_byte`, overriding what the frame
-   * length implies (#75, #331).
+   * length or the scale-info frame implies (#75, #331). Applied to every
+   * protocol-bearing write in the session, including the pre-0x12 unlock
+   * config, the classic dialect, and the no-0x12 fallback handshake: a scale
+   * whose 0x12 is lost in transit must still open with the byte its firmware
+   * accepts.
    *
    * There is no way to detect the wrong choice at runtime: a scale on the wrong
    * byte acknowledges 0x14, 0x21 and 0x23 exactly as it does on the right one
@@ -446,7 +450,7 @@ export class QnScaleAdapter
   async onConnected(ctx: ConnectionContext): Promise<void> {
     // Reset state for new connection
     this.ctx = ctx;
-    this.seenProtocolType = 0x00;
+    this.seenProtocolType = this.forcedProtocolType ?? 0x00;
     this.weightScaleFactor = 100;
     this.hasAe00 = false;
     this.ae02Subscribe = null;
@@ -485,7 +489,17 @@ export class QnScaleAdapter
       // The second unlock is the 0x10 config variant whose byte[3] is the unit
       // flag; honour the configured unit and recompute its checksum (#269). The
       // first unlock is a different 0x01 subcommand and is left as-is.
-      const config = [0x13, 0x09, 0x00, this.unitFlag(), 0x10, 0x00, 0x00, 0x00, 0x00];
+      const config = [
+        0x13,
+        0x09,
+        this.seenProtocolType,
+        this.unitFlag(),
+        0x10,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+      ];
       config[8] = config.reduce((a, b) => a + b, 0) & 0xff;
       const unlocks = [[0x13, 0x09, 0x00, 0x01, 0x01, 0x02], config];
       for (const cmd of unlocks) {
@@ -512,8 +526,11 @@ export class QnScaleAdapter
     const wait = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
     if (!this.configSent) {
-      this.seenProtocolType = 0xff;
-      bleLog.debug('QN: fallback: no 0x12 received, running handshake with proto=0xFF');
+      this.seenProtocolType = this.forcedProtocolType ?? 0xff;
+      bleLog.debug(
+        `QN: fallback: no 0x12 received, running handshake with ` +
+          `proto=0x${this.seenProtocolType.toString(16).padStart(2, '0')}`,
+      );
       // handleScaleInfo sends AE01 init + 0x13 config
       await this.handleScaleInfo();
       await wait(500);
@@ -785,7 +802,7 @@ export class QnScaleAdapter
         // Classic short frame
         this.isLongFrameVariant = false;
         this.isExtendedLongFrame = false;
-        this.seenProtocolType = data[2];
+        this.seenProtocolType = this.forcedProtocolType ?? data[2];
         this.weightScaleFactor = data[10] === 1 ? 100 : 10;
       }
       const dialect = this.isExtendedLongFrame

--- a/tests/scales/qn-scale.test.ts
+++ b/tests/scales/qn-scale.test.ts
@@ -1401,6 +1401,52 @@ describe('AE02 dispatch (#75, #235)', () => {
       expect(writes.find((w) => w[0] === 0x13 && w[4] === 0x10)![2]).toBe(0xff);
     });
 
+    it('applies the override to the classic dialect', async () => {
+      // A classic-dialect scale whose firmware wants a different byte than its
+      // 0x12 reports had no working override before: the classic branch read
+      // data[2] unconditionally.
+      const adapter = makeAdapter();
+      adapter.configure({ qnProtocolByte: 0x15 });
+      const info = Buffer.alloc(11);
+      info[0] = 0x12;
+      info[2] = 0xab;
+      info[10] = 1;
+      const writes = await driveHandshake(adapter, info);
+      expect(writes.find((w) => w[0] === 0x13 && w[4] === 0x10)![2]).toBe(0x15);
+      expect(writes.find((w) => w[0] === 0x22)![2]).toBe(0x15);
+    });
+
+    it('opens with the override before 0x12 and keeps it through the no-0x12 fallback', async () => {
+      // Proxy transports can lose the 0x12 scale-info frame entirely. The
+      // session must then still open the unlock config with the forced byte and
+      // run the fallback handshake on it, not on the 0x00/0xff guesses.
+      const adapter = makeAdapter();
+      adapter.configure({ qnProtocolByte: 0x15 });
+      vi.useFakeTimers();
+      try {
+        const writes: number[][] = [];
+        const ctx = {
+          write: async (_uuid: string, data: Buffer | number[]) => {
+            writes.push([...data]);
+          },
+          read: async () => Buffer.alloc(0),
+          subscribe: async () => {},
+          profile: defaultProfile(),
+          deviceAddress: '',
+          availableChars: new Set<string>(),
+        } as unknown as ConnectionContext;
+        await adapter.onConnected(ctx);
+        await vi.advanceTimersByTimeAsync(4000);
+        const configs = writes.filter((w) => w[0] === 0x13 && w[4] === 0x10);
+        expect(configs.length).toBeGreaterThan(0);
+        for (const c of configs) expect(c[2]).toBe(0x15);
+        expect(writes.find((w) => w[0] === 0x20)![2]).toBe(0x15);
+        expect(writes.find((w) => w[0] === 0x22)![2]).toBe(0x15);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('classic 11B 0x12 frame is unaffected by the extended-dialect rule', async () => {
       const adapter = makeAdapter();
       const info = Buffer.alloc(11);

--- a/tests/scales/qn-scale.test.ts
+++ b/tests/scales/qn-scale.test.ts
@@ -556,6 +556,76 @@ describe('QnScaleAdapter', () => {
       expect(config![8]).toBe(config!.slice(0, 8).reduce((a, b) => a + b, 0) & 0xff);
     });
 
+    it('carries the forced protocol byte into the older-firmware unlock config', async () => {
+      // Same no-AE00 path, with qn_protocol_byte set. The unlock byte[2] must be
+      // the forced value, and it must stay 0x00 when the override is unset.
+      const build = async (opts?: { qnProtocolByte: number }): Promise<number[]> => {
+        const adapter = makeAdapter();
+        if (opts) adapter.configure(opts);
+        const writes: number[][] = [];
+        const ctx = {
+          write: async (_uuid: string, data: Buffer | number[]) => {
+            writes.push([...data]);
+          },
+          read: async () => Buffer.alloc(0),
+          subscribe: async () => {
+            throw new Error('no AE02');
+          },
+          profile: defaultProfile,
+          deviceAddress: '',
+          availableChars: new Set<string>(),
+        } as unknown as ConnectionContext;
+        await adapter.onConnected(ctx);
+        return writes.find((w) => w[0] === 0x13 && w[4] === 0x10)!;
+      };
+      expect((await build({ qnProtocolByte: 0x15 }))[2]).toBe(0x15);
+      expect((await build())[2]).toBe(0x00);
+    });
+
+    it('keeps the unlock at 0x00 when a 0x12 arrives during the AE02 subscribe and no override is set', async () => {
+      vi.useFakeTimers();
+      const adapter = makeAdapter();
+      try {
+        const writes: number[][] = [];
+        let rejectSubscribe!: (e: Error) => void;
+        const ctx = {
+          write: async (_uuid: string, data: Buffer | number[]) => {
+            writes.push([...data]);
+          },
+          read: async () => Buffer.alloc(0),
+          subscribe: () =>
+            new Promise<void>((_resolve, reject) => {
+              rejectSubscribe = reject;
+            }),
+          profile: defaultProfile,
+          deviceAddress: '',
+          availableChars: new Set<string>(),
+        } as unknown as ConnectionContext;
+        const connected = adapter.onConnected(ctx);
+        await vi.advanceTimersByTimeAsync(0);
+
+        // The 0x12 lands while the AE02 subscribe is still in flight (the Linux
+        // node-ble ordering) and seeds seenProtocolType with the scale's byte.
+        const info = Buffer.alloc(11);
+        info[0] = 0x12;
+        info[2] = 0xab;
+        info[10] = 0;
+        adapter.parseNotification(info);
+
+        writes.length = 0;
+        rejectSubscribe(new Error('no AE02'));
+        await connected;
+
+        // The legacy unlock must not inherit 0xab from that timing.
+        const config = writes.find((w) => w[0] === 0x13 && w[4] === 0x10);
+        expect(config).toBeDefined();
+        expect(config![2]).toBe(0x00);
+      } finally {
+        adapter.onSessionEnd!();
+        vi.useRealTimers();
+      }
+    });
+
     it('0x12 frame captures protocol type', () => {
       const adapter = makeAdapter();
       const infoBuf = Buffer.alloc(11);
@@ -1436,11 +1506,18 @@ describe('AE02 dispatch (#75, #235)', () => {
           availableChars: new Set<string>(),
         } as unknown as ConnectionContext;
         await adapter.onConnected(ctx);
+
+        // A 0x14 ready frame arriving before the 2 s fallback drives handleReady
+        // off the onConnected seed, so the 0x20 it emits pins that seed rather
+        // than the fallback's own protocol assignment.
+        adapter.parseNotification(Buffer.from([0x14, 0x0b, 0x15, 0, 0, 0, 0, 0, 0, 0, 0x34]));
+        await vi.advanceTimersByTimeAsync(0);
+        expect(writes.find((w) => w[0] === 0x20)![2]).toBe(0x15);
+
         await vi.advanceTimersByTimeAsync(4000);
         const configs = writes.filter((w) => w[0] === 0x13 && w[4] === 0x10);
         expect(configs.length).toBeGreaterThan(0);
         for (const c of configs) expect(c[2]).toBe(0x15);
-        expect(writes.find((w) => w[0] === 0x20)![2]).toBe(0x15);
         expect(writes.find((w) => w[0] === 0x22)![2]).toBe(0x15);
       } finally {
         vi.useRealTimers();


### PR DESCRIPTION
Full diagnosis in #336. Short version here.

`ble.qn_protocol_byte` was only read in the long-frame branch of the 0x12 handler. The classic branch took `data[2]` unconditionally, `onConnected` reset the session state to 0x00 and hardcoded 0x00 into the generated unlock config, and `runFallbackHandshake` overwrote the state with 0xff. On a classic-dialect scale the setting was a no-op in every path. This matters on proxy transports where the 0x12 can be lost in transit, because those sessions open on 0x00 and fall back to 0xff, and a scale that wants its own byte (my ES-CS20M reports 0x15) rejects both silently, keeps re-sending 0x14, never streams, and caches the weigh-in as a stored record. Whether a weigh-in worked depended on whether the 0x12 survived, so the failure looked intermittent.

The forced byte now seeds the session state in `onConnected`, flows into the generated unlock config with its checksum recomputed, overrides the classic branch of the 0x12 handler, and is kept by the fallback, whose log line now prints the byte it chose instead of a hardcoded `proto=0xFF`. The fixed-payload `[13 09 00 01 01 02]` unlock is untouched on purpose. Its trailing byte is not a computable checksum, and scales verified working received it with 0x00, including mine.

Verified on hardware: with `qn_protocol_byte: 21`, sessions that miss the 0x12 complete the same as sessions that catch it.

Two tests added, one for the classic-dialect override and one driving a session with no 0x12 at all and asserting every protocol-bearing write carries the forced byte. Full suite passing except the pre-existing TZ-sensitive BF720 date-of-birth test, tsc/eslint/prettier clean.
