### PR TITLE
feat(notifications): report the other exporters' results with report_exports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,6 +91,7 @@ HEIGHT_UNIT=cm
 # NTFY_TOKEN=
 # NTFY_USERNAME=
 # NTFY_PASSWORD=
+# NTFY_REPORT_EXPORTS=false
 
 # ==========================================
 # TELEGRAM CONFIGURATION (only when telegram exporter is enabled)
@@ -99,6 +100,7 @@ HEIGHT_UNIT=cm
 # TELEGRAM_CHAT_ID=987654321
 # TELEGRAM_TITLE=Scale Measurement
 # TELEGRAM_SILENT=false
+# TELEGRAM_REPORT_EXPORTS=false
 
 # ==========================================
 # INTERVALS.ICU CONFIGURATION (only when intervals exporter is enabled)

--- a/docs/exporters.md
+++ b/docs/exporters.md
@@ -187,7 +187,7 @@ global_exporters:
 
 Weight, muscle and bone follow `scale.weight_unit`.
 
-With `report_exports: true` the notification is sent after the other exporters finish and ends with one line per exporter, `✅ garmin` or `❌ garmin: <error>`, so a failed sync is visible on the phone. The notification then arrives once the slowest exporter (and its retries) is done.
+With `report_exports: true` the notification is sent after the other exporters finish and ends with one line per non-reporting exporter, `✅ garmin` or `❌ garmin: <error>`, so a failed sync is visible on the phone. Two notifiers with the flag set do not report on each other. The notification arrives once the slowest exporter (and its retries) is done; with Garmin that can be up to three minutes when its uploader times out and retries. Error text is forwarded as-is (truncated to 120 characters), so a public ntfy topic will carry it.
 
 ## Telegram {#telegram}
 

