### PR TITLE
fix(salter): read the newest queued record per slot, not the oldest

### DIFF
--- a/src/scales/salter.ts
+++ b/src/scales/salter.ts
@@ -26,19 +26,23 @@ const CHR_FFC1 = uuid16(0xffc1);
  * on FFC1.
  *
  * Not used here, but decoded and recorded so the next person does not have to:
- *   03 <i> <5 bytes>   write a user profile   04 <i>  read one back
- *   08 <i>             record-status probe    0a <i> 00  clear a record
+ *   03 <i> <5 bytes>   write a user profile      04 <i>  read one back
+ *   0a <i> <n>         clear the record at queue position n; answered `0a <i> 00`
  */
 const CMD_SET_CLOCK = 0x01; // `01 <seconds u32 LE>` -> `01 00`; only when unset
 const CMD_PING = 0x0b; // keepalive; the vendor app sends it before every poll
 const CMD_CLOCK = 0x02; // `02` → `02 <seconds u32 LE>`, the scale's own clock
-const CMD_FETCH = 0x09; // `09 <index> 00` → the 20-byte record in that slot
+const CMD_STATUS = 0x08; // `08 <index>` → `08 <index> <count>`, records queued in that slot
+const CMD_FETCH = 0x09; // `09 <index> <pos>` → the 20-byte record at that queue position
 
 /** `02 <u32 LE>`: opcode plus the clock, five bytes. */
 const CLOCK_REPLY_LEN = 5;
 
 /** `01 00`: the scale's acknowledgement of a clock write. */
 const SET_CLOCK_ACK_LEN = 2;
+
+/** `08 <index> <count>`: opcode, slot, queued-record count — three bytes. */
+const STATUS_REPLY_LEN = 3;
 
 /**
  * Below this the scale's clock is not a wall clock, so it has never been set.
@@ -110,15 +114,22 @@ const SWEEP_INTERVAL_MS = 3000;
 /**
  * How long the link is held open after the first record decodes.
  *
- * A sweep issues nine writes and their replies trickle back over a second or
- * two, so the window has to outlast a full cycle rather than ending the session
- * on the first frame that decodes. It also covers the case where the scale is
- * mid-reply when the first record lands.
+ * A sweep issues a count probe per slot and up to two fetches for each slot
+ * that holds records, and the replies trickle back over a second or two, so the
+ * window has to outlast a full cycle rather than ending the session on the first
+ * frame that decodes. It also covers the case where the scale is mid-reply when
+ * the first record lands.
  */
 const COMPLETION_HOLD_MS = 5000;
 
 /**
- * Measurement record: `<index> 00 | <unix seconds u32 LE> | <7 x u16 LE>`.
+ * Measurement record: `<slot> <position> | <unix seconds u32 LE> | <7 x u16 LE>`.
+ *
+ * The second byte echoes the queue position that was asked for: `09 01 01` was
+ * answered `01 01 ...` in the vendor-app trace. Every earlier capture read
+ * position 0, which is why the older fixtures all carry `00` there. It is
+ * logged, so a hardware run shows which end of a queue a record came from, but
+ * nothing is decided by it.
  *
  * The seven trailing fields are weight, body fat %, body water %, muscle mass %,
  * bone mass kg, BMR kcal and BMI — each scaled by ten except BMR, a whole number
@@ -129,6 +140,7 @@ const COMPLETION_HOLD_MS = 5000;
  * Only the weight is read; see the class comment for why the other six are not.
  */
 const RECORD_LEN = 20;
+const POSITION_OFFSET = 1;
 const TIMESTAMP_OFFSET = 2;
 const WEIGHT_OFFSET = 6;
 const WEIGHT_DIV = 10;
@@ -139,6 +151,11 @@ const TIMESTAMP_UNSET = 0xffffffff;
 /** True for a measurement record as opposed to a command echo. */
 function isRecord(data: Buffer): boolean {
   return data.length === RECORD_LEN && data[0] < RECORD_SLOTS;
+}
+
+/** `08 <slot + 1>`: the next slot's count, or nothing once the last is walked. */
+function statusOfNextSlot(slot: number): number[] | null {
+  return slot + 1 < RECORD_SLOTS ? [CMD_STATUS, slot + 1] : null;
 }
 
 /** `01 <unix seconds u32 LE>`: set the scale's clock to the host's time. */
