### PR TITLE
fix(ble): measure the reading deadline as scale silence, not time since connect

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -71,7 +71,7 @@ ble:
 | `noble_driver`        | No                          | OS default     | `abandonware` or `stoprocent`. Overrides the default BLE driver. Only applies when `handler: auto`.                                                                                                                                                |
 | `adapter`             | No                          | System default | Linux only. Select a specific Bluetooth adapter (e.g., `hci0`, `hci1`). See below.                                                                                                                                                                 |
 | `force_scale_adapter` | No                          | Auto-detect    | Name of the scale protocol adapter to use, bypassing auto-detection. Requires `scale_mac`. See below.                                                                                                                                              |
-| `session_timeout_sec` | No                          | `120`          | Seconds one GATT session may wait for a complete reading (5 to 600). Native BLE handlers only; ignored on `mqtt-proxy` and `esphome-proxy`. See below.                                                                                             |
+| `session_timeout_sec` | No                          | `120`          | Seconds of scale silence that end a GATT session (5 to 600); an inbound frame restarts the clock. Native BLE handlers only; ignored on `mqtt-proxy` and `esphome-proxy`. See below.                                                                |
 | `qn_protocol_byte`    | No                          | Auto           | QN-family scales only. Protocol byte the handshake echoes back to the scale (0 to 255). Set it when a QN scale runs the whole handshake and then reports nothing, or when its scale-info frame is lost in transit on a proxy transport. See below. |
 | `qn_report_byte`      | No                          | `254` (0xFE)   | QN-family scales only. Payload byte of the history-response frame (0 to 255). Try `252` (0xFC) when a QN scale completes the handshake and then reports nothing. See below.                                                                        |
 | `mqtt_proxy`          | If `handler: mqtt-proxy`    | (none)         | MQTT proxy connection (`broker_url`, `device_id`, `topic_prefix`, `username`, `password`, `auto_connect`, `embedded_broker_*`). See [ESP32 BLE Proxy](./esp32-proxy).                                                                              |
@@ -153,7 +153,7 @@ If `252` makes your scale produce a weight, please say so in an issue with the m
 ::: tip Shortening the session (`session_timeout_sec`)
 Some scales will not run a standalone weigh-in while a host holds the GATT session open. The Beurer BF500 is the clearest example: it displays `APP` and waits, so only a measurement taken **between** sessions is picked up.
 
