### PR TITLE
feat(exporters): let the Garmin exporter upload the weight alone

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,14 @@ HEIGHT_UNIT=cm
 # EXPORTERS=garmin
 
 # ==========================================
+# GARMIN CONFIGURATION (only when garmin exporter is enabled)
+# ==========================================
+# Upload the weight alone. BMI, body fat, water, bone mass, muscle mass,
+# visceral fat, physique rating and metabolic age are left unset in Garmin
+# Connect. Other exporters are unaffected. Default: false
+# GARMIN_WEIGHT_ONLY=true
+
+# ==========================================
 # MQTT CONFIGURATION (only when mqtt exporter is enabled)
 # ==========================================
 # MQTT_BROKER_URL=mqtt://localhost:1883

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,6 @@ jobs:
 
       - name: Run firmware unit tests
         run: python -m unittest discover -s firmware/tests -v
+
+      - name: Run Garmin uploader unit tests
+        run: python -m unittest discover -s garmin-scripts/tests -v

--- a/ble-scale-sync-addon/DOCS.md
+++ b/ble-scale-sync-addon/DOCS.md
@@ -64,6 +64,12 @@ To upload measurements to Garmin Connect:
 
 On first start the add-on authenticates with Garmin and stores the OAuth tokens under `/data/garmin-tokens` inside the container. Subsequent runs reuse those tokens, so your password is only used once.
 
+### Weight only
+
+Turn on **Upload weight only** (`garmin_weight_only`) to send just the weight to Garmin Connect and leave BMI, body fat, water, bone mass, muscle mass, visceral fat, physique rating and metabolic age unset. Every other exporter, including the MQTT sensors in Home Assistant, still receives the full body composition.
+
+Garmin Connect calculates its own BMI from the weight and the height in your Garmin profile, so a BMI value may still be shown on the entry — it is Garmin's, not the scale's.
+
 ### If your Garmin account uses MFA
 
 Home Assistant add-ons run without an interactive terminal, so the add-on cannot prompt for a 2FA code. If your account has MFA enabled:

--- a/ble-scale-sync-addon/config.yaml
+++ b/ble-scale-sync-addon/config.yaml
@@ -63,6 +63,7 @@ options:
   garmin_enabled: false
   garmin_email: ''
   garmin_password: ''
+  garmin_weight_only: false
   scan_cooldown: 30
   reset_bluetooth: true
   debug: false
@@ -96,6 +97,7 @@ schema:
   garmin_enabled: bool
   garmin_email: str?
   garmin_password: password?
+  garmin_weight_only: bool?
   scan_cooldown: int(5,3600)
   reset_bluetooth: bool
   debug: bool

--- a/ble-scale-sync-addon/run.sh
+++ b/ble-scale-sync-addon/run.sh
@@ -102,6 +102,12 @@ else
   GARMIN_ENABLED=$(opt_bool garmin_enabled)
   GARMIN_EMAIL=$(opt garmin_email)
   GARMIN_PASSWORD=$(opt garmin_password)
+  GARMIN_WEIGHT_ONLY=$(opt_bool garmin_weight_only)
+  # opt_bool echoes the raw option, and this one is interpolated unquoted into
+  # the generated YAML. The add-on schema declares it bool?, but a hand-edited
+  # options.json is not bound by that, and a stray string would produce YAML
+  # that fails to parse. Anything that is not exactly "true" is false.
+  [ "$GARMIN_WEIGHT_ONLY" = "true" ] || GARMIN_WEIGHT_ONLY=false
 
   SCAN_COOLDOWN=$(opt_int scan_cooldown 30)
   DEBUG=$(opt_bool debug)
@@ -286,6 +292,7 @@ YAML
     email: "$(yaml_escape "$GARMIN_EMAIL")"
     password: "$(yaml_escape "$GARMIN_PASSWORD")"
     token_dir: /data/garmin-tokens