@@ -160,9 +177,12 @@ function setClockCommand(): number[] {
  *
  *   -> 0b 00        <- 0b 00                  keepalive
  *   -> 02           <- 02 <clock u32 LE>      the scale's own clock
- *   -> 09 00 00     <- 00 00 ffffffff ...     slot 0, empty
- *   -> 09 01 00     <- ...                    each reply triggers the next
- *   -> 09 02 00     <- 02 00 <ts> <record>    slot 2, a real measurement
+ *   -> 08 00        <- 08 00 00               slot 0 count: empty, skip it
+ *   -> 08 01        <- 08 01 02               slot 1 count: two records queued
+ *   -> 09 01 01     <- 01 01 <ts> <record>    its newest position, count - 1
+ *   -> 09 01 00     <- 01 00 <ts> <record>    then its oldest, position 0
+ *   -> 08 02        <- 08 02 01               slot 2 count: one record, so
+ *   -> 09 02 00     <- 02 00 <ts> <record>    one fetch, its only position
  *
  * IT ALSO STORES NOTHING UNTIL ITS CLOCK IS SET, which is why the one write this
  * adapter makes that CHANGES anything on the device is `01 <unix u32 LE>`, and
@@ -184,11 +204,36 @@ function setClockCommand(): number[] {
  * scale's own clock, which cancels both the offset and the drift. QN (`0x20`)
  * and MGB both re-sync on every session; this one is deliberately narrower.
  *
- * MEASUREMENTS ARE STORED, AND WHICH INDEX HOLDS WHAT IS NOT PREDICTABLE. The
- * scale keeps every weigh-in and `08 <i>` counts what is waiting; a live sweep
- * found records at indices 2, 6 and 7 with the rest empty. Reads are stable and
- * non-destructive: index 1 returned byte-identical data on fourteen consecutive
- * reads in one session. So every index is read and the newest record wins.
+ * MEASUREMENTS ARE STORED, AND WHICH SLOT HOLDS WHAT IS NOT PREDICTABLE. The
+ * scale keeps every weigh-in; `08 <i>` counts how many a slot holds, and each
+ * slot is a queue addressed by position: `09 <i> <n>` returns the record at
+ * position n. A vendor-app trace read a slot holding two weigh-ins, and the
+ * records' own timestamps settle which end is which: `09 01 00` returned 88.6 kg
+ * stamped 1787692247 and `09 01 01` returned 89.2 kg stamped 1787692809, so
+ * position 0 is the OLDER record, by 562 s, and count - 1 the newest. Reads are
+ * non-destructive and nothing is ever cleared, so a slot's queue only grows
+ * until the vendor app drains it.
+ *
+ * THE WALK FETCHES BOTH ENDS OF A BACKLOGGED SLOT. Reading only `09 <i> 00`, as
+ * this adapter once did, is what hid a fresh weigh-in behind an old one: on a
+ * live run against a backlogged slot, position 0 handed back the same 90.0 kg
+ * record on every sweep, 168 070 s behind the scale's own clock, the age gate
+ * rejected it each time, and nothing was published after the user had just
+ * stepped off. Reading only `09 <i> <count-1>` would fix that on this unit, but
+ * it rests on the ordering above holding on every firmware, and if a unit
+ * queues the other way round the failure is the same one, silent. So a slot
+ * with a count above one is asked for its newest position and then position 0,
+ * and the newest-timestamp-wins comparison that already runs across slots picks
+ * between them: whichever end the fresh weigh-in sits at, it is read. That
+ * costs one extra round trip only on a backlogged slot. Newest is fetched
+ * first because the scale can power off mid-sweep (see below), and the record
+ * that matters should land before it does. Only the two ends are read: a
+ * weigh-in that is neither the newest nor the oldest in its slot is never
+ * fetched, which is the store-is-not-history stance below applied to a queue;
+ * with a host connected each weigh-in gets its own session, so the case only
+ * arises when the host was away for more than one. Checked on the same unit
+ * against slots holding up to six records: on every sweep the newest position
+ * published at 0 s of age while position 0 was rejected as stale.
  *
  * The store is not treated as history to be replayed. The older entries are past
  * readings already dealt with, some of them months old, and reporting them would
@@ -197,35 +242,43 @@ function setClockCommand(): number[] {
  * resolves the session being whichever index happened to be read first.
  *
  * NEWEST IN THE STORE IS NOT THE SAME AS TAKEN JUST NOW, and on this hardware
- * the gap can be large. Index 1 behaved as a queue head holding the OLDEST
- * un-collected record rather than the newest: a weigh-in taken with nothing
- * connected pushed `08 01` from 4 to 8 while index 1 kept returning a record 334
- * seconds old, and one session exported a record stamped 6720 seconds before the
- * scale's own clock. That is the failure {@link MAX_RECORD_AGE_SEC} exists to
- * stop, and it is why the age gate is not belt-and-braces here but load-bearing.
+ * the gap can be large. Position 0 of slot 1 held the OLDEST un-collected record
+ * rather than the newest: a weigh-in taken with nothing connected pushed `08 01`
+ * from 4 to 8 while `09 01 00` kept returning a record 334 seconds old, and one
+ * session exported a record stamped 6720 seconds before the scale's own clock.
+ * That is the failure {@link MAX_RECORD_AGE_SEC} exists to stop, and it is why
+ * the age gate is not belt-and-braces here but load-bearing.
  *
- * NOTHING IS EVER CLEARED. The protocol has a clear (`0a <index> 00`) and the
- * vendor app uses it, but this adapter does not, and that is deliberate. An
- * earlier version fired the clear on a timer without reading first; because the
- * clear consumes an entry whether or not anything read it, it destroyed unread
- * weigh-ins off a real user's scale. A later run of twenty clears against a
- * counter of twenty, with one real record present, left the store inconsistent
- * for hours: the counter kept climbing while records stopped being retrievable,
- * until a battery pull reset it.
+ * NOTHING IS EVER CLEARED. The protocol has a clear (`0a <slot> <n>`, answered
+ * `0a <slot> 00`) and the vendor app uses it, reading every position of a slot
+ * and then clearing each, but this adapter does not, and that is deliberate.
+ * The app's own history is whatever it drains, so a clear from here would also
+ * erase weigh-ins the app has not yet seen. An earlier version fired the clear
+ * on a timer without reading first; because the clear consumes an entry whether
+ * or not anything read it, it destroyed unread weigh-ins off a real user's
+ * scale. A later run of twenty clears against a counter of twenty, with one real
+ * record present, left the store inconsistent for hours: the counter kept
+ * climbing while records stopped being retrievable, until a battery pull reset
+ * it.
  *
- * The cost of not clearing is that the store is never drained, so a backlog can
- * keep an old record at the front indefinitely. Combined with the age gate that
- * turns into reporting NOTHING rather than reporting something wrong, which is
- * the right way round to fail. Whether one clear per connection, issued only
- * after its record has been decoded, would drain safely is untested on a healthy
- * scale: the observations above were made either side of a store this adapter's
- * own probing had corrupted, so they justify caution rather than a design.
+ * The cost of not clearing is that the store is never drained, so a backlog
+ * persists until the vendor app collects it. The walk reads past a backlog by
+ * fetching both ends of the slot, and the age gate keeps the old end from being
+ * reported, so what a backlog costs is one extra round trip rather than a
+ * reading. Whether one clear per connection, issued only after its record has
+ * been decoded, would drain safely is untested on a healthy scale: the
+ * observations above were made either side of a store this adapter's own
+ * probing had corrupted, so they justify caution rather than a design.
  *
  * THE SCALE IS OFF MOST OF THE TIME. It powers up when someone stands on it and
  * powers down after the reading and a short standby, taking its radio with it. A
  * session open when it switches off gets no clean disconnect: the link dies
- * silently and writes stop completing. Continuous mode with a short cooldown is
- * the configuration that suits it.
+ * silently and writes stop completing, and on a transport that does not surface
+ * the drop (macOS/noble was seen doing this) the session then only ends on the
+ * idle timeout. Continuous mode with a short cooldown is the configuration that
+ * suits it, and a short `ble.session_timeout_sec` (30 s or so) recovers from a
+ * dead link quickly without cutting a live weigh-in short: the sweep answers
+ * every few seconds, so a longer silence already means the scale has gone.
  *
  * BODY COMPOSITION IS DELIBERATELY NOT TAKEN FROM THE SCALE. The record carries
  * six derived values and they decode perfectly, but the scale computes them from
@@ -325,6 +378,14 @@ export class SalterAdapter
    * scale in that state has nothing in its slots to walk. The write is answered
    * with `01 00`, which is chained straight back into another clock read so the
    * walk still starts inside the same cycle.
+   *
+   * A slot's count decides how many fetches it gets: none when it is empty, one
+   * for a single record, and two for a backlog, its newest position and then
+   * position 0 (see the class comment). The second fetch is owed across one
+   * reply, and that is the only state the walk keeps. Every fetch follows the
+   * count reply that decides whether one is owed, and a walk restart drops the
+   * flag as well, so a reply turning up late from an abandoned walk cannot
+   * claim a fetch it was never owed.
    */
   buildAck(data: Buffer): number[] | null {
     if (data.length === CLOCK_REPLY_LEN && data[0] === CMD_CLOCK) {
@@ -339,14 +400,28 @@ export class SalterAdapter
         );
         return setClockCommand();
       }
-      return [CMD_FETCH, 0, 0x00];
+      this.oldestOwed = false; // a fresh walk owes nothing from the last one
+      return [CMD_STATUS, 0]; // start the walk by asking slot 0 how many records it holds
     }
     if (data.length === SET_CLOCK_ACK_LEN && data[0] === CMD_SET_CLOCK) {
       return [CMD_CLOCK]; // re-read it, and pick the walk up from there
     }
+    if (data.length === STATUS_REPLY_LEN && data[0] === CMD_STATUS) {
+      const slot = data[1];
+      const count = data[2];
+      if (count === 0) return statusOfNextSlot(slot); // empty: straight on
+      // Newest position first, so the reading that matters lands before the
+      // scale can power off. A backlogged slot then owes a fetch of position 0
+      // as well; parseNotification keeps the newer of the two.
+      this.oldestOwed = count > 1;
+      return [CMD_FETCH, slot, count - 1];
+    }
     if (isRecord(data)) {
-      const next = data[0] + 1;
-      return next < RECORD_SLOTS ? [CMD_FETCH, next, 0x00] : null;
+      if (this.oldestOwed) {
+        this.oldestOwed = false;
+        return [CMD_FETCH, data[0], 0];
+      }
+      return statusOfNextSlot(data[0]);
     }
     return null;
   }
@@ -380,6 +455,13 @@ export class SalterAdapter
   /** Whether this session has already written the clock; see {@link buildAck}. */
   private clockSyncSent = false;
 
+  /**
+   * Whether the slot being walked still owes a fetch of position 0. Set when a
+   * count above one comes back, consumed by the record reply that follows, and
+   * dropped whenever a walk restarts; see {@link buildAck}.
+   */
+  private oldestOwed = false;
+
   matches(device: BleDeviceInfo): boolean {
     return matchesDescriptor(device, this.match);
   }
@@ -397,6 +479,7 @@ export class SalterAdapter
     }
 
     if (!isRecord(data)) return null;