-By default a session waits 120 seconds for a reading. On a scale like this, that is 120 seconds out of every cycle in which stepping on it achieves nothing. Shortening the session, and lengthening the gap after it, frees the scale for most of the cycle:
+By default a session ends after 120 seconds without a notification from the scale. On a scale like this, that is 120 seconds out of every cycle in which stepping on it achieves nothing. Shortening the session, and lengthening the gap after it, frees the scale for most of the cycle:
 
 ```yaml
 ble:

--- a/src/ble/handler-mqtt-proxy/watcher.ts
+++ b/src/ble/handler-mqtt-proxy/watcher.ts
@@ -5,7 +5,7 @@ import { waitForRawReading } from '../shared.js';
 import { resolveAdapter } from '../../scales/resolve.js';
 import { evaluateAdvertisement, GraceTimers, DedupWindow, logAdvert } from '../advertisement.js';
 import type { Watcher, WatcherConfig } from '../reading-source.js';
-import { bleLog, withIdleTimeout, errMsg, IMPEDANCE_GRACE_MS } from '../types.js';
+import { bleLog, withIdleTimeout, withTimeout, errMsg, IMPEDANCE_GRACE_MS } from '../types.js';
 import { AsyncQueue } from '../async-queue.js';
 import { topics } from './topics.js';
 import {
@@ -27,6 +27,14 @@ import { type ScanResultEntry, toBleDeviceInfo } from './scan.js';
 const DEDUP_WINDOW_MS = 30_000;
 /** Milliseconds of scale silence that end a GATT reading session. */
 const GATT_READING_IDLE_MS = 60_000;
+/**
+ * Absolute cap on one GATT session regardless of activity. A scale that keeps
+ * streaming adapter-rejected frames restarts the idle timer forever, and while
+ * the session is up the ESP32 holds its single connection and pauses scanning.
+ * Kept at ReadingWatcher.GATT_STALE_MS so the stale reset's assumption that no
+ * session outlives it stays true.
+ */
+const GATT_SESSION_ABSOLUTE_MS = 90_000;
 
 /** Bluetooth Base UUID for expanding 16-bit UUIDs to 128-bit form. */
 const BT_BASE_UUID = '00000000-0000-1000-8000-00805f9b34fb';
@@ -471,21 +479,25 @@ export class ReadingWatcher implements Watcher {
         entry.address,
       );
       bleLog.debug(`GATT read driven by adapter: ${gattAdapter.name} (${entry.address})`);
-      const raw = await withIdleTimeout(
-        (onActivity) =>
-          waitForRawReading(
-            connected.charMap,
-            connected.device,
-            gattAdapter,
-            profile,
-            entry.address.replace(/[:-]/g, '').toUpperCase(),
-            undefined,
-            undefined,
-            undefined,
-            onActivity,
-          ),
-        GATT_READING_IDLE_MS,
-        `GATT reading timeout for ${entry.address}`,
+      const raw = await withTimeout(
+        withIdleTimeout(
+          (onActivity) =>
+            waitForRawReading(
+              connected.charMap,
+              connected.device,
+              gattAdapter,
+              profile,
+              entry.address.replace(/[:-]/g, '').toUpperCase(),
+              undefined,
+              undefined,
+              undefined,
+              onActivity,
+            ),
+          GATT_READING_IDLE_MS,
+          `GATT reading timeout for ${entry.address}`,
+        ),
+        GATT_SESSION_ABSOLUTE_MS,
+        `GATT session cap exceeded for ${entry.address}`,
       );
       registerScaleMac(this.config, entry.address).catch(() => {});
       this.queue.push(raw);
@@ -605,21 +617,25 @@ export class ReadingWatcher implements Watcher {
         `Autonomous connect: charMap built with ${charMap.size} chars, waiting for reading...`,
       );
 
-      const raw = await withIdleTimeout(
-        (onActivity) =>
-          waitForRawReading(
-            charMap,
-            dev,
-            adapter,
-            profile,
-            data.address.replace(/[:-]/g, '').toUpperCase(),
-            undefined,
-            undefined,
-            undefined,
-            onActivity,
-          ),
-        GATT_READING_IDLE_MS,
-        `GATT reading timeout for ${data.address} (autonomous)`,
+      const raw = await withTimeout(
+        withIdleTimeout(
+          (onActivity) =>
+            waitForRawReading(
+              charMap,
+              dev,
+              adapter,
+              profile,
+              data.address.replace(/[:-]/g, '').toUpperCase(),
+              undefined,
+              undefined,
+              undefined,
+              onActivity,
+            ),
+          GATT_READING_IDLE_MS,
+          `GATT reading timeout for ${data.address} (autonomous)`,
+        ),
+        GATT_SESSION_ABSOLUTE_MS,
+        `GATT session cap exceeded for ${data.address} (autonomous)`,
       );
       registerScaleMac(this.config, data.address).catch(() => {});
       bleLog.info(

--- a/src/ble/handler-mqtt-proxy/watcher.ts
+++ b/src/ble/handler-mqtt-proxy/watcher.ts
@@ -25,7 +25,7 @@ import { registerScaleMac, publishConfig } from './display.js';
 import { type ScanResultEntry, toBleDeviceInfo } from './scan.js';
 
 const DEDUP_WINDOW_MS = 30_000;
-/** Seconds of scale silence that end a GATT reading session. */
+/** Milliseconds of scale silence that end a GATT reading session. */
 const GATT_READING_IDLE_MS = 60_000;
 
 /** Bluetooth Base UUID for expanding 16-bit UUIDs to 128-bit form. */

--- a/src/ble/handler-mqtt-proxy/watcher.ts
+++ b/src/ble/handler-mqtt-proxy/watcher.ts
@@ -5,7 +5,7 @@ import { waitForRawReading } from '../shared.js';
 import { resolveAdapter } from '../../scales/resolve.js';
 import { evaluateAdvertisement, GraceTimers, DedupWindow, logAdvert } from '../advertisement.js';
 import type { Watcher, WatcherConfig } from '../reading-source.js';
-import { bleLog, withTimeout, errMsg, IMPEDANCE_GRACE_MS } from '../types.js';
+import { bleLog, withIdleTimeout, errMsg, IMPEDANCE_GRACE_MS } from '../types.js';
 import { AsyncQueue } from '../async-queue.js';
 import { topics } from './topics.js';
 import {
@@ -25,6 +25,8 @@ import { registerScaleMac, publishConfig } from './display.js';
 import { type ScanResultEntry, toBleDeviceInfo } from './scan.js';
 
 const DEDUP_WINDOW_MS = 30_000;
+/** Seconds of scale silence that end a GATT reading session. */
+const GATT_READING_IDLE_MS = 60_000;
 
 /** Bluetooth Base UUID for expanding 16-bit UUIDs to 128-bit form. */
 const BT_BASE_UUID = '00000000-0000-1000-8000-00805f9b34fb';
@@ -469,18 +471,22 @@ export class ReadingWatcher implements Watcher {
         entry.address,
       );
       bleLog.debug(`GATT read driven by adapter: ${gattAdapter.name} (${entry.address})`);
-      const pending = waitForRawReading(
-        connected.charMap,
-        device,
-        gattAdapter,
-        profile,
-        entry.address.replace(/[:-]/g, '').toUpperCase(),
+      const raw = await withIdleTimeout(
+        (onActivity) =>
+          waitForRawReading(
+            connected.charMap,
+            connected.device,
+            gattAdapter,
+            profile,
+            entry.address.replace(/[:-]/g, '').toUpperCase(),
+            undefined,
+            undefined,
+            undefined,
+            onActivity,
+          ),
+        GATT_READING_IDLE_MS,
+        `GATT reading timeout for ${entry.address}`,
       );
-      // The race abandons `pending` on timeout; the finally block then ends its
-      // session, whose rejection has no other consumer and must not become an
-      // unhandled rejection.
-      pending.catch(() => {});
-      const raw = await withTimeout(pending, 60_000, `GATT reading timeout for ${entry.address}`);
       registerScaleMac(this.config, entry.address).catch(() => {});
       this.queue.push(raw);
       this.deferCounts.delete(entry.address);
@@ -599,18 +605,20 @@ export class ReadingWatcher implements Watcher {
         `Autonomous connect: charMap built with ${charMap.size} chars, waiting for reading...`,
       );
 
-      const pending = waitForRawReading(
-        charMap,
-        device,
-        adapter,
-        profile,
-        data.address.replace(/[:-]/g, '').toUpperCase(),
-      );
-      // See the host-initiated path: the abandoned promise must stay consumed.
-      pending.catch(() => {});
-      const raw = await withTimeout(
-        pending,
-        60_000,
+      const raw = await withIdleTimeout(
+        (onActivity) =>
+          waitForRawReading(
+            charMap,
+            dev,
+            adapter,
+            profile,
+            data.address.replace(/[:-]/g, '').toUpperCase(),
+            undefined,
+            undefined,
+            undefined,
+            onActivity,
+          ),
+        GATT_READING_IDLE_MS,
         `GATT reading timeout for ${data.address} (autonomous)`,
       );
       registerScaleMac(this.config, data.address).catch(() => {});

--- a/src/ble/handler-noble-shared.ts
+++ b/src/ble/handler-noble-shared.ts
@@ -25,6 +25,7 @@ import {
   GATT_DISCOVERY_TIMEOUT_MS,
   IMPEDANCE_GRACE_MS,
   RAW_READING_TIMEOUT_MS,
+  READING_SESSION_CAP_FACTOR,
 } from './types.js';
 
 /**
@@ -599,21 +600,25 @@ export function createNobleHandler({ noble, getState }: NobleHandlerDeps) {
         // Bounded like the node-ble path (handler-node-ble/scan.ts): without
         // this the reading phase relies entirely on the peripheral eventually
         // disconnecting, so a stalled GATT session wedges the process (#283).
-        const raw = await withIdleTimeout(
-          (onActivity) =>
-            waitForRawReading(
-              charMap,
-              wrapPeripheral(peripheral),
-              matchedAdapter,
-              profile,
-              peripheralAddress(peripheral).replace(/[:-]/g, '').toUpperCase(),
-              weightUnit,
-              onLiveData,
-              scaleAuth,
-              onActivity,
-            ),
-          readingTimeoutMs ?? RAW_READING_TIMEOUT_MS,
-          'Timed out waiting for a complete scale reading',
+        const raw = await withTimeout(
+          withIdleTimeout(
+            (onActivity) =>
+              waitForRawReading(
+                charMap,
+                wrapPeripheral(peripheral),
+                matchedAdapter,
+                profile,
+                peripheralAddress(peripheral).replace(/[:-]/g, '').toUpperCase(),
+                weightUnit,
+                onLiveData,
+                scaleAuth,
+                onActivity,
+              ),
+            readingTimeoutMs ?? RAW_READING_TIMEOUT_MS,
+            'Timed out waiting for a complete scale reading',
+          ),
+          (readingTimeoutMs ?? RAW_READING_TIMEOUT_MS) * READING_SESSION_CAP_FACTOR,
+          'GATT session cap exceeded',
         );
 
         return raw;

--- a/src/ble/handler-noble-shared.ts
+++ b/src/ble/handler-noble-shared.ts
@@ -16,6 +16,7 @@ import {
   sleep,
   errMsg,
   withTimeout,
+  withIdleTimeout,
   resetAdapterBtmgmt,
   CONNECT_TIMEOUT_MS,
   MAX_CONNECT_RETRIES,
@@ -598,17 +599,19 @@ export function createNobleHandler({ noble, getState }: NobleHandlerDeps) {
         // Bounded like the node-ble path (handler-node-ble/scan.ts): without
         // this the reading phase relies entirely on the peripheral eventually
         // disconnecting, so a stalled GATT session wedges the process (#283).
-        const raw = await withTimeout(
-          waitForRawReading(
-            charMap,
-            wrapPeripheral(peripheral),
-            matchedAdapter,
-            profile,
-            peripheralAddress(peripheral).replace(/[:-]/g, '').toUpperCase(),
-            weightUnit,
-            onLiveData,
-            scaleAuth,
-          ),
+        const raw = await withIdleTimeout(
+          (onActivity) =>
+            waitForRawReading(
+              charMap,
+              wrapPeripheral(peripheral),
+              matchedAdapter,
+              profile,
+              peripheralAddress(peripheral).replace(/[:-]/g, '').toUpperCase(),
+              weightUnit,
+              onLiveData,
+              scaleAuth,
+              onActivity,
+            ),
           readingTimeoutMs ?? RAW_READING_TIMEOUT_MS,
           'Timed out waiting for a complete scale reading',
         );

--- a/src/ble/handler-node-ble/scan.ts
+++ b/src/ble/handler-node-ble/scan.ts
@@ -15,6 +15,7 @@ import {
   sleep,
   errMsg,
   withTimeout,
+  withIdleTimeout,
   resetAdapterBtmgmt,
   MAX_CONNECT_RETRIES,
   DISCOVERY_TIMEOUT_MS,
@@ -456,17 +457,20 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
       await ensureBonded(device, scaleAuth?.pin);
     }
 
-    const raw = await withTimeout(
-      waitForRawReading(
-        charMap,
-        wrapDevice(device),
-        matchedAdapter,
-        profile,
-        deviceMac.replace(/[:-]/g, '').toUpperCase(),
-        weightUnit,
-        onLiveData,
-        scaleAuth,
-      ),
+    const bleDevice = wrapDevice(device);
+    const raw = await withIdleTimeout(
+      (onActivity) =>
+        waitForRawReading(
+          charMap,
+          bleDevice,
+          matchedAdapter,
+          profile,
+          deviceMac.replace(/[:-]/g, '').toUpperCase(),
+          weightUnit,
+          onLiveData,
+          scaleAuth,
+          onActivity,
+        ),
       readingTimeoutMs ?? RAW_READING_TIMEOUT_MS,
       'Timed out waiting for a complete scale reading',
     );

--- a/src/ble/handler-node-ble/scan.ts
+++ b/src/ble/handler-node-ble/scan.ts
@@ -23,6 +23,7 @@ import {
   POST_DISCOVERY_QUIESCE_MS,
   GATT_DISCOVERY_TIMEOUT_MS,
   RAW_READING_TIMEOUT_MS,
+  READING_SESSION_CAP_FACTOR,
   CHAR_DISCOVERY_MAX_RETRIES,
   CHAR_DISCOVERY_RETRY_DELAY_MS,
 } from '../types.js';
@@ -458,21 +459,25 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
     }
 
     const bleDevice = wrapDevice(device);
-    const raw = await withIdleTimeout(
-      (onActivity) =>
-        waitForRawReading(
-          charMap,
-          bleDevice,
-          matchedAdapter,
-          profile,
-          deviceMac.replace(/[:-]/g, '').toUpperCase(),
-          weightUnit,
-          onLiveData,
-          scaleAuth,
-          onActivity,
-        ),
-      readingTimeoutMs ?? RAW_READING_TIMEOUT_MS,
-      'Timed out waiting for a complete scale reading',
+    const raw = await withTimeout(
+      withIdleTimeout(
+        (onActivity) =>
+          waitForRawReading(
+            charMap,
+            bleDevice,
+            matchedAdapter,
+            profile,
+            deviceMac.replace(/[:-]/g, '').toUpperCase(),
+            weightUnit,
+            onLiveData,
+            scaleAuth,
+            onActivity,
+          ),
+        readingTimeoutMs ?? RAW_READING_TIMEOUT_MS,
+        'Timed out waiting for a complete scale reading',
+      ),
+      (readingTimeoutMs ?? RAW_READING_TIMEOUT_MS) * READING_SESSION_CAP_FACTOR,
+      'GATT session cap exceeded',
     );
     gattSucceeded = true;
 

--- a/src/ble/shared.ts
+++ b/src/ble/shared.ts
@@ -473,6 +473,7 @@ export function waitForRawReading(
   weightUnit?: WeightUnit,
   onLiveData?: (reading: ScaleReading) => void,
   scaleAuth?: ScaleAuth,
+  onActivity?: () => void,
 ): Promise<RawReading> {
   return new Promise<RawReading>((resolve, reject) => {
     let resolved = false;
@@ -496,6 +497,10 @@ export function waitForRawReading(
 
     const handleNotification = (sourceUuid: string, data: Buffer): void => {
       if (resolved) return;
+
+      // Counted before the adapter gate, because a frame the adapter rejects
+      // (an unstable QN 0x10) still shows the scale is mid weigh-in.
+      onActivity?.();
 
       // Every frame the scale sends, before any adapter gate can discard it.
       // Without this a silent cycle cannot be told apart from one where frames

--- a/src/ble/types.ts
+++ b/src/ble/types.ts
@@ -24,9 +24,9 @@ export const GATT_DISCOVERY_TIMEOUT_MS = 30_000;
 /**
  * How long the reading phase waits without a notification from the scale. The
  * timer restarts on every frame, so it counts silence rather than time since
- * connect. The ESP32 proxy connects as soon as the scale advertises, often
- * well before anyone steps on, and a window counted from connect ran out
- * during a weigh-in.
+ * connect: a window counted from connect can expire before the user steps on,
+ * because connect is driven by the advertisement, not the weigh-in. Native
+ * handlers only; the mqtt-proxy uses its own GATT_READING_IDLE_MS.
  */
 export const RAW_READING_TIMEOUT_MS = 120_000;
 
@@ -48,9 +48,11 @@ export const POST_DISCOVERY_QUIESCE_MS = 500;
 /**
  * Hard ceiling on one native poll cycle.
  *
- * The worst legitimate node-ble cycle is roughly 575 s (discovery 120 + six
- * connect attempts 170 + GATT acquisition 30 + characteristic retries + reading
- * 120), so 900 s never fires on a healthy run.
+ * The reading phase is now bounded by scale silence rather than a fixed 120 s,
+ * so it has no fixed upper term: a scale that keeps emitting frames the adapter
+ * rejects can hold the phase open indefinitely, and this ceiling is what still
+ * fires in that case (discovery 120 + six connect attempts 170 + GATT
+ * acquisition 30 + characteristic retries, plus the unbounded reading phase).
  *
  * It exists because dbus-next never rejects an in-flight `MessageBus.call()`
  * when the socket dies: the resolver is stored in `_methodReturnHandlers` and is
@@ -184,7 +186,9 @@ export async function withTimeout<T>(promise: Promise<T>, ms: number, message: s
 
 /**
  * Like withTimeout, but the deadline restarts whenever `start`'s callback is
- * invoked: the promise from `start` is rejected only after `ms` of inactivity.
+ * invoked: the returned promise rejects after `ms` with no activity. Like
+ * withTimeout, the promise from `start` is abandoned rather than cancelled, so
+ * callers must still tear down whatever it holds.
  */
 export async function withIdleTimeout<T>(
   start: (onActivity: () => void) => Promise<T>,

--- a/src/ble/types.ts
+++ b/src/ble/types.ts
@@ -21,7 +21,13 @@ export const DISCOVERY_POLL_MS = 2_000;
 /** Timeout for GATT service/characteristic enumeration after connecting. */
 export const GATT_DISCOVERY_TIMEOUT_MS = 30_000;
 
-/** Timeout for the full reading phase (subscribe → first complete reading). */
+/**
+ * How long the reading phase waits without a notification from the scale. The
+ * timer restarts on every frame, so it counts silence rather than time since
+ * connect. The ESP32 proxy connects as soon as the scale advertises, often
+ * well before anyone steps on, and a window counted from connect ran out
+ * during a weigh-in.
+ */
 export const RAW_READING_TIMEOUT_MS = 120_000;
 
 /**
@@ -114,7 +120,7 @@ export interface ScanOptions {
   mqttProxy?: MqttProxyConfig;
   esphomeProxy?: EsphomeProxyConfig;
   bleAdapter?: string;
-  /** Override RAW_READING_TIMEOUT_MS for one session (ble.session_timeout_sec, #83). */
+  /** Override RAW_READING_TIMEOUT_MS (seconds of silence) for one session (ble.session_timeout_sec, #83). */
   readingTimeoutMs?: number;
 }
 
@@ -173,6 +179,32 @@ export async function withTimeout<T>(promise: Promise<T>, ms: number, message: s
     return await Promise.race([promise, timeout]);
   } finally {
     clearTimeout(timer!);
+  }
+}
+
+/**
+ * Like withTimeout, but the deadline restarts whenever `start`'s callback is
+ * invoked: the promise from `start` is rejected only after `ms` of inactivity.
+ */
+export async function withIdleTimeout<T>(
+  start: (onActivity: () => void) => Promise<T>,
+  ms: number,
+  message: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let rejectTimeout!: (err: Error) => void;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    rejectTimeout = reject;
+  });
+  const onActivity = (): void => {
+    clearTimeout(timer);
+    timer = setTimeout(() => rejectTimeout(new Error(message)), ms);
+  };
+  onActivity();
+  try {
+    return await Promise.race([start(onActivity), timeout]);
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/src/ble/types.ts
+++ b/src/ble/types.ts
@@ -31,6 +31,16 @@ export const GATT_DISCOVERY_TIMEOUT_MS = 30_000;
 export const RAW_READING_TIMEOUT_MS = 120_000;
 
 /**
+ * Absolute cap on one native reading session, as a multiple of the configured
+ * silence window. The idle timer restarts on every frame, so a scale that
+ * streams adapter-rejected frames forever would otherwise hold the session
+ * open with no bound; the cap ends it while leaving room for a weigh-in that
+ * spans several restarts. A session_timeout_sec above 300 makes
+ * POLL_CYCLE_TIMEOUT_MS the effective ceiling instead.
+ */
+export const READING_SESSION_CAP_FACTOR = 3;
+
+/**
  * Max attempts to enumerate GATT characteristics. BlueZ can signal
  * `ServicesResolved=true` before all characteristic interfaces are exported
  * over D-Bus ([bluez/bluez#1489](https://github.com/bluez/bluez/issues/1489)),
@@ -48,11 +58,11 @@ export const POST_DISCOVERY_QUIESCE_MS = 500;
 /**
  * Hard ceiling on one native poll cycle.
  *
- * The reading phase is now bounded by scale silence rather than a fixed 120 s,
- * so it has no fixed upper term: a scale that keeps emitting frames the adapter
- * rejects can hold the phase open indefinitely, and this ceiling is what still
- * fires in that case (discovery 120 + six connect attempts 170 + GATT
- * acquisition 30 + characteristic retries, plus the unbounded reading phase).
+ * The reading phase is bounded by scale silence, capped in absolute terms at
+ * READING_SESSION_CAP_FACTOR x the silence window (360 s by default). The worst
+ * legitimate node-ble cycle is then roughly 815 s (discovery 120 + six connect
+ * attempts 170 + GATT acquisition 30 + characteristic retries + reading 360),
+ * so 900 s never fires on a healthy run with the default session_timeout_sec.
  *
  * It exists because dbus-next never rejects an in-flight `MessageBus.call()`
  * when the socket dies: the resolver is stored in `_methodReturnHandlers` and is

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -121,11 +121,13 @@ export const BleSchema = z
      */
     force_scale_adapter: z.string().min(1).optional().nullable(),
     /**
-     * How long one GATT session may wait for a complete reading, in seconds
-     * (default 120). Some scales refuse to run a standalone weigh-in while a
-     * host holds the session open (the Beurer BF500 shows "APP", #83), so a
-     * shorter session frees the scale sooner. The cost is proportionally more
-     * Bluetooth adapter resets per hour, since every failed read triggers one.
+     * Seconds of scale silence that end one GATT session (default 120); every
+     * notification restarts the clock. Native BLE handlers only; the mqtt-proxy
+     * and esphome-proxy transports ignore it. Some scales refuse to run a
+     * standalone weigh-in while a host holds the session open (the Beurer BF500
+     * shows "APP", #83), so a shorter session frees the scale sooner. The cost
+     * is more Bluetooth adapter churn per hour, since a timed-out read resets
+     * the adapter on node-ble and disconnects on Noble.
      */
     session_timeout_sec: z.number().int().min(5).max(600).optional().nullable(),
     /**

--- a/tests/ble/handler-mqtt-proxy.test.ts
+++ b/tests/ble/handler-mqtt-proxy.test.ts
@@ -1790,6 +1790,51 @@ describe('handler-mqtt-proxy', () => {
       expect(connectCalls).toHaveLength(0);
     });
 
+    it('autonomous session survives a weigh-in that starts near the old fixed deadline', async () => {
+      vi.useFakeTimers();
+      try {
+        const adapter = createGattAdapter();
+        const watcher = new ReadingWatcher(MQTT_PROXY_CONFIG, [adapter], undefined, PROFILE);
+        await watcher.start();
+
+        mockClient._simulateMessage(
+          `${PREFIX}/connected`,
+          JSON.stringify({
+            autonomous: true,
+            address: 'AA:BB:CC:DD:EE:FF',
+            chars: [
+              { uuid: GATT_NOTIFY_UUID, properties: ['notify'] },
+              { uuid: GATT_WRITE_UUID, properties: ['write'] },
+            ],
+          }),
+        );
+        const pending = watcher.nextReading();
+
+        // The scale is connected but idle for 55 s, then streams a frame the
+        // adapter rejects (an unstable weight), exactly what a QN scale does
+        // while the weight settles before its silent impedance phase.
+        await vi.advanceTimersByTimeAsync(55_000);
+        mockClient._simulateMessage(`${PREFIX}/notify/${GATT_NOTIFY_UUID}`, Buffer.from([0x10]));
+        expect(adapter.parseNotification).toHaveLastReturnedWith(null);
+
+        // 61 s after connect: the old fixed deadline has passed, the session is still up.
+        await vi.advanceTimersByTimeAsync(6_000);
+        const disconnects = (mockClient.publishAsync as ReturnType<typeof vi.fn>).mock.calls.filter(
+          (c: unknown[]) => c[0] === `${PREFIX}/disconnect`,
+        );
+        expect(disconnects).toHaveLength(0);
+
+        const buf = Buffer.alloc(4);
+        buf.writeUInt16LE(9030, 0);
+        buf.writeUInt16LE(500, 2);
+        mockClient._simulateMessage(`${PREFIX}/notify/${GATT_NOTIFY_UUID}`, buf);
+        const raw = await pending;
+        expect(raw.reading.weight).toBe(90.3);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('ReadingWatcher ignores autonomous connect when no adapter matches', async () => {
       // Adapter only matches by name 'GattScale', but the autonomous connect
       // comes from a different device with no name info.
@@ -2373,7 +2418,7 @@ describe('handler-mqtt-proxy', () => {
         await vi.advanceTimersByTimeAsync(10);
         expect((mockClient._listeners.get('message') ?? []).length).toBeGreaterThan(baseline);
 
-        // The 60s reading timeout must tear the whole session down: a leaked
+        // 60 s of silence must tear the whole session down: a leaked
         // notify listener on the persistent client re-processes every later
         // notification and compounds with each timed-out session.
         await vi.advanceTimersByTimeAsync(60_000);

--- a/tests/ble/handler-mqtt-proxy.test.ts
+++ b/tests/ble/handler-mqtt-proxy.test.ts
@@ -1835,6 +1835,45 @@ describe('handler-mqtt-proxy', () => {
       }
     });
 
+    it('ends a session that streams rejected frames at the absolute cap so the ESP32 is released', async () => {
+      vi.useFakeTimers();
+      try {
+        const adapter = createGattAdapter();
+        const watcher = new ReadingWatcher(MQTT_PROXY_CONFIG, [adapter], undefined, PROFILE);
+        await watcher.start();
+
+        mockClient._simulateMessage(
+          `${PREFIX}/connected`,
+          JSON.stringify({
+            autonomous: true,
+            address: 'AA:BB:CC:DD:EE:FF',
+            chars: [
+              { uuid: GATT_NOTIFY_UUID, properties: ['notify'] },
+              { uuid: GATT_WRITE_UUID, properties: ['write'] },
+            ],
+          }),
+        );
+        void watcher.nextReading();
+
+        // A frame the adapter rejects arrives every 30 s, so the 60 s idle
+        // timer never fires and only the absolute cap can end the session.
+        for (let elapsed = 0; elapsed < 90_000; elapsed += 30_000) {
+          await vi.advanceTimersByTimeAsync(30_000);
+          mockClient._simulateMessage(`${PREFIX}/notify/${GATT_NOTIFY_UUID}`, Buffer.from([0x10]));
+          expect(adapter.parseNotification).toHaveLastReturnedWith(null);
+        }
+
+        // Just past 90 s the cap has fired and the teardown released the proxy.
+        await vi.advanceTimersByTimeAsync(1_000);
+        const disconnects = (mockClient.publishAsync as ReturnType<typeof vi.fn>).mock.calls.filter(
+          (c: unknown[]) => c[0] === `${PREFIX}/disconnect`,
+        );
+        expect(disconnects).toHaveLength(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('ReadingWatcher ignores autonomous connect when no adapter matches', async () => {
       // Adapter only matches by name 'GattScale', but the autonomous connect
       // comes from a different device with no name info.

--- a/tests/ble/shared.test.ts
+++ b/tests/ble/shared.test.ts
@@ -5,6 +5,7 @@ import {
   findMissingCharacteristics,
   resolveWriteChar,
 } from '../../src/ble/shared.js';
+import { withIdleTimeout } from '../../src/ble/types.js';
 import type { BleChar, BleDevice } from '../../src/ble/shared.js';
 import { normalizeUuid, bleLog } from '../../src/ble/types.js';
 import { KoogeekS1Adapter } from '../../src/scales/koogeek-s1.js';
@@ -1600,5 +1601,88 @@ describe('waitForRawReading() — notification teardown', () => {
 
     await promise;
     await vi.waitFor(() => expect(unsub).toHaveBeenCalledTimes(1));
+  });
+});
+
+// ─── native call-site wiring: idle deadline over waitForRawReading ───────────
+// Both native handlers (noble, node-ble) wrap waitForRawReading in
+// withIdleTimeout(onActivity => waitForRawReading(..., onActivity), timeout).
+// These pin that composition: the onActivity ninth argument must reach
+// waitForRawReading so an adapter-rejected frame restarts the deadline, and a
+// silent session must still reject at the configured timeout (#83 wiring).
+describe('waitForRawReading() under the native idle deadline', () => {
+  const IDLE_MS = 1000;
+
+  function runWithIdle(adapter: ScaleAdapter, notifyChar: MockBleChar, device: BleDevice) {
+    const { charMap } = createCharMap([
+      [NOTIFY_UUID, notifyChar],
+      [WRITE_UUID, createMockChar()],
+    ]);
+    return withIdleTimeout(
+      (onActivity) =>
+        waitForRawReading(
+          charMap,
+          device,
+          adapter,
+          PROFILE,
+          '',
+          undefined,
+          undefined,
+          undefined,
+          onActivity,
+        ),
+      IDLE_MS,
+      'Timed out waiting for a complete scale reading',
+    );
+  }
+
+  it('restarts the deadline on an adapter-rejected frame so a later complete frame resolves', async () => {
+    vi.useFakeTimers();
+    try {
+      const notifyChar = createMockChar();
+      const device = createMockDevice();
+      let seen = 0;
+      const adapter = createLegacyAdapter({
+        parseNotification: vi.fn((): ScaleReading | null => {
+          seen++;
+          // First frame parses to null (adapter-rejected), so this also covers
+          // onActivity firing before the parse gate, not only before isComplete.
+          return seen === 1 ? null : { weight: 75, impedance: 500 };
+        }),
+      });
+
+      const promise = runWithIdle(adapter, notifyChar, device);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(notifyChar.subscribeCalled).toBe(true);
+
+      // Just before the deadline, a rejected frame arrives and must re-arm it.
+      await vi.advanceTimersByTimeAsync(IDLE_MS - 100);
+      notifyChar.triggerData(Buffer.from([0x01]));
+
+      // Past the original deadline: only the restart keeps the session alive.
+      await vi.advanceTimersByTimeAsync(IDLE_MS - 100);
+      notifyChar.triggerData(Buffer.from([0x02]));
+
+      const result = await promise;
+      expect(result.reading).toEqual({ weight: 75, impedance: 500 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects at the timeout when the scale stays silent', async () => {
+    vi.useFakeTimers();
+    try {
+      const notifyChar = createMockChar();
+      const device = createMockDevice();
+      const promise = runWithIdle(createLegacyAdapter(), notifyChar, device);
+      const rejection = expect(promise).rejects.toThrow(
+        'Timed out waiting for a complete scale reading',
+      );
+      await vi.advanceTimersByTimeAsync(IDLE_MS);
+      await rejection;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/ble/types.test.ts
+++ b/tests/ble/types.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   formatMac,
   normalizeUuid,
   sleep,
   withTimeout,
+  withIdleTimeout,
   BT_BASE_UUID_SUFFIX,
 } from '../../src/ble/types.js';
 
@@ -77,5 +78,45 @@ describe('withTimeout()', () => {
   it('propagates the original error if promise rejects before timeout', async () => {
     const failing = Promise.reject(new Error('original error'));
     await expect(withTimeout(failing, 1000, 'timeout')).rejects.toThrow('original error');
+  });
+});
+
+describe('withIdleTimeout()', () => {
+  it('rejects after the idle period when nothing signals activity', async () => {
+    vi.useFakeTimers();
+    try {
+      const never = withIdleTimeout(() => new Promise<never>(() => {}), 1000, 'idle');
+      const outcome = expect(never).rejects.toThrow('idle');
+      await vi.advanceTimersByTimeAsync(1000);
+      await outcome;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('restarts the deadline on activity so a slow but live source completes', async () => {
+    vi.useFakeTimers();
+    try {
+      let signal!: () => void;
+      let finish!: (v: string) => void;
+      const result = withIdleTimeout(
+        (onActivity) => {
+          signal = onActivity;
+          return new Promise<string>((resolve) => {
+            finish = resolve;
+          });
+        },
+        1000,
+        'idle',
+      );
+      await vi.advanceTimersByTimeAsync(900);
+      signal();
+      // Past the original deadline, inside the restarted one.
+      await vi.advanceTimersByTimeAsync(900);
+      finish('reading');
+      await expect(result).resolves.toBe('reading');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
Full log in #346. Branched from #339 because it rewrites the same two watcher call sites that PR touches, so this one shows both commits until #339 merges and the change here is the second commit.

`withIdleTimeout()` sits next to `withTimeout()` in `src/ble/types.ts` and restarts its timer whenever the callback it hands the caller is invoked. `waitForRawReading()` takes that callback as `onActivity` and calls it first thing in `handleNotification`, before the ACK and the adapter parse, so a frame the adapter rejects (an unstable QN 0x10) still counts. Outgoing writes don't, so a scale that says nothing still times out on schedule. All four reading call sites switched, both mqtt-proxy paths keep 60 s (now a named `GATT_READING_IDLE_MS`) and noble and node-ble keep `readingTimeoutMs ?? RAW_READING_TIMEOUT_MS`. The `pending.catch(() => {})` in the watcher went away because the helper races the promise itself, and the `fireDisconnect()` then `cleanup()` teardown from #339 is untouched.

The `session_timeout_sec` row and tip in the docs now describe silence, and the comments on the constants match.

Two unit tests on the helper (silence rejects, activity restarts) and one autonomous regression in `handler-mqtt-proxy.test.ts`, idle for 55 s, a frame the adapter rejects, past 60 s no disconnect is published, a complete frame at 61 s resolves. That test fails on the previous code, the disconnect is published at 60 s, and passes with the change. The leak test from #339 still passes, pure silence tears the session down at 60 s. Full suite passing except the two pre-existing macOS-only failures, tsc/eslint/prettier clean.