+    weight_only: $GARMIN_WEIGHT_ONLY
 YAML
     fi
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -118,6 +118,9 @@ global_exporters:
     email: "${GARMIN_EMAIL}"
     password: "${GARMIN_PASSWORD}"
     token_dir: ~/.garmin_tokens
+    # weight_only: true    # upload the weight alone; BMI, body fat, water, bone,
+    #                      # muscle, visceral fat, physique rating and metabolic
+    #                      # age are left unset in Garmin Connect
 
   # -- MQTT (Home Assistant auto-discovery) --
   # - type: mqtt

--- a/docs/exporters.md
+++ b/docs/exporters.md
@@ -31,11 +31,12 @@ Exporters are configured in `global_exporters` (shared by all users). For multi-
 
 Automatic body composition upload to Garmin Connect, no phone app needed. Uses a Python subprocess with cached authentication tokens.
 
-| Field       | Required | Default            | Description                      |
-| ----------- | -------- | ------------------ | -------------------------------- |
-| `email`     | Yes      | (none)             | Garmin account email             |
-| `password`  | Yes      | (none)             | Garmin account password          |
-| `token_dir` | No       | `~/.garmin_tokens` | Directory for cached auth tokens |
+| Field         | Required | Default            | Description                                                    |
+| ------------- | -------- | ------------------ | -------------------------------------------------------------- |
+| `email`       | Yes      | (none)             | Garmin account email                                           |
+| `password`    | Yes      | (none)             | Garmin account password                                        |
+| `token_dir`   | No       | `~/.garmin_tokens` | Directory for cached auth tokens                               |
+| `weight_only` | No       | `false`            | Upload the weight alone, leaving every derived metric unset     |
 
 ```yaml
 global_exporters:
@@ -43,6 +44,21 @@ global_exporters:
     email: '${GARMIN_EMAIL}'
     password: '${GARMIN_PASSWORD}'
 ```
+
+::: tip Weight only
+Set `weight_only: true` to record just the weight and leave BMI, body fat, water, bone mass, muscle mass, visceral fat, physique rating and metabolic age unset in Garmin Connect. Useful when you trust the scale's weight but not its bioimpedance estimates. In continuous mode the config watcher picks it up on the next scan cycle, so no restart is needed (unless you have set `runtime.watch_config: false`). It does not affect any other exporter.
+
+Note that Garmin Connect derives its own BMI from the weight and the height in your Garmin profile, so a BMI figure may still appear on the entry — it just will not be the scale's.
+
+```yaml
+global_exporters:
+  - type: garmin
+    email: '${GARMIN_EMAIL}'
+    password: '${GARMIN_PASSWORD}'
+    weight_only: true
+```
+
+:::
 
 ::: tip Authentication
 The setup wizard handles Garmin authentication automatically. You only need to authenticate once; tokens are cached and reused. To re-authenticate manually:

--- a/docs/guide/home-assistant-addon.md
+++ b/docs/guide/home-assistant-addon.md
@@ -105,6 +105,7 @@ The CLI and exporters display weights and heights in your chosen unit; all inter
 | ---------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `garmin_enabled`                   | `false` | Enable the Garmin Connect exporter.                                                                                                    |
 | `garmin_email` / `garmin_password` | empty   | Garmin credentials. On first start the add-on runs `setup_garmin.py` to authenticate and saves OAuth tokens to `/data/garmin-tokens/`. |