--- a/docs/exporters.md
+++ b/docs/exporters.md
@@ -167,15 +167,16 @@ global_exporters:
 
 Push notifications to phone/desktop via [ntfy](https://ntfy.sh). Works with ntfy.sh or self-hosted instances.
 
-| Field      | Required | Default             | Description         |
-| ---------- | -------- | ------------------- | ------------------- |
-| `url`      | No       | `https://ntfy.sh`   | Ntfy server URL     |
-| `topic`    | Yes      | (none)              | Topic name          |
-| `title`    | No       | `Scale Measurement` | Notification title  |
-| `priority` | No       | `3`                 | Priority (1 to 5)   |
-| `token`    | No       | (none)              | Bearer token auth   |
-| `username` | No       | (none)              | Basic auth username |
-| `password` | No       | (none)              | Basic auth password |
+| Field            | Required | Default             | Description                         |
+| ---------------- | -------- | ------------------- | ----------------------------------- |
+| `url`            | No       | `https://ntfy.sh`   | Ntfy server URL                     |
+| `topic`          | Yes      | (none)              | Topic name                          |
+| `title`          | No       | `Scale Measurement` | Notification title                  |
+| `priority`       | No       | `3`                 | Priority (1 to 5)                   |
+| `token`          | No       | (none)              | Bearer token auth                   |
+| `username`       | No       | (none)              | Basic auth username                 |
+| `password`       | No       | (none)              | Basic auth password                 |
+| `report_exports` | No       | `false`             | Append the other exporters' results |
 
 ```yaml
 global_exporters:
@@ -186,16 +187,19 @@ global_exporters:
 
 Weight, muscle and bone follow `scale.weight_unit`.
 
+With `report_exports: true` the notification is sent after the other exporters finish and ends with one line per exporter, `✅ garmin` or `❌ garmin: <error>`, so a failed sync is visible on the phone. The notification then arrives once the slowest exporter (and its retries) is done.
+
 ## Telegram {#telegram}
 
 Send a measurement notification to a Telegram chat via a bot. Create a bot with [@BotFather](https://t.me/BotFather) to get a bot token, then start a chat with your bot (or add it to a group/channel) so it can message you.
 
-| Field       | Required | Default             | Description                                    |
-| ----------- | -------- | ------------------- | ---------------------------------------------- |
-| `bot_token` | Yes      | (none)              | Bot token from @BotFather                      |
-| `chat_id`   | Yes      | (none)              | Target chat ID (numeric) or `@channelusername` |
-| `title`     | No       | `Scale Measurement` | First line of the message                      |
-| `silent`    | No       | `false`             | Deliver without a notification sound           |
+| Field            | Required | Default             | Description                                    |
+| ---------------- | -------- | ------------------- | ---------------------------------------------- |
+| `bot_token`      | Yes      | (none)              | Bot token from @BotFather                      |
+| `chat_id`        | Yes      | (none)              | Target chat ID (numeric) or `@channelusername` |
+| `title`          | No       | `Scale Measurement` | First line of the message                      |
+| `silent`         | No       | `false`             | Deliver without a notification sound           |
+| `report_exports` | No       | `false`             | Append the other exporters' results            |
 
 ```yaml
 global_exporters:
@@ -206,7 +210,7 @@ global_exporters:
     silent: false
 ```
 
-The message is sent as plain text. Weight, muscle and bone follow `scale.weight_unit`. In multi-user setups the user's name is prepended as `[Name]`. Historical readings replayed from a scale's offline cache are skipped (a notification for an old measurement is not meaningful).
+The message is sent as plain text. Weight, muscle and bone follow `scale.weight_unit`. `report_exports` works as for [Ntfy](#ntfy). In multi-user setups the user's name is prepended as `[Name]`. Historical readings replayed from a scale's offline cache are skipped (a notification for an old measurement is not meaningful).
 
 ::: tip Finding your chat ID
 Message your bot once, then open `https://api.telegram.org/bot<token>/getUpdates` in a browser — the `chat.id` field holds your chat ID. For groups, add the bot to the group first.

--- a/src/config/env-load.ts
+++ b/src/config/env-load.ts
@@ -62,6 +62,7 @@ export function loadEnvConfig(): AppConfig {
         token: n.token,
         username: n.username,
         password: n.password,
+        report_exports: n.reportExports,
       });
     }
     if (name === 'telegram' && exporterConfig.telegram) {
@@ -71,6 +72,7 @@ export function loadEnvConfig(): AppConfig {
         chat_id: t.chatId,
         title: t.title,
         silent: t.silent,
+        report_exports: t.reportExports,
       });
     }
     if (name === 'intervals' && exporterConfig.intervals) {

--- a/src/exporters/config.ts
+++ b/src/exporters/config.ts
@@ -64,6 +64,7 @@ export interface NtfyConfig {
   token?: string;
   username?: string;
   password?: string;
+  reportExports: boolean;
 }
 
 export interface FileConfig {
@@ -82,6 +83,7 @@ export interface TelegramConfig {
   chatId: string;
   title: string;
   silent: boolean;
+  reportExports: boolean;
 }
 
 export interface IntervalsConfig {
@@ -248,6 +250,11 @@ export function loadExporterConfig(): ExporterConfig {
       token: process.env.NTFY_TOKEN?.trim() || undefined,
       username: process.env.NTFY_USERNAME?.trim() || undefined,
       password: process.env.NTFY_PASSWORD?.trim() || undefined,
+      reportExports: parseBoolean(
+        'NTFY_REPORT_EXPORTS',
+        process.env.NTFY_REPORT_EXPORTS?.trim(),
+        false,
+      ),
     };
   }
 
@@ -302,6 +309,11 @@ export function loadExporterConfig(): ExporterConfig {
       chatId,
       title: process.env.TELEGRAM_TITLE?.trim() || 'Scale Measurement',
       silent: parseBoolean('TELEGRAM_SILENT', process.env.TELEGRAM_SILENT?.trim(), false),
+      reportExports: parseBoolean(
+        'TELEGRAM_REPORT_EXPORTS',
+        process.env.TELEGRAM_REPORT_EXPORTS?.trim(),
+        false,
+      ),
     };
   }
 

--- a/src/exporters/notification-message.ts
+++ b/src/exporters/notification-message.ts
@@ -17,7 +17,11 @@ export function formatNotification(data: BodyComposition, context?: ExportContex
     lines.push(`⚠️ ${context.driftWarning}`);
   }
   for (const r of context?.exportResults ?? []) {
-    lines.push(r.ok ? `✅ ${r.name}` : `❌ ${r.name}: ${r.error}`);
+    // Error text is forwarded verbatim to a channel that may be public (an
+    // unauthenticated ntfy topic), so bound how much of it travels. Slice by
+    // code point so a multibyte character is never split into a replacement.
+    const error = [...(r.error ?? '')].slice(0, 120).join('');
+    lines.push(r.ok ? `✅ ${r.name}` : `❌ ${r.name}: ${error}`);
   }
   return lines.join('\n');
 }

