### PR TITLE
fix(mqtt-proxy): stop leaking message listeners from timed-out and failed GATT sessions

### DIFF
--- a/src/ble/handler-mqtt-proxy/gatt.ts
+++ b/src/ble/handler-mqtt-proxy/gatt.ts
@@ -17,13 +17,21 @@ export class MqttBleChar implements BleChar {
       if (t === topic) onData(payload);
     };
     this.client.on('message', handler);
-    await this.client.subscribeAsync(topic);
-    // Ordering is the whole point of #231: the MQTT notify subscription and the
-    // message handler are in place BEFORE we tell the firmware to enable BLE
-    // notify, so the firmware-triggered kickoff frame (QN/Renpho 0x12) always has
-    // a listener. New firmware enables notify on this command; old firmware (eager)
-    // ignores it and behaves exactly as before.
-    await this.client.publishAsync(`${this.base}/subscribe/${this.uuid}`, '');
+    try {
+      await this.client.subscribeAsync(topic);
+      // Ordering is the whole point of #231: the MQTT notify subscription and the
+      // message handler are in place BEFORE we tell the firmware to enable BLE
+      // notify, so the firmware-triggered kickoff frame (QN/Renpho 0x12) always has
+      // a listener. New firmware enables notify on this command; old firmware (eager)
+      // ignores it and behaves exactly as before.
+      await this.client.publishAsync(`${this.base}/subscribe/${this.uuid}`, '');
+    } catch (err) {
+      // A failed setup returns no unsubscriber, so the listener must not outlive
+      // this call: the client is persistent and every leaked listener re-processes
+      // all later notifications.
+      this.client.removeListener('message', handler);
+      throw err;
+    }
     return () => {
       this.client.removeListener('message', handler);
     };
