### PR TITLE
fix(notifications): format weight, muscle and bone in the configured weight unit

### DIFF
--- a/docs/exporters.md
+++ b/docs/exporters.md
@@ -184,6 +184,8 @@ global_exporters:
     priority: 4
 ```
 
+Weight, muscle and bone follow `scale.weight_unit`.
+
 ## Telegram {#telegram}
 
 Send a measurement notification to a Telegram chat via a bot. Create a bot with [@BotFather](https://t.me/BotFather) to get a bot token, then start a chat with your bot (or add it to a group/channel) so it can message you.
@@ -204,7 +206,7 @@ global_exporters:
     silent: false
 ```
 
-The message is sent as plain text. In multi-user setups the user's name is prepended as `[Name]`. Historical readings replayed from a scale's offline cache are skipped (a notification for an old measurement is not meaningful).
+The message is sent as plain text. Weight, muscle and bone follow `scale.weight_unit`. In multi-user setups the user's name is prepended as `[Name]`. Historical readings replayed from a scale's offline cache are skipped (a notification for an old measurement is not meaningful).
 
 ::: tip Finding your chat ID
 Message your bot once, then open `https://api.telegram.org/bot<token>/getUpdates` in a browser — the `chat.id` field holds your chat ID. For groups, add the bot to the group first.

--- a/src/exporters/notification-message.ts
+++ b/src/exporters/notification-message.ts
@@ -1,0 +1,20 @@
+import type { BodyComposition } from '../interfaces/scale-adapter.js';
+import type { ExportContext } from '../interfaces/exporter.js';
+import { fmtWeight } from '../runtime/format.js';
+
+/** Message body shared by the push notification exporters (ntfy, telegram). */
+export function formatNotification(data: BodyComposition, context?: ExportContext): string {
+  const unit = context?.weightUnit ?? 'kg';
+  const prefix = context?.userName ? `[${context.userName}] ` : '';
+  const lines = [
+    `${prefix}⚖️ ${fmtWeight(data.weight, unit)} | BMI ${data.bmi.toFixed(1)}`,
+    `🏋️ Body Fat ${data.bodyFatPercent.toFixed(1)}% | Muscle ${fmtWeight(data.muscleMass, unit)}`,
+    `💧 Water ${data.waterPercent.toFixed(1)}% | 🦴 Bone ${fmtWeight(data.boneMass, unit)}`,
+    `🫀 Visceral Fat ${data.visceralFat} | BMR ${data.bmr} kcal`,
+    `📅 Metabolic Age ${data.metabolicAge} yr | Physique ${data.physiqueRating}`,
+  ];
+  if (context?.driftWarning) {
+    lines.push(`⚠️ ${context.driftWarning}`);
+  }
+  return lines.join('\n');
+}

--- a/src/exporters/ntfy.ts
+++ b/src/exporters/ntfy.ts
@@ -3,6 +3,7 @@ import type { BodyComposition } from '../interfaces/scale-adapter.js';
 import type { Exporter, ExportContext, ExportResult } from '../interfaces/exporter.js';
 import type { ExporterSchema } from '../interfaces/exporter-schema.js';
 import type { NtfyConfig } from './config.js';
+import { formatNotification } from './notification-message.js';
 import { withRetry, httpError } from '../utils/retry.js';
 import { errMsg } from '../utils/error.js';
 
@@ -49,21 +50,6 @@ export const ntfySchema: ExporterSchema = {
   supportsPerUser: false,
 };
 
