### PR TITLE
fix(beurer): provision the date of birth in UTC so the day does not shift west of Greenwich

### DIFF
--- a/src/scales/beurer-bf720.ts
+++ b/src/scales/beurer-bf720.ts
@@ -64,10 +64,12 @@ const PROFILE_FIELDS: ProfileField[] = [
       return year >= 1900 && year <= new Date().getFullYear();
     },
     fromProfile: (p) => {
+      // YYYY-MM-DD parses as UTC midnight, so read it back in UTC: the local
+      // getters shift the day west of Greenwich.
       const born = p.birthDate ? new Date(p.birthDate) : null;
       if (born && !Number.isNaN(born.getTime())) {
-        const y = born.getFullYear();
-        return [y & 0xff, (y >> 8) & 0xff, born.getMonth() + 1, born.getDate()];
+        const y = born.getUTCFullYear();
+        return [y & 0xff, (y >> 8) & 0xff, born.getUTCMonth() + 1, born.getUTCDate()];
       }
       // No birth date in the profile: anchor to 1 January of the derived year.
       const year = new Date().getFullYear() - Math.max(1, Math.round(p.age));

--- a/tests/scales/beurer-bf720.test.ts
+++ b/tests/scales/beurer-bf720.test.ts
@@ -918,6 +918,31 @@ describe('BeurerBf720Adapter', () => {
       expect(Buffer.from(dob![1] as number[]).toString('hex')).toBe('c607060f');
     });
 
+    // Local and UTC getters agree at or east of Greenwich, so CI (UTC) cannot
+    // see #344. Pin the zone or this branch is effectively untested.
+    it('provisions the calendar date of birth on a host west of Greenwich', async () => {
+      const savedTz = process.env.TZ;
+      process.env.TZ = 'America/Montreal';
+      try {
+        const a = makeAdapter();
+        const ctx = ctxWith(
+          { [DOB]: Buffer.from('00000000', 'hex') },
+          { provision: true, profile: defaultProfile({ birthDate: '1990-06-15' }) },
+        );
+        await a.onConnected(ctx);
+        const write = ctx.write as ReturnType<typeof vi.fn>;
+        write.mockClear();
+        a.parseCharNotification(UCP, Buffer.from('200201', 'hex'));
+        await settle();
+        const dob = write.mock.calls.find((c) => c[0] === DOB);
+        // 1990-06-15, not the 14th the local getters read back at UTC-4.
+        expect(Buffer.from(dob![1] as number[]).toString('hex')).toBe('c607060f');
+      } finally {
+        if (savedTz === undefined) delete process.env.TZ;
+        else process.env.TZ = savedTz;
+      }
+    });
+
     it('does not claim the scale is empty once the consent was accepted', () => {
       const warn = vi.spyOn(bleLog, 'warn').mockImplementation(() => {});
       const a = makeAdapter();


### PR DESCRIPTION
Closes #344.

`birth_date` is validated as `YYYY-MM-DD`, which `Date` parses as UTC midnight, and the provisioning code read it back with the local-time getters, so any host west of UTC wrote the previous day. It now reads the parts back with `getUTCFullYear` / `getUTCMonth` / `getUTCDate`. The time-of-day write in the same adapter stays on local time, that one is the wall clock.

The existing test passes in America/Montreal and in UTC+14 now, it was already asserting the right bytes. tsc/eslint/prettier clean.