@@ -104,41 +112,52 @@ export async function mqttGattConnect(
   await client.subscribeAsync(t.disconnected);
   await client.subscribeAsync(t.error);
 
-  const response = await withTimeout(
-    new Promise<{ chars: Array<{ uuid: string; properties: string[] }> }>((resolve, reject) => {
-      const handler = (topic: string, payload: Buffer) => {
-        if (topic === t.connected) {
-          let data: Record<string, unknown>;
-          try {
-            data = JSON.parse(payload.toString());
-          } catch (err) {
-            client.removeListener('message', handler);
-            reject(new Error(`Invalid connected payload from ESP32: ${err}`));
-            return;
-          }
-          // Ignore autonomous connects from ESP32 — those are handled by
-          // ReadingWatcher.handleAutonomousConnect, not mqttGattConnect (#201).
-          if (data.autonomous) return;
-          client.removeListener('message', handler);
-          resolve(data as { chars: Array<{ uuid: string; properties: string[] }> });
-        }
-        if (topic === t.error) {
-          client.removeListener('message', handler);
-          // Older firmware (and MicroPython exceptions like asyncio.TimeoutError
-          // whose str() is empty) can publish a blank payload — surface a
-          // placeholder so the host log is not a dangling "ESP32 error:".
-          const detail = payload.toString() || '(no detail)';
-          reject(new Error(`ESP32 error: ${detail}`));
-        }
-      };
-      client.on('message', handler);
-      client
-        .publishAsync(t.connect, JSON.stringify({ address, addr_type: addrType }))
-        .catch(reject);
-    }),
-    COMMAND_TIMEOUT_MS,
-    `GATT connect timeout for ${address}`,
+  let resolveResponse!: (v: { chars: Array<{ uuid: string; properties: string[] }> }) => void;
+  let rejectResponse!: (err: Error) => void;
+  const responsePromise = new Promise<{ chars: Array<{ uuid: string; properties: string[] }> }>(
+    (resolve, reject) => {
+      resolveResponse = resolve;
+      rejectResponse = reject;
+    },
   );
+  const handler = (topic: string, payload: Buffer) => {
+    if (topic === t.connected) {
+      let data: Record<string, unknown>;
+      try {
+        data = JSON.parse(payload.toString());
+      } catch (err) {
+        rejectResponse(new Error(`Invalid connected payload from ESP32: ${err}`));
+        return;
+      }
+      // Ignore autonomous connects from ESP32 — those are handled by
+      // ReadingWatcher.handleAutonomousConnect, not mqttGattConnect (#201).
+      if (data.autonomous) return;
+      resolveResponse(data as { chars: Array<{ uuid: string; properties: string[] }> });
+    }
+    if (topic === t.error) {
+      // Older firmware (and MicroPython exceptions like asyncio.TimeoutError
+      // whose str() is empty) can publish a blank payload — surface a
+      // placeholder so the host log is not a dangling "ESP32 error:".
+      const detail = payload.toString() || '(no detail)';
+      rejectResponse(new Error(`ESP32 error: ${detail}`));
+    }
+  };
+  client.on('message', handler);
+  let response: { chars: Array<{ uuid: string; properties: string[] }> };
+  try {
+    client
+      .publishAsync(t.connect, JSON.stringify({ address, addr_type: addrType }))
+      .catch(rejectResponse);
+    response = await withTimeout(
+      responsePromise,
+      COMMAND_TIMEOUT_MS,
+      `GATT connect timeout for ${address}`,
+    );
+  } finally {
+    // The handler previously removed itself only when a response arrived, so a
+    // connect timeout left it on the persistent client forever.
+    client.removeListener('message', handler);
+  }
 
   const charMap = new Map<string, BleChar>();
   for (const char of response.chars) {

--- a/src/ble/handler-mqtt-proxy/watcher.ts
+++ b/src/ble/handler-mqtt-proxy/watcher.ts
@@ -469,21 +469,31 @@ export class ReadingWatcher implements Watcher {
         entry.address,
       );
       bleLog.debug(`GATT read driven by adapter: ${gattAdapter.name} (${entry.address})`);
-      const raw = await withTimeout(
-        waitForRawReading(
-          connected.charMap,
-          device,
-          gattAdapter,
-          profile,
-          entry.address.replace(/[:-]/g, '').toUpperCase(),
-        ),
-        60_000,
-        `GATT reading timeout for ${entry.address}`,
+      const pending = waitForRawReading(
+        connected.charMap,
+        device,
+        gattAdapter,
+        profile,
+        entry.address.replace(/[:-]/g, '').toUpperCase(),
       );
+      // The race abandons `pending` on timeout; the finally block then ends its
+      // session, whose rejection has no other consumer and must not become an
+      // unhandled rejection.
+      pending.catch(() => {});
+      const raw = await withTimeout(pending, 60_000, `GATT reading timeout for ${entry.address}`);
       registerScaleMac(this.config, entry.address).catch(() => {});
       this.queue.push(raw);
       this.deferCounts.delete(entry.address);
     } finally {
+      // End the reading session before dropping the disconnect relay: after a
+      // timeout the abandoned waitForRawReading still holds its notification
+      // listeners on the persistent MQTT client, and only its own disconnect
+      // path removes them. Without this, every timed-out session leaked one
+      // notify listener, and each leaked listener re-processed every later
+      // notification frame (duplicate handshake writes, eventually a write
+      // storm that killed live sessions). Harmless after a completed reading:
+      // the disconnect callback returns immediately once resolved.
+      device?.fireDisconnect();
       device?.cleanup();
       // A superseded session must not tear down the one that replaced it (#296).
       if (seq === this.gattSessionSeq) {
@@ -589,14 +599,17 @@ export class ReadingWatcher implements Watcher {
         `Autonomous connect: charMap built with ${charMap.size} chars, waiting for reading...`,
       );
 
+      const pending = waitForRawReading(
+        charMap,
+        device,
+        adapter,
+        profile,
+        data.address.replace(/[:-]/g, '').toUpperCase(),
+      );
+      // See the host-initiated path: the abandoned promise must stay consumed.
+      pending.catch(() => {});
       const raw = await withTimeout(
-        waitForRawReading(
-          charMap,
-          device,
-          adapter,
-          profile,
-          data.address.replace(/[:-]/g, '').toUpperCase(),
-        ),
+        pending,
         60_000,
         `GATT reading timeout for ${data.address} (autonomous)`,
       );
@@ -606,6 +619,9 @@ export class ReadingWatcher implements Watcher {
       );
       this.queue.push(raw);
     } finally {
+      // Same teardown as the host-initiated path: end the session so a timed-out
+      // reading releases its notification listeners.
+      device?.fireDisconnect();
       device?.cleanup();
       if (seq === this.gattSessionSeq) {
         this.gattInProgress = false;

--- a/tests/ble/handler-mqtt-proxy.test.ts
+++ b/tests/ble/handler-mqtt-proxy.test.ts
@@ -2348,4 +2348,65 @@ describe('handler-mqtt-proxy', () => {
       expect(writeSubscribeCmds).toHaveLength(0);
     });
   });
+
+  describe('listener leaks on abnormal teardown', () => {
+    it('autonomous session timeout releases the notification listeners', async () => {
+      vi.useFakeTimers();
+      try {
+        const adapter = createGattAdapter();
+        const watcher = new ReadingWatcher(MQTT_PROXY_CONFIG, [adapter], undefined, PROFILE);
+        await watcher.start();
+        const baseline = (mockClient._listeners.get('message') ?? []).length;
+
+        // ESP32 reports an autonomous connect; the scale then never sends a frame.
+        mockClient._simulateMessage(
+          `${PREFIX}/connected`,
+          JSON.stringify({
+            autonomous: true,
+            address: 'AA:BB:CC:DD:EE:FF',
+            chars: [
+              { uuid: GATT_NOTIFY_UUID, properties: ['notify'] },
+              { uuid: GATT_WRITE_UUID, properties: ['write'] },
+            ],
+          }),
+        );
+        await vi.advanceTimersByTimeAsync(10);
+        expect((mockClient._listeners.get('message') ?? []).length).toBeGreaterThan(baseline);
+
+        // The 60s reading timeout must tear the whole session down: a leaked
+        // notify listener on the persistent client re-processes every later
+        // notification and compounds with each timed-out session.
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect((mockClient._listeners.get('message') ?? []).length).toBe(baseline);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('MqttBleChar.subscribe removes its listener when setup fails', async () => {
+      const { MqttBleChar } = await import('../../src/ble/handler-mqtt-proxy/gatt.js');
+      mockClient.subscribeAsync = vi.fn(async () => {
+        throw new Error('broker down');
+      });
+      const char = new MqttBleChar(mockClient as never, PREFIX, 'somechar');
+      await expect(char.subscribe(() => {})).rejects.toThrow('broker down');
+      expect(mockClient._listeners.get('message') ?? []).toHaveLength(0);
+    });
+
+    it('mqttGattConnect timeout removes its response handler', async () => {
+      vi.useFakeTimers();
+      try {
+        const { mqttGattConnect } = await import('../../src/ble/handler-mqtt-proxy/gatt.js');
+        const { topics } = await import('../../src/ble/handler-mqtt-proxy/topics.js');
+        const t = topics('ble-proxy', 'esp32-test');
+        const pending = mqttGattConnect(mockClient as never, t, 'AA:BB:CC:DD:EE:FF', 0);
+        const rejection = expect(pending).rejects.toThrow('GATT connect timeout');
+        await vi.advanceTimersByTimeAsync(30_000);
+        await rejection;
+        expect(mockClient._listeners.get('message') ?? []).toHaveLength(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
 });


### PR DESCRIPTION
Full diagnosis in #338. Three paths left handlers on the persistent MQTT client with nothing to remove them.

A session hitting the 60s reading timeout abandoned `waitForRawReading` mid-flight. The watcher's cleanup removed the disconnected-topic relay but not the notify listeners held by the pending promise, and removing the relay also removed the only path that could still clean them. The watcher now fires the local disconnect before dropping the relay, so the abandoned session tears itself down through its normal disconnect path. The abandoned promise gets a no-op catch first, because its rejection now actually happens and has no other consumer, and an unconsumed rejection would take the process down on current Node.

`MqttBleChar.subscribe()` attached its listener before awaiting the broker subscribe and the firmware notify command. A failure in either await meant no unsubscriber was ever returned. The listener is now removed on setup failure before the error propagates.

`mqttGattConnect()`'s response handler removed itself only when a connected or error message arrived, so a connect timeout leaked it. The handler now lives outside the promise executor and is removed in a `finally` around the wait, which also let the executor's three self-removal calls collapse into that single removal point.

Every leaked listener re-processed all later notifications, so each timed-out session compounded. After an evening of them, one scale frame was handled hundreds of times, each firing duplicate handshake writes, which buried the scale and killed live weigh-ins until a restart.

Three tests added: an autonomous session that times out must return the client to its baseline listener count, a failed `subscribe()` setup must not leave its listener behind, and a timed-out `mqttGattConnect` must remove its response handler. Full suite passing except the pre-existing TZ-sensitive BF720 date-of-birth test, tsc/eslint/prettier clean.
