### PR TITLE
ci(worker): install the pinned wrangler before deploying

### DIFF
--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -14,6 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+          cache-dependency-path: worker/package-lock.json
+
+      # Installs the wrangler pinned in worker/package-lock.json so
+      # wrangler-action finds it locally. Without this the action falls back to
+      # a fresh `npm i wrangler@4`, which resolves to a wrangler whose optional
+      # peer @cloudflare/workers-types has moved to v5 and fails ERESOLVE
+      # against the v4 pinned here.
+      - name: Install worker dependencies
+        run: npm ci
+        working-directory: worker
+
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v4
         with:


### PR DESCRIPTION
Fixes the `Deploy Worker` failure on the v1.26.0 promotion
(run 33010151137).

The job ran `wrangler-action` on a bare checkout, so the action's
`npx --no-install wrangler --version` probe found nothing and fell back to
installing wrangler fresh. That now resolves to 4.126.0, whose optional peer
`@cloudflare/workers-types` moved to `^5.20260825.1` and fails ERESOLVE
against the `^4.20250321.0` pinned in `worker/package.json`.

Installing `worker/package-lock.json` first, the way `docs.yml` already does,
makes the probe find the pinned wrangler 4.78.0 so the fresh install never
happens.

Verified locally: `npm ci` in `worker/` then
`npx --no-install wrangler --version` reports 4.78.0.