-function formatMessage(data: BodyComposition, userName?: string, driftWarning?: string): string {
-  const prefix = userName ? `[${userName}] ` : '';
-  const lines = [
-    `${prefix}⚖️ ${data.weight.toFixed(2)} kg | BMI ${data.bmi.toFixed(1)}`,
-    `🏋️ Body Fat ${data.bodyFatPercent.toFixed(1)}% | Muscle ${data.muscleMass.toFixed(1)} kg`,
-    `💧 Water ${data.waterPercent.toFixed(1)}% | 🦴 Bone ${data.boneMass.toFixed(1)} kg`,
-    `🫀 Visceral Fat ${data.visceralFat} | BMR ${data.bmr} kcal`,
-    `📅 Metabolic Age ${data.metabolicAge} yr | Physique ${data.physiqueRating}`,
-  ];
-  if (driftWarning) {
-    lines.push(`⚠️ ${driftWarning}`);
-  }
-  return lines.join('\n');
-}
-
 export class NtfyExporter implements Exporter {
   readonly name = 'ntfy';
   private readonly config: NtfyConfig;
@@ -103,7 +89,7 @@ export class NtfyExporter implements Exporter {
       headers['Authorization'] = `Basic ${btoa(username + ':' + password)}`;
     }
 
-    const body = formatMessage(data, context?.userName, context?.driftWarning);
+    const body = formatNotification(data, context);
 
     return withRetry(
       async () => {

--- a/src/exporters/telegram.ts
+++ b/src/exporters/telegram.ts
@@ -3,6 +3,7 @@ import type { BodyComposition } from '../interfaces/scale-adapter.js';
 import type { Exporter, ExportContext, ExportResult } from '../interfaces/exporter.js';
 import type { ExporterSchema } from '../interfaces/exporter-schema.js';
 import type { TelegramConfig } from './config.js';
+import { formatNotification } from './notification-message.js';
 import { withRetry, httpError } from '../utils/retry.js';
 import { errMsg } from '../utils/error.js';
 
@@ -48,27 +49,6 @@ export const telegramSchema: ExporterSchema = {
   supportsPerUser: false,
 };
 
-function formatMessage(
-  data: BodyComposition,
-  title: string,
-  userName?: string,
-  driftWarning?: string,
-): string {
-  const prefix = userName ? `[${userName}] ` : '';
-  const lines = [
-    title,
-    `${prefix}⚖️ ${data.weight.toFixed(2)} kg | BMI ${data.bmi.toFixed(1)}`,
-    `🏋️ Body Fat ${data.bodyFatPercent.toFixed(1)}% | Muscle ${data.muscleMass.toFixed(1)} kg`,
-    `💧 Water ${data.waterPercent.toFixed(1)}% | 🦴 Bone ${data.boneMass.toFixed(1)} kg`,
-    `🫀 Visceral Fat ${data.visceralFat} | BMR ${data.bmr} kcal`,
-    `📅 Metabolic Age ${data.metabolicAge} yr | Physique ${data.physiqueRating}`,
-  ];
-  if (driftWarning) {
-    lines.push(`⚠️ ${driftWarning}`);
-  }
-  return lines.join('\n');
-}
-
 export class TelegramExporter implements Exporter {
   readonly name = 'telegram';
   private readonly config: TelegramConfig;
@@ -98,7 +78,7 @@ export class TelegramExporter implements Exporter {
   async export(data: BodyComposition, context?: ExportContext): Promise<ExportResult> {
     const { botToken, chatId, title, silent } = this.config;
     const url = `${API_BASE}/bot${botToken}/sendMessage`;
-    const text = formatMessage(data, title, context?.userName, context?.driftWarning);
+    const text = `${title}\n${formatNotification(data, context)}`;
 
     return withRetry(
       async () => {

--- a/src/interfaces/exporter.ts
+++ b/src/interfaces/exporter.ts
@@ -1,5 +1,5 @@
 import type { BodyComposition } from './scale-adapter.js';
-import type { UserConfig } from '../config/schema.js';
+import type { UserConfig, WeightUnit } from '../config/schema.js';
 
 export interface ExportResult {
   success: boolean;
@@ -11,6 +11,8 @@ export interface ExportContext {
   userSlug?: string;
   userConfig?: UserConfig;
   driftWarning?: string;
+  /** Display unit for weight-valued fields (`scale.weight_unit`); values stay in kg. */
+  weightUnit?: WeightUnit;
   /** Original measurement time for historical readings replayed from a scale's offline cache. */
   timestamp?: Date;
 }

--- a/src/runtime/processor.ts
+++ b/src/runtime/processor.ts
@@ -176,6 +176,7 @@ async function processReadingFrames(
       userName: user.name,
       userSlug: user.slug,
       userConfig: user,
+      weightUnit: ctx.weightUnit,
       ...(policy.drift && isLast ? { driftWarning: policy.drift } : {}),
       ...(reading.timestamp ? { timestamp: reading.timestamp } : {}),
     };

--- a/tests/exporters/ntfy.test.ts
+++ b/tests/exporters/ntfy.test.ts
@@ -80,9 +80,21 @@ describe('NtfyExporter', () => {
     expect(body).toContain('80.00 kg');
     expect(body).toContain('BMI 23.9');
     expect(body).toContain('Body Fat 18.5%');
-    expect(body).toContain('Muscle 62.4 kg');
+    expect(body).toContain('Muscle 62.40 kg');
+    expect(body).toContain('Bone 3.10 kg');
     expect(body).toContain('BMR 1750 kcal');
     expect(body).toContain('Physique 5');
+  });
+
+  it('formats weight-valued fields in the configured unit', async () => {
+    const exporter = new NtfyExporter(defaultConfig);
+    await exporter.export(samplePayload, { weightUnit: 'lbs' });
+
+    const body = mockFetch.mock.calls[0][1].body as string;
+    expect(body).toContain('⚖️ 176.37 lbs');
+    expect(body).toContain('Muscle 137.57 lbs');
+    expect(body).toContain('Bone 6.83 lbs');
+    expect(body).not.toContain('kg');
   });
 
   it('uses Bearer token auth when token is set', async () => {

--- a/tests/exporters/telegram.test.ts
+++ b/tests/exporters/telegram.test.ts
@@ -81,9 +81,21 @@ describe('TelegramExporter', () => {
     expect(text).toContain('80.00 kg');
     expect(text).toContain('BMI 23.9');
     expect(text).toContain('Body Fat 18.5%');
-    expect(text).toContain('Muscle 62.4 kg');
+    expect(text).toContain('Muscle 62.40 kg');
+    expect(text).toContain('Bone 3.10 kg');
     expect(text).toContain('BMR 1750 kcal');
     expect(text).toContain('Physique 5');
+  });
+
+  it('formats weight-valued fields in the configured unit', async () => {
+    const exporter = new TelegramExporter(defaultConfig);
+    await exporter.export(samplePayload, { weightUnit: 'lbs' });
+
+    const text = lastBody().text as string;
+    expect(text).toContain('⚖️ 176.37 lbs');
+    expect(text).toContain('Muscle 137.57 lbs');
+    expect(text).toContain('Bone 6.83 lbs');
+    expect(text).not.toContain('kg');
   });
 
   it('prepends [Name] when context has userName', async () => {

--- a/tests/runtime/processor.test.ts
+++ b/tests/runtime/processor.test.ts
@@ -192,6 +192,7 @@ describe('processReading: single-user', () => {
       userName: 'Dad',
       userSlug: 'dad',
       userConfig: dad,
+      weightUnit: 'kg',
     });
   });
 
@@ -264,7 +265,7 @@ describe('processReading: multi-user', () => {
   });
 
   it('dispatches per matched user with drift warning in ExportContext when applicable', async () => {
-    const ctx = makeCtx([dad, mom]);
+    const ctx = makeCtx([dad, mom], { weightUnit: 'lbs' });
     // 94 kg lands in upper 10% of dad's [75..95] range → triggers drift warn.
     const exporters = [fakeExporter()];
     const getter = vi.fn(() => exporters);
@@ -274,7 +275,7 @@ describe('processReading: multi-user', () => {
     expect(ok).toBe(true);
     expect(getter).toHaveBeenCalledWith('dad');
     const [, , context] = vi.mocked(dispatchExports).mock.calls[0];
-    expect(context).toMatchObject({ userName: 'Dad', userSlug: 'dad' });
+    expect(context).toMatchObject({ userName: 'Dad', userSlug: 'dad', weightUnit: 'lbs' });
     expect(context).toHaveProperty('driftWarning');
     expect(String((context as { driftWarning?: string }).driftWarning)).toMatch(/upper boundary/);
   });


### PR DESCRIPTION
Closes #342.

The ntfy and telegram exporters each had their own copy of the message formatter with `kg` hardcoded, and the console was already formatting the same three fields through `fmtWeight()`, which handles `scale.weight_unit`. The processor now puts the unit in `ExportContext.weightUnit`, and the two formatters, which have been identical apart from telegram's title line since telegram was added, became one `formatNotification()` in `src/exporters/notification-message.ts` that calls `fmtWeight()`. The notification now says what the log line says.

Muscle and bone go from one decimal to two as a side effect, because `fmtWeight()` prints two and the console already did.

I added an lbs case for each exporter and the processor test checks the context carries the unit. One sentence in each exporter's doc section. Full suite passing except the two pre-existing macOS-only failures (BF720 date of birth, config watcher), tsc/eslint/prettier clean.
