### PR TITLE
fix(qn): hold the connection context across the FFE3 fallback so the 0x1F ack reaches the scale

### DIFF
--- a/src/scales/qn-scale.ts
+++ b/src/scales/qn-scale.ts
@@ -515,12 +515,17 @@ export class QnScaleAdapter
   }
 
   private async writeCmd(data: number[]): Promise<void> {
-    if (!this.ctx) return;
+    // Hold the context for both attempts. The 0x1F ack is issued from
+    // parseNotification, whose caller ends the session (onSessionEnd nulls
+    // this.ctx) in the same tick, so on FFE3-only scales the fallback would
+    // otherwise dereference null and the ack would never reach the scale.
+    const ctx = this.ctx;
+    if (!ctx) return;
     try {
-      await this.ctx.write(CHR_WRITE, data, false);
+      await ctx.write(CHR_WRITE, data, false);
     } catch (primaryErr: unknown) {
       try {
-        await this.ctx.write(CHR_WRITE_T1, data, false);
+        await ctx.write(CHR_WRITE_T1, data, false);
       } catch (altErr: unknown) {
         // Both write characteristics rejected. Logging this matters: a silent
         // return here is why a failed handshake looks identical to a scale

--- a/tests/scales/qn-scale.test.ts
+++ b/tests/scales/qn-scale.test.ts
@@ -1333,6 +1333,46 @@ describe('AE02 dispatch (#75, #235)', () => {
         vi.useRealTimers();
       }
     });
+
+    it('still delivers the 0x1F ack on FFE3 when the session ends before the FFF2 fallback runs', async () => {
+      const adapter = makeAdapter();
+      const writes: Array<{ uuid: string; data: number[] }> = [];
+      const ctx = {
+        // An FFE3-only scale: the FFF2 attempt rejects, the fallback must land on FFE3.
+        write: async (uuid: string, data: Buffer | number[]) => {
+          if (uuid === '0000fff200001000800000805f9b34fb') {
+            throw new Error(`Characteristic ${uuid} not found`);
+          }
+          writes.push({ uuid, data: [...data] });
+        },
+        read: async () => Buffer.alloc(0),
+        subscribe: async () => {},
+        profile: defaultProfile(),
+        deviceAddress: '',
+        availableChars: new Set<string>(),
+      } as unknown as ConnectionContext;
+      await adapter.onConnected(ctx);
+      writes.length = 0;
+
+      const stable = Buffer.alloc(10);
+      stable[0] = 0x10;
+      stable[1] = 0x0a;
+      stable[2] = 0x01;
+      stable.writeUInt16BE(8000, 3);
+      stable[5] = 1;
+      stable.writeUInt16BE(550, 6);
+      stable.writeUInt16BE(530, 8);
+
+      // waitForReading's finishWith runs cleanup -> onSessionEnd synchronously
+      // after parseNotification returns, before the rejected FFF2 write is observed.
+      expect(adapter.parseNotification(stable)).not.toBeNull();
+      adapter.onSessionEnd!();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      const ack = writes.find((w) => w.data[0] === 0x1f);
+      expect(ack?.uuid).toBe('0000ffe300001000800000805f9b34fb');
+      expect(ack?.data).toEqual([0x1f, 0x05, 0x00, 0x10, 0x34]);
+    });
   });
 
   // ── GE CS 10 G "Fit Plus" extended long frame (#235) ────────────────────────


### PR DESCRIPTION
Full diagnosis in #370. The 0x1F ack after a stable reading is sent fire-and-forget from parseWeightFrame, and waitForReading ends the session in the same tick, which nulls this.ctx through onSessionEnd. writeCmd guarded this.ctx once and then read it again for the FFE3 fallback, so on scales that only expose FFE3 the FFF2 attempt rejected after the session had already ended and the fallback dereferenced null. The ack was lost on every reading, and the scale kept advertising and reconnecting because it never heard that the reading was received.

writeCmd now captures the context once and uses it for both attempts. The write is a fire-and-forget publish to the proxy, so sending it after onSessionEnd is fine, and I traced the ordering against the current watcher nesting: the FFF2 rejection's continuation runs before the reading's resolution propagates up through withIdleTimeout and withTimeout, so the FFE3 publish enters the MQTT client before the watcher's finally reaches mqttGattDisconnect, on both the host-initiated and autonomous paths. Capturing also pins the ack to its own session, so a replacement session's context can never be picked up by a stale fallback.

One test added: an FFE3-only context whose session ends right after parseNotification returns must still see the [1f 05 00 10 34] ack on FFE3. It fails with the writeCmd hunk reverted, no FFE3 ack is sent. Full suite, tsc, eslint and prettier clean on top of current dev.