--- a/src/exporters/notification-message.ts
+++ b/src/exporters/notification-message.ts
@@ -16,5 +16,8 @@ export function formatNotification(data: BodyComposition, context?: ExportContex
   if (context?.driftWarning) {
     lines.push(`⚠️ ${context.driftWarning}`);
   }
+  for (const r of context?.exportResults ?? []) {
+    lines.push(r.ok ? `✅ ${r.name}` : `❌ ${r.name}: ${r.error}`);
+  }
   return lines.join('\n');
 }

--- a/src/exporters/ntfy.ts
+++ b/src/exporters/ntfy.ts
@@ -47,7 +47,7 @@ export const ntfySchema: ExporterSchema = {
     { key: 'password', label: 'Password', type: 'password', required: false },
     {
       key: 'report_exports',
-      label: 'Report export results',
+      label: 'Report export results (waits for the other exporters)',
       type: 'boolean',
       required: false,
       default: false,

--- a/src/exporters/ntfy.ts
+++ b/src/exporters/ntfy.ts
@@ -45,6 +45,14 @@ export const ntfySchema: ExporterSchema = {
     { key: 'token', label: 'Bearer Token', type: 'password', required: false },
     { key: 'username', label: 'Username', type: 'string', required: false },
     { key: 'password', label: 'Password', type: 'password', required: false },
+    {
+      key: 'report_exports',
+      label: 'Report export results',
+      type: 'boolean',
+      required: false,
+      default: false,
+      description: 'Wait for the other exporters and append their results to the message',
+    },
   ],
   supportsGlobal: true,
   supportsPerUser: false,
@@ -52,10 +60,12 @@ export const ntfySchema: ExporterSchema = {
 
 export class NtfyExporter implements Exporter {
   readonly name = 'ntfy';
+  readonly reportsExports: boolean;
   private readonly config: NtfyConfig;
 
   constructor(config: NtfyConfig) {
     this.config = config;
+    this.reportsExports = config.reportExports;
   }
 
   async healthcheck(): Promise<ExportResult> {

--- a/src/exporters/registry.ts
+++ b/src/exporters/registry.ts
@@ -112,6 +112,7 @@ export const EXPORTER_REGISTRY: ExporterRegistryEntry[] = [
         token: config.token as string | undefined,
         username: config.username as string | undefined,
         password: config.password as string | undefined,
+        reportExports: (config.report_exports as boolean) ?? false,
       };
       return new NtfyExporter(ntfyConfig);
     },
@@ -145,6 +146,7 @@ export const EXPORTER_REGISTRY: ExporterRegistryEntry[] = [
         chatId: requireField(config, 'telegram', 'chat_id'),
         title: (config.title as string) ?? 'Scale Measurement',
         silent: (config.silent as boolean) ?? false,
+        reportExports: (config.report_exports as boolean) ?? false,
       };
       return new TelegramExporter(telegramConfig);
     },

--- a/src/exporters/telegram.ts
+++ b/src/exporters/telegram.ts
@@ -44,6 +44,14 @@ export const telegramSchema: ExporterSchema = {
       required: false,
       default: false,
     },
+    {
+      key: 'report_exports',
+      label: 'Report export results',
+      type: 'boolean',
+      required: false,
+      default: false,
+      description: 'Wait for the other exporters and append their results to the message',
+    },
   ],
   supportsGlobal: true,
   supportsPerUser: false,
@@ -51,10 +59,12 @@ export const telegramSchema: ExporterSchema = {
 
 export class TelegramExporter implements Exporter {
   readonly name = 'telegram';
+  readonly reportsExports: boolean;
   private readonly config: TelegramConfig;
 
   constructor(config: TelegramConfig) {
     this.config = config;
+    this.reportsExports = config.reportExports;
   }
 
   async healthcheck(): Promise<ExportResult> {

--- a/src/exporters/telegram.ts
+++ b/src/exporters/telegram.ts
@@ -46,7 +46,7 @@ export const telegramSchema: ExporterSchema = {
     },
     {
       key: 'report_exports',
-      label: 'Report export results',
+      label: 'Report export results (waits for the other exporters)',
       type: 'boolean',
       required: false,
       default: false,

--- a/src/interfaces/exporter.ts
+++ b/src/interfaces/exporter.ts
@@ -6,6 +6,12 @@ export interface ExportResult {
   error?: string;
 }
 
+export interface ExportResultDetail {
+  name: string;
+  ok: boolean;
+  error?: string;
+}
+
 export interface ExportContext {
   userName?: string;
   userSlug?: string;
@@ -15,12 +21,16 @@ export interface ExportContext {
   weightUnit?: WeightUnit;
   /** Original measurement time for historical readings replayed from a scale's offline cache. */
   timestamp?: Date;
+  /** Outcome of the other exporters; only set for exporters with `reportsExports`. */
+  exportResults?: ExportResultDetail[];
 }
 
 export interface Exporter {
   readonly name: string;
   /** True when this exporter honours `context.timestamp`. Historical readings skip exporters without it. */
   readonly supportsBackdate?: boolean;
+  /** True when this exporter runs after the others and receives their outcomes in `context.exportResults`. */
+  readonly reportsExports?: boolean;
   export(data: BodyComposition, context?: ExportContext): Promise<ExportResult>;
   healthcheck?(): Promise<ExportResult>;
 }

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,15 +1,9 @@
 import { createLogger } from './logger.js';
 import { errMsg } from './utils/error.js';
-import type { Exporter, ExportContext } from './interfaces/exporter.js';
+import type { Exporter, ExportContext, ExportResultDetail } from './interfaces/exporter.js';
 import type { BodyComposition } from './interfaces/scale-adapter.js';
 
 const log = createLogger('Sync');
-
-export interface ExportResultDetail {
-  name: string;
-  ok: boolean;
-  error?: string;
-}
 
 export interface DispatchResult {
   success: boolean;
@@ -84,17 +78,43 @@ export async function dispatchExports(
 
   log.info(`Exporting to: ${eligible.map((e) => e.name).join(', ')}...`);
 
+  // Exporters that report on the others wait for the first wave and get its outcome.
+  const reporters = eligible.filter((e) => e.reportsExports === true);
+  const details = await runExports(
+    eligible.filter((e) => e.reportsExports !== true),
+    payload,
+    context,
+  );
+  if (reporters.length > 0) {
+    details.push(
+      ...(await runExports(reporters, payload, { ...context, exportResults: [...details] })),
+    );
+  }
+
+  const allFailed = details.every((d) => !d.ok);
+  if (allFailed) {
+    log.error('All exports failed.');
+    return buildResult(false, details);
+  }
+
+  log.info('Done.');
+  return buildResult(true, details);
+}
+
+async function runExports(
+  exporters: Exporter[],
+  payload: BodyComposition,
+  context?: ExportContext,
+): Promise<ExportResultDetail[]> {
   const results = await Promise.allSettled(
-    eligible.map((e) => (context ? e.export(payload, context) : e.export(payload))),
+    exporters.map((e) => (context ? e.export(payload, context) : e.export(payload))),
   );
 
   const details: ExportResultDetail[] = [];
-  let allFailed = true;
   for (let i = 0; i < results.length; i++) {
     const result = results[i];
-    const name = eligible[i].name;
+    const name = exporters[i].name;
     if (result.status === 'fulfilled' && result.value.success) {
-      allFailed = false;
       details.push({ name, ok: true });
     } else if (result.status === 'fulfilled') {
       log.error(`${name}: ${result.value.error}`);
@@ -105,12 +125,5 @@ export async function dispatchExports(
       details.push({ name, ok: false, error: msg });
     }
   }
-
-  if (allFailed) {
-    log.error('All exports failed.');
-    return buildResult(false, details);
-  }
-
-  log.info('Done.');
-  return buildResult(true, details);
+  return details;
 }

--- a/tests/config/load.test.ts
+++ b/tests/config/load.test.ts
@@ -7,6 +7,7 @@ import {
   loadAppConfig,
   loadBleConfig,
 } from '../../src/config/load.js';
+import { createExporterFromEntry } from '../../src/exporters/registry.js';
 
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
@@ -392,6 +393,27 @@ global_exporters:
     expect(result.config.users).toHaveLength(1);
     expect(result.config.users[0].name).toBe('Default');
     expect(result.config.users[0].birth_date).toBe('1990-06-15');
+  });
+
+  // The env vars are parsed by loadExporterConfig() but only reach the exporter
+  // through the ExporterEntry that loadEnvConfig() builds, so cross that seam.
+  it('carries NTFY_REPORT_EXPORTS and TELEGRAM_REPORT_EXPORTS into the .env exporter entries', () => {
+    vi.spyOn(fs, 'existsSync').mockImplementation((p) => String(p).endsWith('.env'));
+    vi.stubEnv('USER_HEIGHT', '183');
+    vi.stubEnv('USER_BIRTH_DATE', '1990-06-15');
+    vi.stubEnv('USER_GENDER', 'male');
+    vi.stubEnv('USER_IS_ATHLETE', 'true');
+    vi.stubEnv('EXPORTERS', 'ntfy,telegram');
+    vi.stubEnv('NTFY_TOPIC', 'my-scale');
+    vi.stubEnv('NTFY_REPORT_EXPORTS', 'true');
+    vi.stubEnv('TELEGRAM_BOT_TOKEN', '123:abc');
+    vi.stubEnv('TELEGRAM_CHAT_ID', '42');
+    vi.stubEnv('TELEGRAM_REPORT_EXPORTS', 'true');
+
+    const { config } = loadAppConfig();
+    const byType = Object.fromEntries(config.global_exporters!.map((e) => [e.type, e]));
+    expect(createExporterFromEntry(byType.ntfy).reportsExports).toBe(true);
+    expect(createExporterFromEntry(byType.telegram).reportsExports).toBe(true);
   });
 
   it('exits when no config source exists', () => {

--- a/tests/exporters/config.test.ts
+++ b/tests/exporters/config.test.ts
@@ -302,6 +302,7 @@ describe('loadExporterConfig()', () => {
         token: undefined,
         username: undefined,
         password: undefined,
+        reportExports: false,
       });
     });
 
@@ -312,6 +313,7 @@ describe('loadExporterConfig()', () => {
       vi.stubEnv('NTFY_TITLE', 'Weight Update');
       vi.stubEnv('NTFY_PRIORITY', '5');
       vi.stubEnv('NTFY_TOKEN', 'tk_abc');
+      vi.stubEnv('NTFY_REPORT_EXPORTS', 'true');
       const cfg = loadExporterConfig();
       expect(cfg.ntfy).toEqual({
         url: 'https://my-ntfy.example.com',
@@ -321,7 +323,15 @@ describe('loadExporterConfig()', () => {
         token: 'tk_abc',
         username: undefined,
         password: undefined,
+        reportExports: true,
       });
+    });
+
+    it('rejects invalid NTFY_REPORT_EXPORTS', () => {
+      vi.stubEnv('EXPORTERS', 'ntfy');
+      vi.stubEnv('NTFY_TOPIC', 'my-scale');
+      vi.stubEnv('NTFY_REPORT_EXPORTS', 'maybe');
+      expect(() => loadExporterConfig()).toThrow(/NTFY_REPORT_EXPORTS must be true\/false/);
     });
 
     it('parses custom priority', () => {
@@ -383,6 +393,7 @@ describe('loadExporterConfig()', () => {
         chatId: '987654321',
         title: 'Scale Measurement',
         silent: false,
+        reportExports: false,
       });
     });
 
@@ -392,13 +403,23 @@ describe('loadExporterConfig()', () => {
       vi.stubEnv('TELEGRAM_CHAT_ID', '987654321');
       vi.stubEnv('TELEGRAM_TITLE', 'Weight Update');
       vi.stubEnv('TELEGRAM_SILENT', 'true');
+      vi.stubEnv('TELEGRAM_REPORT_EXPORTS', 'true');
       const cfg = loadExporterConfig();
       expect(cfg.telegram).toEqual({
         botToken: '123456:ABC',
         chatId: '987654321',
         title: 'Weight Update',
         silent: true,
+        reportExports: true,
       });
+    });
+
+    it('rejects invalid TELEGRAM_REPORT_EXPORTS', () => {
+      vi.stubEnv('EXPORTERS', 'telegram');
+      vi.stubEnv('TELEGRAM_BOT_TOKEN', '123456:ABC');
+      vi.stubEnv('TELEGRAM_CHAT_ID', '987654321');
+      vi.stubEnv('TELEGRAM_REPORT_EXPORTS', 'maybe');
+      expect(() => loadExporterConfig()).toThrow(/TELEGRAM_REPORT_EXPORTS must be true\/false/);
     });
 
     it('rejects invalid TELEGRAM_SILENT', () => {

--- a/tests/exporters/ntfy.test.ts
+++ b/tests/exporters/ntfy.test.ts
@@ -105,6 +105,16 @@ describe('NtfyExporter', () => {
     expect(body.endsWith('\n✅ garmin\n❌ influxdb: HTTP 401')).toBe(true);
   });
 
+  it('truncates a forwarded export error to 120 characters', async () => {
+    const exporter = new NtfyExporter({ ...defaultConfig, reportExports: true });
+    await exporter.export(samplePayload, {
+      exportResults: [{ name: 'file', ok: false, error: 'x'.repeat(200) }],
+    });
+
+    const body = mockFetch.mock.calls[0][1].body as string;
+    expect(body.endsWith(`\n❌ file: ${'x'.repeat(120)}`)).toBe(true);
+  });
+
   it('formats weight-valued fields in the configured unit', async () => {
     const exporter = new NtfyExporter(defaultConfig);
     await exporter.export(samplePayload, { weightUnit: 'lbs' });

--- a/tests/exporters/ntfy.test.ts
+++ b/tests/exporters/ntfy.test.ts
@@ -22,6 +22,7 @@ const defaultConfig: NtfyConfig = {
   topic: 'my-scale',
   title: 'Scale Measurement',
   priority: 3,
+  reportExports: false,
 };
 
 const mockFetch = vi.fn();
@@ -84,6 +85,24 @@ describe('NtfyExporter', () => {
     expect(body).toContain('Bone 3.10 kg');
     expect(body).toContain('BMR 1750 kcal');
     expect(body).toContain('Physique 5');
+  });
+
+  it('exposes reportsExports from the config', () => {
+    expect(new NtfyExporter(defaultConfig).reportsExports).toBe(false);
+    expect(new NtfyExporter({ ...defaultConfig, reportExports: true }).reportsExports).toBe(true);
+  });
+
+  it('appends one line per export result', async () => {
+    const exporter = new NtfyExporter({ ...defaultConfig, reportExports: true });
+    await exporter.export(samplePayload, {
+      exportResults: [
+        { name: 'garmin', ok: true },
+        { name: 'influxdb', ok: false, error: 'HTTP 401' },
+      ],
+    });
+
+    const body = mockFetch.mock.calls[0][1].body as string;
+    expect(body.endsWith('\n✅ garmin\n❌ influxdb: HTTP 401')).toBe(true);
   });
 
   it('formats weight-valued fields in the configured unit', async () => {

--- a/tests/exporters/registry.test.ts
+++ b/tests/exporters/registry.test.ts
@@ -299,6 +299,21 @@ describe('createExporterFromEntry()', () => {
     expect(exporter.name).toBe('ntfy');
   });
 
+  it('maps report_exports onto the notification exporters', () => {
+    expect(createExporterFromEntry({ type: 'ntfy', topic: 't' }).reportsExports).toBe(false);
+    expect(
+      createExporterFromEntry({ type: 'ntfy', topic: 't', report_exports: true }).reportsExports,
+    ).toBe(true);
+    expect(
+      createExporterFromEntry({
+        type: 'telegram',
+        bot_token: '1:a',
+        chat_id: '2',
+        report_exports: true,
+      }).reportsExports,
+    ).toBe(true);
+  });
+
   it('throws on unknown exporter type', () => {
     const entry: ExporterEntry = { type: 'unknown' };
     expect(() => createExporterFromEntry(entry)).toThrow("Unknown exporter type 'unknown'");

--- a/tests/exporters/telegram.test.ts
+++ b/tests/exporters/telegram.test.ts
@@ -23,6 +23,7 @@ const defaultConfig: TelegramConfig = {
   chatId: '987654321',
   title: 'Scale Measurement',
   silent: false,
+  reportExports: false,
 };
 
 const mockFetch = vi.fn();
@@ -85,6 +86,26 @@ describe('TelegramExporter', () => {
     expect(text).toContain('Bone 3.10 kg');
     expect(text).toContain('BMR 1750 kcal');
     expect(text).toContain('Physique 5');
+  });
+
+  it('exposes reportsExports from the config', () => {
+    expect(new TelegramExporter(defaultConfig).reportsExports).toBe(false);
+    expect(new TelegramExporter({ ...defaultConfig, reportExports: true }).reportsExports).toBe(
+      true,
+    );
+  });
+
+  it('appends one line per export result', async () => {
+    const exporter = new TelegramExporter({ ...defaultConfig, reportExports: true });
+    await exporter.export(samplePayload, {
+      exportResults: [
+        { name: 'garmin', ok: true },
+        { name: 'influxdb', ok: false, error: 'HTTP 401' },
+      ],
+    });
+
+    const text = lastBody().text as string;
+    expect(text.endsWith('\n✅ garmin\n❌ influxdb: HTTP 401')).toBe(true);
   });
 
   it('formats weight-valued fields in the configured unit', async () => {

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -214,6 +214,86 @@ describe('dispatchExports()', () => {
   });
 });
 
+// ─── dispatchExports: reportsExports ────────────────────────────────────────
+
+describe('dispatchExports() reportsExports', () => {
+  const context: ExportContext = { userName: 'Dad', userSlug: 'dad' };
+
+  function reporter(
+    name: string,
+    exportResult: ExportResult | Error = { success: true },
+  ): Exporter {
+    return { ...mockExporter(name, exportResult), reportsExports: true };
+  }
+
+  it('runs reporting exporters after the others and hands them the outcomes', async () => {
+    const order: string[] = [];
+    const slow: Exporter = {
+      name: 'garmin',
+      export: vi.fn(async () => {
+        await new Promise((r) => setTimeout(r, 50));
+        order.push('garmin');
+        return { success: true };
+      }),
+    };
+    const failing = mockExporter('influxdb', { success: false, error: 'HTTP 401' });
+    const ntfy = reporter('ntfy');
+    vi.mocked(ntfy.export).mockImplementation(async () => {
+      order.push('ntfy');
+      return { success: true };
+    });
+
+    const result = await dispatchExports([ntfy, slow, failing], SAMPLE_PAYLOAD, context);
+
+    expect(order).toEqual(['garmin', 'ntfy']);
+    expect(ntfy.export).toHaveBeenCalledWith(SAMPLE_PAYLOAD, {
+      ...context,
+      exportResults: [
+        { name: 'garmin', ok: true },
+        { name: 'influxdb', ok: false, error: 'HTTP 401' },
+      ],
+    });
+    expect(result.success).toBe(true);
+    expect(result.details).toEqual([
+      { name: 'garmin', ok: true },
+      { name: 'influxdb', ok: false, error: 'HTTP 401' },
+      { name: 'ntfy', ok: true },
+    ]);
+  });
+
+  it('still notifies when every other exporter failed', async () => {
+    const garmin = mockExporter('garmin', new Error('timeout'));
+    const ntfy = reporter('ntfy');
+    const result = await dispatchExports([garmin, ntfy], SAMPLE_PAYLOAD, context);
+
+    expect(ntfy.export).toHaveBeenCalledWith(SAMPLE_PAYLOAD, {
+      ...context,
+      exportResults: [{ name: 'garmin', ok: false, error: 'timeout' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('returns success false when the others and the reporter all fail', async () => {
+    const garmin = mockExporter('garmin', { success: false, error: 'auth failed' });
+    const ntfy = reporter('ntfy', { success: false, error: 'HTTP 500' });
+    const result = await dispatchExports([garmin, ntfy], SAMPLE_PAYLOAD, context);
+    expect(result.success).toBe(false);
+  });
+
+  it('passes an empty outcome list when only reporting exporters are configured', async () => {
+    const ntfy = reporter('ntfy');
+    await dispatchExports([ntfy], SAMPLE_PAYLOAD, context);
+    expect(ntfy.export).toHaveBeenCalledWith(SAMPLE_PAYLOAD, { ...context, exportResults: [] });
+  });
+
+  it('does not expose the outcomes to exporters that do not report', async () => {
+    const garmin = mockExporter('garmin');
+    const ntfy = reporter('ntfy');
+    await dispatchExports([garmin, ntfy], SAMPLE_PAYLOAD, context);
+    expect(garmin.export).toHaveBeenCalledWith(SAMPLE_PAYLOAD, context);
+  });
+});
+
 // ─── dispatchExports: historical reading + supportsBackdate ─────────────────
 
 describe('dispatchExports() historical reading filter', () => {


### PR DESCRIPTION
Closes #343. Branched from #347 because it builds on the shared formatter from that PR, so this one shows both commits until #347 merges and the change here is the second commit.

`report_exports` in YAML, `NTFY_REPORT_EXPORTS` / `TELEGRAM_REPORT_EXPORTS` in env mode, default `false`. The exporter exposes it as `Exporter.reportsExports`. `dispatchExports` splits the eligible exporters on that flag, everything without it runs concurrently as before, then the ones with it run with the collected `ExportResultDetail[]` in `context.exportResults`, and `formatNotification()` appends `✅ name` or `❌ name: error` per entry. `ExportResultDetail` moved from `orchestrator.ts` to `interfaces/exporter.ts` so the context can carry it without importing the orchestrator. The dispatch result is unchanged, success still means at least one exporter succeeded.

With the flag off nothing changes, timing included. With it on, the notification arrives after the slowest exporter and its retries, and the docs say so.

Tests cover the orchestrator ordering and context propagation, all sinks failing still notifies, a notifier-only config, non-reporting exporters not seeing the results, the message formatting in both exporters, env parsing including invalid values, and the registry mapping of the YAML key. Docs and `.env.example` updated. Full suite passing except the two pre-existing macOS-only failures, tsc/eslint/prettier clean.