+| `garmin_weight_only`               | `false` | Upload the weight alone; BMI, body fat, water, bone, muscle, visceral fat, physique rating and metabolic age are left unset in Garmin. |
 
 If your account uses MFA, see [MFA workaround](#mfa-workaround) below.
 

--- a/garmin-scripts/garmin_upload.py
+++ b/garmin-scripts/garmin_upload.py
@@ -76,27 +76,42 @@ def upload(payload, token_dir=None):
     if ts:
         log(f"[Garmin] Back-dating measurement to {ts}")
 
-    log("[Garmin] Uploading body composition...")
+    # When the exporter is configured weight_only, every derived metric is sent
+    # as None. garminconnect encodes None as the FIT basetype's "invalid"
+    # marker, which is how the format says "no value here" - Garmin records the
+    # weight and leaves the rest blank rather than storing a zero.
+    weight_only = bool(payload.get("weight_only"))
+
+    def derived(key):
+        return None if weight_only else payload.get(key)
+
+    if weight_only:
+        log("[Garmin] Uploading weight only (derived metrics suppressed)...")
+    else:
+        log("[Garmin] Uploading body composition...")
+
     garmin.add_body_composition(
         timestamp=ts,
         weight=payload["weight"],
-        percent_fat=payload["bodyFatPercent"],
-        percent_hydration=payload["waterPercent"],
-        bone_mass=payload["boneMass"],
-        muscle_mass=payload["muscleMass"],
-        visceral_fat_rating=payload["visceralFat"],
-        physique_rating=payload["physiqueRating"],
-        metabolic_age=payload["metabolicAge"],
-        bmi=payload["bmi"],
+        percent_fat=derived("bodyFatPercent"),
+        percent_hydration=derived("waterPercent"),
+        bone_mass=derived("boneMass"),
+        muscle_mass=derived("muscleMass"),
+        visceral_fat_rating=derived("visceralFat"),
+        physique_rating=derived("physiqueRating"),
+        metabolic_age=derived("metabolicAge"),
+        bmi=derived("bmi"),
     )
 
     log("[Garmin] Upload successful!")
+    # Echoes what was actually uploaded, so a weight_only run does not report
+    # metrics Garmin never received.
     return {
         "weight": payload["weight"],
-        "bodyFatPercent": payload["bodyFatPercent"],
-        "muscleMass": payload["muscleMass"],
-        "visceralFat": payload["visceralFat"],
-        "physiqueRating": payload["physiqueRating"],
+        "bodyFatPercent": derived("bodyFatPercent"),
+        "muscleMass": derived("muscleMass"),
+        "visceralFat": derived("visceralFat"),
+        "physiqueRating": derived("physiqueRating"),
     }
 
 

--- a/garmin-scripts/tests/test_garmin_upload.py
+++ b/garmin-scripts/tests/test_garmin_upload.py
@@ -1,0 +1,108 @@
+"""Host-runnable tests for the Garmin uploader's payload handling.
+
+Imports garmin_upload directly and patches the authenticated client away, so
+nothing here touches Garmin or the network.
+
+The weight-only switch lives on the Python side of the stdin boundary: the
+TypeScript exporter only sets a flag, and every metric still crosses the wire,
+so the assertion that matters -- that each derived metric reaches
+add_body_composition as None -- cannot be made from the Vitest suite.
+
+Run: python -m unittest discover -s garmin-scripts/tests
+"""
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+_SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import garmin_upload  # noqa: E402
+
+FULL_PAYLOAD = {
+    "weight": 80.0,
+    "impedance": 500,
+    "bmi": 23.9,
+    "bodyFatPercent": 18.5,
+    "waterPercent": 55.2,
+    "boneMass": 3.1,
+    "muscleMass": 62.4,
+    "visceralFat": 8,
+    "physiqueRating": 5,
+    "bmr": 1750,
+    "metabolicAge": 30,
+}
+
+# Every add_body_composition argument the uploader fills from the payload.
+# Weight is deliberately absent: it is the one value weight-only mode keeps.
+DERIVED_ARGS = (
+    "percent_fat",
+    "percent_hydration",
+    "bone_mass",
+    "muscle_mass",
+    "visceral_fat_rating",
+    "physique_rating",
+    "metabolic_age",
+    "bmi",
+)
+
+
+def run_upload(payload):
+    """Run upload() against a mock client; return its call kwargs and result."""
+    client = mock.Mock()
+    with mock.patch.object(garmin_upload, "get_garmin_client", return_value=client):
+        result = garmin_upload.upload(payload)
+    client.add_body_composition.assert_called_once()
+    return client.add_body_composition.call_args.kwargs, result
+
+
+class DefaultUploadTest(unittest.TestCase):
+    def test_sends_every_derived_metric(self):
+        kwargs, _ = run_upload(dict(FULL_PAYLOAD))
+        self.assertEqual(kwargs["weight"], 80.0)
+        for name in DERIVED_ARGS:
+            with self.subTest(argument=name):
+                self.assertIsNotNone(kwargs[name])
+
+    def test_forwards_the_payload_values_unchanged(self):
+        kwargs, _ = run_upload(dict(FULL_PAYLOAD))
+        self.assertEqual(kwargs["bmi"], 23.9)
+        self.assertEqual(kwargs["percent_fat"], 18.5)
+        self.assertEqual(kwargs["metabolic_age"], 30)
+
+
+class WeightOnlyUploadTest(unittest.TestCase):
+    def test_nulls_every_derived_metric(self):
+        kwargs, _ = run_upload({**FULL_PAYLOAD, "weight_only": True})
+        for name in DERIVED_ARGS:
+            with self.subTest(argument=name):
+                self.assertIsNone(kwargs[name])
+
+    def test_keeps_the_weight(self):
+        kwargs, _ = run_upload({**FULL_PAYLOAD, "weight_only": True})
+        self.assertEqual(kwargs["weight"], 80.0)
+
+    def test_keeps_a_backdated_timestamp(self):
+        kwargs, _ = run_upload(
+            {**FULL_PAYLOAD, "weight_only": True, "timestamp": "2025-07-01T07:15:00+00:00"}
+        )
+        self.assertEqual(kwargs["timestamp"], "2025-07-01T07:15:00+00:00")
+        self.assertIsNone(kwargs["bmi"])
+
+    def test_result_does_not_report_metrics_that_were_not_sent(self):
+        _, result = run_upload({**FULL_PAYLOAD, "weight_only": True})
+        self.assertEqual(result["weight"], 80.0)
+        for key in ("bodyFatPercent", "muscleMass", "visceralFat", "physiqueRating"):
+            with self.subTest(key=key):
+                self.assertIsNone(result[key])
+
+    def test_false_behaves_like_absent(self):
+        kwargs, _ = run_upload({**FULL_PAYLOAD, "weight_only": False})
+        self.assertEqual(kwargs["bmi"], 23.9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/config/env-load.ts
+++ b/src/config/env-load.ts
@@ -19,6 +19,11 @@ export function loadEnvConfig(): AppConfig {
   const globalExporters: ExporterEntry[] = exporterConfig.exporters.map((name) => {
     const entry: Record<string, unknown> = { type: name };
 
+    if (name === 'garmin' && exporterConfig.garmin) {
+      Object.assign(entry, {
+        weight_only: exporterConfig.garmin.weightOnly,
+      });
+    }
     if (name === 'mqtt' && exporterConfig.mqtt) {
       const m = exporterConfig.mqtt;
       Object.assign(entry, {

--- a/src/exporters/config.ts
+++ b/src/exporters/config.ts
@@ -29,6 +29,11 @@ const KNOWN_EXPORTERS = new Set<ExporterName>([
   'wger',
 ]);
 
+export interface GarminConfig {
+  /** Upload the weight alone, leaving every derived metric unset in Garmin. */
+  weightOnly: boolean;
+}
+
 export interface MqttConfig {
   brokerUrl: string;
   topic: string;
@@ -106,6 +111,7 @@ export interface WgerConfig {
 
 export interface ExporterConfig {
   exporters: ExporterName[];
+  garmin?: GarminConfig;
   mqtt?: MqttConfig;
   webhook?: WebhookConfig;
   influxdb?: InfluxDbConfig;
@@ -176,6 +182,13 @@ export function loadExporterConfig(): ExporterConfig {
 
   if (exporters.length === 0) {
     fail('EXPORTERS must contain at least one exporter.');
+  }
+
+  let garmin: GarminConfig | undefined;
+  if (exporters.includes('garmin')) {
+    garmin = {
+      weightOnly: parseBoolean('GARMIN_WEIGHT_ONLY', process.env.GARMIN_WEIGHT_ONLY?.trim(), false),
+    };
   }
 
   let mqtt: MqttConfig | undefined;
@@ -364,6 +377,7 @@ export function loadExporterConfig(): ExporterConfig {
 
   return {
     exporters,
+    garmin,
     mqtt,
     webhook,
     influxdb,

--- a/src/exporters/garmin.ts
+++ b/src/exporters/garmin.ts
@@ -50,9 +50,11 @@ export { expandTilde as _expandTilde };
 /**
  * Wire payload handed to the Python uploader: live readings carry the metrics
  * only, historical replay (#164) adds an ISO 8601 `timestamp` field that
- * `garmin_upload.py` forwards as `add_body_composition(timestamp=...)`.
+ * `garmin_upload.py` forwards as `add_body_composition(timestamp=...)`, and
+ * `weight_only` tells the uploader to pass `None` for every derived metric so
+ * Garmin records the weight alone.
  */
-type GarminUploadPayload = BodyComposition & { timestamp?: string };
+type GarminUploadPayload = BodyComposition & { timestamp?: string; weight_only?: boolean };
 
 function uploadToGarmin(
   payload: GarminUploadPayload,
@@ -107,6 +109,13 @@ export interface GarminEntryConfig {
   email?: string;
   password?: string;
   token_dir?: string;
+  /**
+   * Upload the weight alone, leaving BMI, body fat, water, bone, muscle,
+   * visceral fat, physique rating and metabolic age unset in Garmin Connect.
+   * For scales whose derived metrics you do not trust, or profiles where only
+   * the weight trend matters.
+   */
+  weight_only?: boolean;
 }
 
 export const garminSchema: ExporterSchema = {
@@ -136,6 +145,15 @@ export const garminSchema: ExporterSchema = {
       default: './garmin-tokens',
       description: 'Directory for storing auth tokens',
     },
+    {
+      key: 'weight_only',
+      label: 'Upload weight only',
+      type: 'boolean',
+      required: false,
+      default: false,
+      description:
+        'Send only the weight; leave BMI, body fat, water, bone, muscle, visceral fat, physique rating and metabolic age unset',
+    },
   ],
   supportsGlobal: false,
   supportsPerUser: true,
@@ -160,9 +178,9 @@ export class GarminExporter implements Exporter {
 
   async export(data: BodyComposition, context?: ExportContext): Promise<ExportResult> {
     const pythonCmd = await findPython();
-    const payload: GarminUploadPayload = context?.timestamp
-      ? { ...data, timestamp: context.timestamp.toISOString() }
-      : data;
+    const payload: GarminUploadPayload = { ...data };
+    if (context?.timestamp) payload.timestamp = context.timestamp.toISOString();
+    if (this.entryConfig.weight_only) payload.weight_only = true;
 
     return withRetry(
       async () => {

--- a/src/exporters/index.ts
+++ b/src/exporters/index.ts
@@ -21,7 +21,7 @@ export function createExporters(config: ExporterConfig): Exporter[] {
   for (const name of config.exporters) {
     switch (name) {
       case 'garmin':
-        exporters.push(new GarminExporter());
+        exporters.push(new GarminExporter({ weight_only: config.garmin?.weightOnly }));
         break;
       case 'mqtt':
         exporters.push(new MqttExporter(config.mqtt!));

--- a/src/exporters/registry.ts
+++ b/src/exporters/registry.ts
@@ -32,6 +32,37 @@ interface ExporterRegistryEntry {
   factory: (config: Record<string, unknown>) => Exporter;
 }
 
+const TRUE_STRINGS = new Set(['true', 'yes', '1', 'on']);
+const FALSE_STRINGS = new Set(['false', 'no', '0', 'off', '']);
+
+/**
+ * Read an optional boolean field that must not be guessed at.
+ *
+ * `ExporterEntrySchema` is `.passthrough()`, so YAML hands the factory whatever
+ * the user typed, and `${ENV_VAR}` references resolve to STRINGS before the
+ * schema ever sees them (`resolveEnvReferences`). A bare `as boolean` cast plus
+ * a truthiness test therefore reads `weight_only: "false"` as true — the exact
+ * inverse of what was written, silently. Accept the boolean, accept the usual
+ * string spellings, and throw on anything else rather than pick a side.
+ */
+function optionalBool(
+  config: Record<string, unknown>,
+  type: string,
+  key: string,
+): boolean | undefined {
+  const value = config[key];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const lower = value.trim().toLowerCase();
+    if (TRUE_STRINGS.has(lower)) return true;
+    if (FALSE_STRINGS.has(lower)) return false;
+  }
+  throw new Error(
+    `Exporter "${type}" field "${key}" must be true or false, got '${String(value)}'. Check your config.yaml.`,
+  );
+}
+
 /**
  * Read a required config field, throwing a clear error when it is missing or
  * empty. Surfaces hand-written `config.yaml` mistakes instead of letting an
@@ -57,6 +88,7 @@ export const EXPORTER_REGISTRY: ExporterRegistryEntry[] = [
         email: config.email as string | undefined,
         password: config.password as string | undefined,
         token_dir: config.token_dir as string | undefined,
+        weight_only: optionalBool(config, 'garmin', 'weight_only'),
       }),
   },
   {

--- a/tests/config/load.test.ts
+++ b/tests/config/load.test.ts
@@ -416,6 +416,36 @@ global_exporters:
     expect(createExporterFromEntry(byType.telegram).reportsExports).toBe(true);
   });
 
+  it('carries GARMIN_WEIGHT_ONLY into the .env Garmin exporter entry', () => {
+    vi.spyOn(fs, 'existsSync').mockImplementation((p) => String(p).endsWith('.env'));
+    vi.stubEnv('USER_HEIGHT', '183');
+    vi.stubEnv('USER_BIRTH_DATE', '1990-06-15');
+    vi.stubEnv('USER_GENDER', 'male');
+    vi.stubEnv('USER_IS_ATHLETE', 'true');
+    vi.stubEnv('EXPORTERS', 'garmin');
+    vi.stubEnv('GARMIN_WEIGHT_ONLY', 'true');
+
+    const { config } = loadAppConfig();
+    const garmin = config.global_exporters!.find((e) => e.type === 'garmin');
+    expect(garmin).toMatchObject({ weight_only: true });
+    // The entry has to survive the factory too, not just the loader.
+    expect(() => createExporterFromEntry(garmin!)).not.toThrow();
+  });
+
+  it('defaults the .env Garmin entry to weight_only false', () => {
+    vi.spyOn(fs, 'existsSync').mockImplementation((p) => String(p).endsWith('.env'));
+    vi.stubEnv('USER_HEIGHT', '183');
+    vi.stubEnv('USER_BIRTH_DATE', '1990-06-15');
+    vi.stubEnv('USER_GENDER', 'male');
+    vi.stubEnv('USER_IS_ATHLETE', 'true');
+    vi.stubEnv('EXPORTERS', 'garmin');
+
+    const { config } = loadAppConfig();
+    expect(config.global_exporters!.find((e) => e.type === 'garmin')).toMatchObject({
+      weight_only: false,
+    });
+  });
+
   it('exits when no config source exists', () => {
     vi.spyOn(fs, 'existsSync').mockReturnValue(false);
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);

--- a/tests/exporters/config.test.ts
+++ b/tests/exporters/config.test.ts
@@ -10,6 +10,34 @@ describe('loadExporterConfig()', () => {
     vi.unstubAllEnvs();
   });
 
+  describe('GARMIN_WEIGHT_ONLY', () => {
+    it('defaults to false when unset', () => {
+      const cfg = loadExporterConfig();
+      expect(cfg.garmin).toEqual({ weightOnly: false });
+    });
+
+    it('parses true', () => {
+      vi.stubEnv('GARMIN_WEIGHT_ONLY', 'true');
+      expect(loadExporterConfig().garmin?.weightOnly).toBe(true);
+    });
+
+    it('parses false', () => {
+      vi.stubEnv('GARMIN_WEIGHT_ONLY', 'false');
+      expect(loadExporterConfig().garmin?.weightOnly).toBe(false);
+    });
+
+    it('throws on a non-boolean value', () => {
+      vi.stubEnv('GARMIN_WEIGHT_ONLY', 'maybe');
+      expect(() => loadExporterConfig()).toThrow(/GARMIN_WEIGHT_ONLY/);
+    });
+
+    it('is absent when the garmin exporter is not enabled', () => {
+      vi.stubEnv('EXPORTERS', 'file');
+      vi.stubEnv('FILE_PATH', '/tmp/readings.csv');
+      expect(loadExporterConfig().garmin).toBeUndefined();
+    });
+  });
+
   describe('EXPORTERS parsing', () => {
     it('defaults to garmin when EXPORTERS is not set', () => {
       const cfg = loadExporterConfig();

--- a/tests/exporters/garmin.test.ts
+++ b/tests/exporters/garmin.test.ts
@@ -299,4 +299,141 @@ describe('GarminExporter', () => {
     const stdinBody = captured.getStdinBody();
     expect(stdinBody).not.toContain('"timestamp"');
   });
+
+  // ─── Weight only ──────────────────────────────────────────────────────────
+
+  it('flags the stdin payload weight_only when configured', async () => {
+    const captured = makeCapturingUploadFactory(JSON.stringify({ success: true }), 0);
+
+    mockSpawn.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === '--version') return createVersionCheckProc(0);
+      return captured.factory();
+    });
+
+    const { GarminExporter } = await import('../../src/exporters/garmin.js');
+    const exporter = new GarminExporter({ weight_only: true });
+    const result = await exporter.export(samplePayload);
+
+    expect(result.success).toBe(true);
+    const payload = JSON.parse(captured.getStdinBody());
+    expect(payload.weight_only).toBe(true);
+    expect(payload.weight).toBe(80);
+    // The metrics still cross the wire; garmin_upload.py is what drops them, so
+    // the flag stays the single place the decision is made.
+    expect(payload.bmi).toBe(23.9);
+  });
+
+  it('omits weight_only from the payload by default', async () => {
+    const captured = makeCapturingUploadFactory(JSON.stringify({ success: true }), 0);
+
+    mockSpawn.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === '--version') return createVersionCheckProc(0);
+      return captured.factory();
+    });
+
+    const { GarminExporter } = await import('../../src/exporters/garmin.js');
+    const exporter = new GarminExporter();
+    await exporter.export(samplePayload);
+
+    expect(captured.getStdinBody()).not.toContain('weight_only');
+  });
+
+  it('combines weight_only with a back-dated timestamp', async () => {
+    const captured = makeCapturingUploadFactory(JSON.stringify({ success: true }), 0);
+
+    mockSpawn.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === '--version') return createVersionCheckProc(0);
+      return captured.factory();
+    });
+
+    const { GarminExporter } = await import('../../src/exporters/garmin.js');
+    const exporter = new GarminExporter({ weight_only: true });
+    await exporter.export(samplePayload, { timestamp: new Date('2025-07-01T07:15:00Z') });
+
+    const payload = JSON.parse(captured.getStdinBody());
+    expect(payload.weight_only).toBe(true);
+    expect(payload.timestamp).toBe('2025-07-01T07:15:00.000Z');
+  });
+
+  it('is off when the registry factory gets no weight_only key', async () => {
+    const captured = makeCapturingUploadFactory(JSON.stringify({ success: true }), 0);
+
+    mockSpawn.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === '--version') return createVersionCheckProc(0);
+      return captured.factory();
+    });
+
+    const { createExporterFromEntry } = await import('../../src/exporters/registry.js');
+    const exporter = createExporterFromEntry({ type: 'garmin', email: 'a@b.c', password: 'x' });
+    await exporter.export(samplePayload);
+
+    expect(captured.getStdinBody()).not.toContain('weight_only');
+  });
+
+  it('is on when the registry factory gets weight_only: true from config.yaml', async () => {
+    const captured = makeCapturingUploadFactory(JSON.stringify({ success: true }), 0);
+
+    mockSpawn.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === '--version') return createVersionCheckProc(0);
+      return captured.factory();
+    });
+
+    const { createExporterFromEntry } = await import('../../src/exporters/registry.js');
+    const exporter = createExporterFromEntry({
+      type: 'garmin',
+      email: 'a@b.c',
+      password: 'x',
+      weight_only: true,
+    });
+    await exporter.export(samplePayload);
+
+    expect(JSON.parse(captured.getStdinBody()).weight_only).toBe(true);
+  });
+
+  // ExporterEntrySchema is passthrough and `${ENV_VAR}` references resolve to
+  // strings, so the string spellings reach the factory verbatim. Reading
+  // "false" as true would silently invert the setting.
+  it.each([
+    ['true', true],
+    ['yes', true],
+    ['1', true],
+    ['on', true],
+    ['TRUE', true],
+    ['false', false],
+    ['no', false],
+    ['0', false],
+    ['off', false],
+    ['', false],
+  ])('coerces the string weight_only %j to %s', async (raw, expected) => {
+    const captured = makeCapturingUploadFactory(JSON.stringify({ success: true }), 0);
+
+    mockSpawn.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === '--version') return createVersionCheckProc(0);
+      return captured.factory();
+    });
+
+    const { createExporterFromEntry } = await import('../../src/exporters/registry.js');
+    const exporter = createExporterFromEntry({
+      type: 'garmin',
+      email: 'a@b.c',
+      password: 'x',
+      weight_only: raw,
+    });
+    await exporter.export(samplePayload);
+
+    const payload = JSON.parse(captured.getStdinBody());
+    expect(payload.weight_only).toBe(expected ? true : undefined);
+  });
+
+  it('rejects a weight_only value that is neither boolean nor a known spelling', async () => {
+    const { createExporterFromEntry } = await import('../../src/exporters/registry.js');
+    expect(() =>
+      createExporterFromEntry({
+        type: 'garmin',
+        email: 'a@b.c',
+        password: 'x',
+        weight_only: 'maybe',
+      }),
+    ).toThrow(/must be true or false/);
+  });
 });


### PR DESCRIPTION
## Summary

Adds an opt-in `weight_only` setting for the Garmin exporter. When enabled, only weight is uploaded; Garmin receives the other body-composition values as absent rather than zero. Other exporters continue to receive the full measurement.

The setting is off by default, so existing configurations are unchanged.

```yaml
global_exporters:
  - type: garmin
    email: "${GARMIN_EMAIL}"
    password: "${GARMIN_PASSWORD}"
    weight_only: true
```

## Changes

- Supports `weight_only` in config, `GARMIN_WEIGHT_ONLY` for legacy `.env` users, and the Home Assistant add-on UI.
- Adds documentation and examples.
- Parses boolean environment values safely and reports only the values sent to Garmin.

Garmin may still calculate BMI from the uploaded weight and the height in the user profile; scale-derived metrics remain blank.

## Validation

- `npm test` (2506 tests)
- Python Garmin upload tests
- Lint, format, and TypeScript checks
- Manual verification of normal, weight-only, timestamp, `.env`, and add-on paths