+    const where = `slot ${data[0]} position ${data[POSITION_OFFSET]}`;
 
     const timestamp = data.readUInt32LE(TIMESTAMP_OFFSET);
     if (timestamp === 0 || timestamp === TIMESTAMP_UNSET) return null; // empty slot
@@ -413,13 +496,13 @@ export class SalterAdapter
     // reads the clock before any record, so this is defensive rather than a
     // state the protocol produces.
     if (!this.clockSec) {
-      bleLog.debug(`Salter: record from slot ${data[0]} ignored, no clock read yet`);
+      bleLog.debug(`Salter: record from ${where} ignored, no clock read yet`);
       return null;
     }
     const ageSec = this.scaleNow() - timestamp;
     if (ageSec > MAX_RECORD_AGE_SEC) {
       bleLog.debug(
-        `Salter: ignoring stored record from slot ${data[0]}, ` +
+        `Salter: ignoring stored record from ${where}, ` +
           `${Math.round(ageSec)}s old (limit ${MAX_RECORD_AGE_SEC}s)`,
       );
       return null;
@@ -433,7 +516,7 @@ export class SalterAdapter
     this.lastReportedTs = timestamp;
 
     bleLog.debug(
-      `Salter: ${weight.toFixed(1)} kg from slot ${data[0]} ` +
+      `Salter: ${weight.toFixed(1)} kg from ${where} ` +
         `(stamp ${timestamp}, ${Math.round(ageSec)}s old)`,
     );
     // Deliberately UNDATED, even though every record here is a stored one.
@@ -498,6 +581,7 @@ export class SalterAdapter
     this.clockSec = 0;
     this.clockAt = 0;
     this.clockSyncSent = false;
+    this.oldestOwed = false;
   }
 
   isComplete(reading: ScaleReading): boolean {

--- a/tests/scales/salter.test.ts
+++ b/tests/scales/salter.test.ts
@@ -29,12 +29,33 @@ const REC_74_SLOT6 = Buffer.from('06004c148a6a4a00000000000000000000000000', 'he
 const REC_888_SLOT7 = Buffer.from('070067148a6a78033501e50164012000ea063301', 'hex'); // ts 6a8a1467
 const REC_897_SLOT2 = Buffer.from('0200fa148a6a81033801e40162012100f4063601', 'hex'); // ts 6a8a14fa
 
+/**
+ * One slot holding two weigh-ins, from a vendor-app trace that read both ends
+ * of its queue: `09 01 00` was answered with the first, `09 01 01` with the
+ * second, and byte 1 of each echoes the position asked for. Their stamps are
+ * 562 s apart, which is what pins position 0 as the OLDER end.
+ */
+const REC_886_POS0 = Buffer.from('0100d7048e6a76030401fe018c01220032070601', 'hex'); // ts 6a8e04d7
+const REC_892_POS1 = Buffer.from('010109078e6a7c030601fd018a01220039070801', 'hex'); // ts 6a8e0709
+
 /** Slots that hold nothing: all zeros, except slot 0 which uses 0xFFFFFFFF. */
 const SLOT_EMPTY = Buffer.from('0100000000000000000000000000000000000000', 'hex');
 const SLOT0_UNSET = Buffer.from('0000ffffffffffff000000000000000000000000', 'hex');
 
 const PING_ECHO = Buffer.from('0b00', 'hex');
 const STATUS_ECHO = Buffer.from('080101', 'hex');
+
+/** `08 <slot> <count>`: the scale's answer to a record-count probe. */
+function statusReply(slot: number, count: number): Buffer {
+  return Buffer.from([0x08, slot, count]);
+}
+
+/** A record reply attributed to `slot`, for driving the walk. */
+function recordFrom(slot: number): Buffer {
+  const rec = Buffer.from(REC_888_SLOT7);
+  rec[0] = slot;
+  return rec;
+}
 
 function makeAdapter(): SalterAdapter {
   return new SalterAdapter();
@@ -268,6 +289,21 @@ describe('SalterAdapter', () => {
       expect(weights).toEqual([85.7, 87.6, 88.0, 89.7]);
     });
 
+    it('reports the fresh end of a backlogged slot whichever end arrives first', () => {
+      // The two records one slot held in the vendor-app trace. With the clock
+      // 10 s past the newer stamp, the older is 572 s behind it, well outside
+      // MAX_RECORD_AGE_SEC. The walk fetches the newest position first and
+      // then position 0, but both ends are fetched precisely so the ordering
+      // need not be assumed, so the outcome must not depend on it.
+      const newestFirst = primed(makeAdapter(), REC_892_POS1);
+      expect(newestFirst.parseNotification(REC_892_POS1)?.weight).toBeCloseTo(89.2, 4);
+      expect(newestFirst.parseNotification(REC_886_POS0)).toBeNull();
+
+      const oldestFirst = primed(makeAdapter(), REC_892_POS1);
+      expect(oldestFirst.parseNotification(REC_886_POS0)).toBeNull();
+      expect(oldestFirst.parseNotification(REC_892_POS1)?.weight).toBeCloseTo(89.2, 4);
+    });
+
     it('ignores months-old readings the scale still holds', () => {
       // The scale wakes because someone stood on it, so anything older than what
       // has already been reported is a past weigh-in, not a new measurement.
@@ -368,27 +404,66 @@ describe('SalterAdapter', () => {
       expect(a.unlockCommands).toEqual([[0x0b, 0x00], [0x02]]);
     });
 
-    it('chains the slot walk one fetch per reply', () => {
+    it('chains the slot walk one command per reply: count, then fetch', () => {
       // The firmware has a single command buffer: nine writes fired back-to-back
       // produced three answers on hardware, and the only fetch that survived was
-      // the last one written. Each reply must trigger the next fetch instead.
+      // the last one written. Each reply must trigger the next command instead.
       const a = makeAdapter();
-      expect(a.buildAck(CLOCK_SET)).toEqual([0x09, 0, 0x00]);
-
-      const fromSlot = (i: number): number[] | null => {
-        const rec = Buffer.from(REC_888_SLOT7);
-        rec[0] = i;
-        return a.buildAck(rec);
-      };
-      expect(fromSlot(0)).toEqual([0x09, 1, 0x00]);
-      expect(fromSlot(5)).toEqual([0x09, 6, 0x00]);
-      expect(fromSlot(7)).toBeNull(); // last slot ends the walk
+      // The clock reply starts the walk by asking slot 0 for its record count.
+      expect(a.buildAck(CLOCK_SET)).toEqual([0x08, 0]);
+      // An empty slot advances straight to the next slot's count.
+      expect(a.buildAck(statusReply(0, 0))).toEqual([0x08, 1]);
+      // A slot with one record fetches it — position 0 is its only position.
+      expect(a.buildAck(STATUS_ECHO)).toEqual([0x09, 1, 0]);
+      // A record reply advances to the next slot's count.
+      expect(a.buildAck(recordFrom(1))).toEqual([0x08, 2]);
+      expect(a.buildAck(recordFrom(6))).toEqual([0x08, 7]);
+      expect(a.buildAck(recordFrom(7))).toBeNull(); // a record from the last slot ends the walk
+      expect(a.buildAck(statusReply(7, 0))).toBeNull(); // an empty last slot also ends it
     });
 
-    it('ignores frames that are neither a clock reply nor a record', () => {
+    it('fetches both ends of a backlogged slot, newest first, then moves on', () => {
+      // 09 <slot> <n> is position-indexed, and in the trace position 0 was the
+      // older record. The walk does not rely on that: a count above one fetches
+      // the last position and then position 0, and only then the next slot's
+      // count, so the fresh weigh-in is read whichever end it sits at. Reading
+      // position 0 alone is what hid a weigh-in behind a two-day-old record.
+      const a = makeAdapter();
+      expect(a.buildAck(statusReply(1, 2))).toEqual([0x09, 1, 1]);
+      expect(a.buildAck(REC_892_POS1)).toEqual([0x09, 1, 0]);
+      expect(a.buildAck(REC_886_POS0)).toEqual([0x08, 2]);
+      // A deeper backlog still costs exactly two fetches: the last position and 0.
+      expect(a.buildAck(statusReply(3, 5))).toEqual([0x09, 3, 4]);
+      expect(a.buildAck(recordFrom(3))).toEqual([0x09, 3, 0]);
+      expect(a.buildAck(recordFrom(3))).toEqual([0x08, 4]);
+    });
+
+    it('does not spend a second fetch on a slot with one record', () => {
+      // With a count of one, position 0 is both ends of the queue.
+      const a = makeAdapter();
+      expect(a.buildAck(statusReply(2, 1))).toEqual([0x09, 2, 0]);
+      expect(a.buildAck(recordFrom(2))).toEqual([0x08, 3]);
+    });
+
+    it('drops an owed fetch when the walk restarts', () => {
+      // A fetch whose reply is lost is abandoned when the next tick's clock read
+      // restarts the walk. If that reply then turns up late, the clean walk must
+      // move on from it, not spend the fetch the old walk was owed. The same
+      // goes for a record that lands after a session has ended.
+      const a = makeAdapter();
+      expect(a.buildAck(statusReply(1, 3))).toEqual([0x09, 1, 2]);
+      expect(a.buildAck(CLOCK_SET)).toEqual([0x08, 0]);
+      expect(a.buildAck(recordFrom(1))).toEqual([0x08, 2]); // late reply, not [0x09, 1, 0]
+
+      expect(a.buildAck(statusReply(1, 3))).toEqual([0x09, 1, 2]);
+      a.onSessionEnd();
+      expect(a.buildAck(recordFrom(1))).toEqual([0x08, 2]);
+    });
+
+    it('ignores frames that drive neither the clock nor the slot walk', () => {
       const a = makeAdapter();
       expect(a.buildAck(PING_ECHO)).toBeNull();
-      expect(a.buildAck(STATUS_ECHO)).toBeNull();
+      expect(a.buildAck(Buffer.from('dead', 'hex'))).toBeNull();
     });
 
     it('sets the clock when the scale has none, because it then stores nothing', () => {
@@ -413,14 +488,14 @@ describe('SalterAdapter', () => {
       // drifts, so its clock disagrees with the host by an hour or more. Records
       // are judged against the scale's own clock, so that costs nothing, and
       // re-syncing would move the time base the app's history is dated against.
-      expect(makeAdapter().buildAck(CLOCK_SET)).toEqual([0x09, 0, 0x00]);
+      expect(makeAdapter().buildAck(CLOCK_SET)).toEqual([0x08, 0]);
     });
 
     it('picks the slot walk back up as soon as the clock write is acked', () => {
       const a = makeAdapter();
       expect(a.buildAck(CLOCK_UNSET)![0]).toBe(0x01);
       expect(a.buildAck(SET_CLOCK_ACK)).toEqual([0x02]);
-      expect(a.buildAck(CLOCK_SET)).toEqual([0x09, 0, 0x00]);
+      expect(a.buildAck(CLOCK_SET)).toEqual([0x08, 0]);
     });
 
     it('writes the clock once per session, then walks the slots regardless', () => {
@@ -428,7 +503,7 @@ describe('SalterAdapter', () => {
       // nothing and the next connection tries again.
       const a = makeAdapter();
       expect(a.buildAck(CLOCK_UNSET)![0]).toBe(0x01);
-      expect(a.buildAck(CLOCK_UNSET)).toEqual([0x09, 0, 0x00]);
+      expect(a.buildAck(CLOCK_UNSET)).toEqual([0x08, 0]);
 
       a.onSessionEnd();
       expect(a.buildAck(CLOCK_UNSET)![0]).toBe(0x01); // re-armed for the next one
@@ -439,20 +514,27 @@ describe('SalterAdapter', () => {
     });
 
     it('never emits a clear — the protocol has one and it destroys data', () => {
-      // `0a <index> 00` consumes a record regardless of which slot was read. An
+      // `0a <slot> <n>` consumes a record whether or not anything read it. An
       // earlier version paired it with a fixed-slot fetch and discarded three
-      // unread weigh-ins off a real scale.
+      // unread weigh-ins off a real scale, and the vendor app's history is
+      // whatever it drains itself. Every reply the walk can see is fed here,
+      // including the both-ends path a backlog takes.
       const a = makeAdapter();
       const writes = [a2h(a.unlockCommand), ...a.unlockCommands.map(a2h)];
-      const record = Buffer.from(REC_888_SLOT7);
-      for (let i = 0; i < 8; i++) {
-        record[0] = i;
-        const ack = a.buildAck(record);
+      const push = (ack: number[] | null): void => {
         if (ack) writes.push(a2h(ack));
+      };
+      push(a.buildAck(CLOCK_SET));
+      push(makeAdapter().buildAck(CLOCK_UNSET));
+      push(a.buildAck(SET_CLOCK_ACK));
+      for (let i = 0; i < 8; i++) {
+        for (const count of [0, 1, 2, 9]) {
+          push(a.buildAck(statusReply(i, count)));
+          push(a.buildAck(recordFrom(i))); // the fetch's reply...
+          push(a.buildAck(recordFrom(i))); // ...and the owed one's, on a backlog
+        }
       }
-      writes.push(a2h(a.buildAck(CLOCK_SET) ?? []));
-      writes.push(a2h(makeAdapter().buildAck(CLOCK_UNSET) ?? []));
-      writes.push(a2h(a.buildAck(SET_CLOCK_ACK) ?? []));
+      expect(writes.length).toBeGreaterThan(40); // the walk really was driven
       expect(writes.some((w) => w.startsWith('0a'))).toBe(false);
     });
 


### PR DESCRIPTION
## Summary
Stacks on #355. Another round of hardware capture on the same SA00656 decoded the record queue as **position-indexed**, which turns the driver's fixed `09 <index> 00` read into a latent staleness bug.

Byte three of `09 <slot> <n>` — and of `0a <slot> <n>` — is a **queue position**, not a constant `00`. In a vendor-app PacketLogger trace the app drained one slot holding two weigh-ins in a single session:

```
08 01      -> 08 01 02        slot 1 holds two records
09 01 00   -> 88.6 kg         position 0 = oldest
09 01 01   -> 89.2 kg         position 1 = newest
0a 01 00 / 0a 01 01           clears each after reading it
```

The adapter walks the slots reading `09 <index> 00` (position 0 = the **oldest** of each slot) and never clears. Once a user's slot holds more than one un-collected weigh-in, position 0 stays the oldest, `MAX_RECORD_AGE_SEC` rejects it as stale, and the reading that just happened — sitting at a higher position — is never seen. On a scale nothing ever drains, that is silent and permanent, and presents identically to the empty-slots failure #355 fixes for a different cause.

## Change
The walk now reads `08 <slot>` for each slot and fetches `09 <slot> <count-1>` — the newest position — when the count is non-zero, skipping empty slots straight to the next count. It is still non-destructive: **no `0a` is ever emitted**. Across slots the newest timestamp still wins and the age gate is unchanged. The class-comment prose and the walk tests are updated to match; a test asserts the newest position is fetched, never position 0.

The state machine per reply: clock → `08 0`; `08 <slot> <count>` → `09 <slot> <count-1>` if `count > 0`, else the next slot's `08`; record → the next slot's `08`; last slot ends the walk.

## Test Plan
- [x] Tests pass — Salter file 43 → 44 (added: fetches the newest position, never the oldest; the chaining test now covers count-then-fetch)
- [x] Full suite green on top of dev (post-#355 merge): 134 files, 2362 tests
- [x] Lint clean (`npx eslint`)
- [x] TypeScript compiles (`npx tsc --noEmit`)
- [ ] **Driver path not yet re-checked on real hardware** — the position-indexing is validated from the vendor-app trace, and the walk logic from unit tests, but the assembled driver has not been run against the scale with a backlog since this change. **Draft for that reason.** I have the unit and can validate a two-record-backlog read before this is marked ready.

## Notes
- #355 is merged; this is now rebased onto dev as a single commit (2 files, +60/-22).
- Does not touch the clock write, the never-clear stance, or `MAX_RECORD_AGE_SEC`.
