### PR TITLE
fix: three defects that crash the process or silently lose a weigh-in

### DIFF
--- a/src/ble/handler-esphome-proxy/gatt.ts
+++ b/src/ble/handler-esphome-proxy/gatt.ts
@@ -16,10 +16,26 @@ const NOTIFY_EVENT = 'message.BluetoothGATTNotifyDataResponse';
 const CONNECTION_EVENT = 'message.BluetoothDeviceConnectionResponse';
 const GATT_ERROR_EVENT = 'message.BluetoothGATTErrorResponse';
 
+export interface EsphomeBleDevice extends BleDevice {
+  /**
+   * Abandon this session locally, as if the proxy had reported a disconnect.
+   *
+   * waitForRawReading() only settles on a reading, a subscribe failure, or this
+   * disconnect callback, and the callback is driven purely by the proxy's
+   * connection frames. When the ESP32 drops off Wi-Fi mid-session no such frame
+   * ever arrives, so a caller that gives up on a timeout leaves the abandoned
+   * wait holding its notify unsubscribers and its unlock interval forever, and
+   * never runs the adapter's onSessionEnd. Firing the disconnect path before
+   * close() lets it tear itself down. Harmless after a completed reading: the
+   * callback returns immediately once resolved.
+   */
+  fireDisconnect(): void;
+}
+
 export interface GattSession {
   /** Normalized-UUID -> BleChar, the shape waitForRawReading() consumes. */
   charMap: Map<string, BleChar>;
-  device: BleDevice;
+  device: EsphomeBleDevice;
   close(): Promise<void>;
 }
 
@@ -248,17 +264,23 @@ export async function openGattSession(
     }
   }
 
-  const device: BleDevice = {
+  let disconnectCb: (() => void) | undefined;
+  let disconnectFired = false;
+  const fireDisconnect = (): void => {
+    if (disconnectFired) return;
+    disconnectFired = true;
+    disconnectCb?.();
+  };
+
+  const device: EsphomeBleDevice = {
     onDisconnect(cb: () => void): void {
-      let fired = false;
+      disconnectCb = cb;
       track(CONNECTION_EVENT, (raw: unknown) => {
         const m = raw as EsphomeDeviceConnection;
-        if (!fired && m.address === addr && m.connected === false) {
-          fired = true;
-          cb();
-        }
+        if (m.address === addr && m.connected === false) fireDisconnect();
       });
     },
+    fireDisconnect,
   };
 
   const close = async (): Promise<void> => {

--- a/src/ble/handler-esphome-proxy/gatt.ts
+++ b/src/ble/handler-esphome-proxy/gatt.ts
@@ -29,10 +29,14 @@ export interface EsphomeBleDevice extends BleDevice {
    * down. Harmless after a completed reading: the callback returns immediately
    * once resolved.
    *
-   * Call it before close(): not because close() removes anything this needs
-   * (the callback is invoked directly, not through the CONNECTION_EVENT
-   * listener), but so the cleanup runs before close() sets `closed` and the
-   * session starts rejecting every queued GATT call.
+   * Call it before close(), though the order is not load-bearing and two
+   * earlier versions of this comment claimed reasons that were not real. It
+   * does not depend on the CONNECTION_EVENT listener close() removes (the
+   * callback is invoked directly), and the cleanup it triggers - clearInterval,
+   * listener removal, and onSessionEnd, which the contract forbids from doing
+   * I/O - issues no GATT call, so `closed` cannot cut it short either. Kept
+   * first simply so the wait is finished with the session before the session
+   * goes away.
    */
   fireDisconnect(): void;
 }

--- a/src/ble/handler-esphome-proxy/gatt.ts
+++ b/src/ble/handler-esphome-proxy/gatt.ts
@@ -25,9 +25,14 @@ export interface EsphomeBleDevice extends BleDevice {
    * connection frames. When the ESP32 drops off Wi-Fi mid-session no such frame
    * ever arrives, so a caller that gives up on a timeout leaves the abandoned
    * wait holding its notify unsubscribers and its unlock interval forever, and
-   * never runs the adapter's onSessionEnd. Firing the disconnect path before
-   * close() lets it tear itself down. Harmless after a completed reading: the
-   * callback returns immediately once resolved.
+   * never runs the adapter's onSessionEnd. Firing this lets it tear itself
+   * down. Harmless after a completed reading: the callback returns immediately
+   * once resolved.
+   *
+   * Call it before close(): not because close() removes anything this needs
+   * (the callback is invoked directly, not through the CONNECTION_EVENT
+   * listener), but so the cleanup runs before close() sets `closed` and the
+   * session starts rejecting every queued GATT call.
    */
   fireDisconnect(): void;
 }
@@ -267,9 +272,13 @@ export async function openGattSession(
   let disconnectCb: (() => void) | undefined;
   let disconnectFired = false;
   const fireDisconnect = (): void => {
-    if (disconnectFired) return;
+    // Latch only once there is something to latch. Setting the flag with no
+    // callback registered would silently swallow the REAL disconnect frame for
+    // a caller that registers afterwards. Not reachable through today's two
+    // callers, but it is the kind of thing the next one would inherit.
+    if (disconnectFired || !disconnectCb) return;
     disconnectFired = true;
-    disconnectCb?.();
+    disconnectCb();
   };
 
   const device: EsphomeBleDevice = {

--- a/src/ble/handler-esphome-proxy/scan.ts
+++ b/src/ble/handler-esphome-proxy/scan.ts
@@ -199,8 +199,10 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
               } catch (e) {
                 reject(e instanceof Error ? e : new Error(errMsg(e)));
               } finally {
-                // Before close(), which splices out the very listener the
-                // abandoned wait's disconnect path needs to clean itself up.
+                // Before close(), so the abandoned wait's cleanup (notify
+                // unsubscribers, unlock interval, onSessionEnd) runs while the
+                // session can still talk: close() sets `closed`, after which
+                // every queued GATT call is rejected.
                 session?.device.fireDisconnect();
                 if (session) await session.close();
                 gattInFlight.delete(addrLc);

--- a/src/ble/handler-esphome-proxy/scan.ts
+++ b/src/ble/handler-esphome-proxy/scan.ts
@@ -4,7 +4,7 @@ import type { ScanOptions, ScanResult } from '../types.js';
 import { type RawReading, waitForRawReading } from '../shared.js';
 import { resolveAdapter } from '../../scales/resolve.js';
 import { evaluateAdvertisement, GraceTimers, logAdvert } from '../advertisement.js';
-import { bleLog, errMsg, withTimeout, IMPEDANCE_GRACE_MS } from '../types.js';
+import { bleLog, errMsg, withTimeout, withIdleTimeout, IMPEDANCE_GRACE_MS } from '../types.js';
 import { EsphomeProxyPool } from './pool.js';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -12,6 +12,10 @@ import { EsphomeProxyPool } from './pool.js';
 // 60s matches the native BLE handlers and gives slow-advertising scales (e.g. Mi,
 // some Renpho) enough time to emit a broadcast frame after the user steps on.
 const BROADCAST_WAIT_MS = 60_000;
+// Idle bound for an on-demand GATT read. The outer BROADCAST_WAIT_MS race only
+// abandons the wait; without this the abandoned read still hangs forever when
+// the proxy vanishes and never reports a disconnect.
+const GATT_READING_IDLE_MS = 60_000;
 const SCAN_DEFAULT_MS = 15_000;
 
 // ─── Scan-and-read (broadcast + GATT) ────────────────────────────────────────
@@ -175,20 +179,29 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
               let session: Awaited<ReturnType<typeof pool.connectGatt>> | null = null;
               try {
                 session = await pool.connectGatt(address);
-                const raw = await waitForRawReading(
-                  session.charMap,
-                  session.device,
-                  adapter,
-                  opts.profile,
-                  address.replace(/[:-]/g, '').toUpperCase(),
-                  opts.weightUnit,
-                  opts.onLiveData,
-                  opts.scaleAuth,
+                const raw = await withIdleTimeout(
+                  (onActivity) =>
+                    waitForRawReading(
+                      session!.charMap,
+                      session!.device,
+                      adapter,
+                      opts.profile,
+                      address.replace(/[:-]/g, '').toUpperCase(),
+                      opts.weightUnit,
+                      opts.onLiveData,
+                      opts.scaleAuth,
+                      onActivity,
+                    ),
+                  GATT_READING_IDLE_MS,
+                  `GATT reading timeout for ${address}`,
                 );
                 resolve(raw);
               } catch (e) {
                 reject(e instanceof Error ? e : new Error(errMsg(e)));
               } finally {
+                // Before close(), which splices out the very listener the
+                // abandoned wait's disconnect path needs to clean itself up.
+                session?.device.fireDisconnect();
                 if (session) await session.close();
                 gattInFlight.delete(addrLc);
               }

--- a/src/ble/handler-esphome-proxy/scan.ts
+++ b/src/ble/handler-esphome-proxy/scan.ts
@@ -199,10 +199,9 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
               } catch (e) {
                 reject(e instanceof Error ? e : new Error(errMsg(e)));
               } finally {
-                // Before close(), so the abandoned wait's cleanup (notify
-                // unsubscribers, unlock interval, onSessionEnd) runs while the
-                // session can still talk: close() sets `closed`, after which
-                // every queued GATT call is rejected.
+                // Before close(), so the wait is finished with the session
+                // before the session goes away. See fireDisconnect's own doc
+                // for why the order is not load-bearing either way.
                 session?.device.fireDisconnect();
                 if (session) await session.close();
                 gattInFlight.delete(addrLc);

--- a/src/ble/handler-esphome-proxy/watcher.ts
+++ b/src/ble/handler-esphome-proxy/watcher.ts
@@ -265,9 +265,12 @@ export class ReadingWatcher implements Watcher {
       } catch (e) {
         this.warnGattFailure(gattAdapter.name, address, errMsg(e));
       } finally {
-        // Order matters: let the abandoned wait tear itself down while its
-        // listeners are still registered, because close() splices out every
-        // listener including the connection one the disconnect path needs.
+        // Order matters, though not for the reason it first appears:
+        // fireDisconnect() invokes the stored callback directly, so it does not
+        // depend on the CONNECTION_EVENT listener close() removes. It goes
+        // first so the abandoned wait's cleanup - notify unsubscribers, the
+        // unlock interval, onSessionEnd - runs before close() sets `closed` and
+        // starts rejecting every queued GATT call.
         session?.device.fireDisconnect();
         if (session) await session.close();
         this.gattInFlight.delete(addrLc);

--- a/src/ble/handler-esphome-proxy/watcher.ts
+++ b/src/ble/handler-esphome-proxy/watcher.ts
@@ -265,12 +265,9 @@ export class ReadingWatcher implements Watcher {
       } catch (e) {
         this.warnGattFailure(gattAdapter.name, address, errMsg(e));
       } finally {
-        // Order matters, though not for the reason it first appears:
-        // fireDisconnect() invokes the stored callback directly, so it does not
-        // depend on the CONNECTION_EVENT listener close() removes. It goes
-        // first so the abandoned wait's cleanup - notify unsubscribers, the
-        // unlock interval, onSessionEnd - runs before close() sets `closed` and
-        // starts rejecting every queued GATT call.
+        // Before close(), so the wait is finished with the session before
+        // the session goes away. See fireDisconnect's own doc for why the order
+        // is not load-bearing either way.
         session?.device.fireDisconnect();
         if (session) await session.close();
         this.gattInFlight.delete(addrLc);

--- a/src/ble/handler-esphome-proxy/watcher.ts
+++ b/src/ble/handler-esphome-proxy/watcher.ts
@@ -9,7 +9,7 @@ import { type RawReading, waitForRawReading } from '../shared.js';
 import { resolveAdapter } from '../../scales/resolve.js';
 import { evaluateAdvertisement, GraceTimers, DedupWindow, logAdvert } from '../advertisement.js';
 import type { Watcher, WatcherConfig } from '../reading-source.js';
-import { bleLog, errMsg, IMPEDANCE_GRACE_MS } from '../types.js';
+import { bleLog, errMsg, IMPEDANCE_GRACE_MS, withTimeout, withIdleTimeout } from '../types.js';
 import { AsyncQueue } from '../async-queue.js';
 import { EsphomeProxyPool } from './pool.js';
 import { logTransportCapabilities } from './scan.js';
@@ -17,6 +17,14 @@ import { logTransportCapabilities } from './scan.js';
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const DEDUP_WINDOW_MS = 30_000;
+// Bounds for an on-demand GATT read, matching the mqtt-proxy watcher. Without
+// them a proxy that vanishes mid-session (Wi-Fi drop, reboot) never sends the
+// connection frame waitForRawReading waits on, so the read hangs forever: the
+// gattInFlight entry is never cleared (that scale is never read again) and
+// noteGattEnd never runs (the advertisement watchdog stays disarmed for that
+// endpoint, and keeps re-stamping its liveness on every sweep).
+const GATT_READING_IDLE_MS = 60_000;
+const GATT_SESSION_ABSOLUTE_MS = 90_000;
 // Cap for the "already warned about this scale's GATT failure" tracker. Old
 // entries are evicted LRU-style so dedup persists long-term in continuous mode.
 const GATT_WARN_LRU_MAX = 256;
@@ -233,20 +241,34 @@ export class ReadingWatcher implements Watcher {
             `Re-resolved adapter after GATT discovery: ${adapter.name} -> ${gattAdapter.name} (${address})`,
           );
         }
-        const raw = await waitForRawReading(
-          session.charMap,
-          session.device,
-          gattAdapter,
-          this.profile ?? { height: 170, age: 30, gender: 'male', isAthlete: false },
-          address.replace(/[:-]/g, '').toUpperCase(),
-          undefined,
-          undefined,
-          this.scaleAuth,
+        const raw = await withTimeout(
+          withIdleTimeout(
+            (onActivity) =>
+              waitForRawReading(
+                session!.charMap,
+                session!.device,
+                gattAdapter,
+                this.profile ?? { height: 170, age: 30, gender: 'male', isAthlete: false },
+                address.replace(/[:-]/g, '').toUpperCase(),
+                undefined,
+                undefined,
+                this.scaleAuth,
+                onActivity,
+              ),
+            GATT_READING_IDLE_MS,
+            `GATT reading timeout for ${address}`,
+          ),
+          GATT_SESSION_ABSOLUTE_MS,
+          `GATT session cap exceeded for ${address}`,
         );
         this.pushDeduped(address, raw, raw.reading.weight);
       } catch (e) {
         this.warnGattFailure(gattAdapter.name, address, errMsg(e));
       } finally {
+        // Order matters: let the abandoned wait tear itself down while its
+        // listeners are still registered, because close() splices out every
+        // listener including the connection one the disconnect path needs.
+        session?.device.fireDisconnect();
         if (session) await session.close();
         this.gattInFlight.delete(addrLc);
       }

--- a/src/runtime/processor.ts
+++ b/src/runtime/processor.ts
@@ -106,8 +106,11 @@ function frameTag(prefix: string, timestamp: Date | undefined): string {
  * `checkAndLogUpdate` for the cycle.
  *
  * Returns the success of the last (live) dispatch and the payload of that
- * dispatch (`null` if every frame was deduped or skipped via dry-run), which the
- * caller uses to gate the dedup-anchor / last_known_weight write.
+ * dispatch, which the caller uses to gate the dedup-anchor / last_known_weight
+ * write. The payload is `null` when every frame was deduped, when dry-run
+ * skipped the export, AND when the export ran but every exporter failed - the
+ * anchor means "the weight we actually exported", so a total failure must not
+ * move it.
  */
 async function processReadingFrames(
   ctx: AppContext,

--- a/src/runtime/processor.ts
+++ b/src/runtime/processor.ts
@@ -158,8 +158,6 @@ async function processReadingFrames(
       continue;
     }
 
-    if (isLast) latestPayload = payload;
-
     if (isLast) {
       // notifyReading uses raw scale values (pre-computeMetrics) so the display
       // mirrors what the scale measured; notifyResult uses the computed payload.
@@ -186,6 +184,14 @@ async function processReadingFrames(
     if (isLast) {
       ctx.display?.result(user.slug, user.name, payload.weight, details);
       lastSuccess = success;
+      // Both things this gates - the runtime replay anchor and the persisted
+      // last_known_weight - mean "the weight we ACTUALLY exported". Setting it
+      // before the dispatch made a total export failure poison the next
+      // attempt: the scale reconnects, replays the same frame now carrying a
+      // timestamp, and the dedup above drops it as already synced. The weigh-in
+      // is then lost with nothing to retry from. dispatchExports returns false
+      // only when EVERY exporter failed, so a partial success still anchors.
+      if (success) latestPayload = payload;
     }
   }
 
@@ -344,8 +350,8 @@ async function processMultiUser(
   );
 
   // last_known_weight stores the raw scale value, not the computed payload.
-  // latestPayload is set only after a non-dry export on the last reading,
-  // so dry-run is already excluded here.
+  // latestPayload is set only after a SUCCEEDING non-dry export on the last
+  // reading, so both dry-run and a total export failure are excluded here.
   if (latestPayload && ctx.configSource === 'yaml' && ctx.configPath) {
     updateLastKnownWeight(ctx.configPath, user.slug, latest.weight, previousLastKnown);
   }

--- a/src/scales/speediance.ts
+++ b/src/scales/speediance.ts
@@ -144,7 +144,14 @@ export class SpeedianceAdapter implements ScaleAdapterCore, GattWiring, MultiCha
       const w = data.readUIntBE(WEIGHT_OFFSET, WEIGHT_BYTES) / WEIGHT_DIV;
       if (w > 0 && Number.isFinite(w)) {
         this.cachedWeight = w;
-        const imp = data.readUInt16LE(IMPEDANCE_OFFSET);
+        // The impedance field ends 5 bytes past the length the guard above
+        // enforces, so a short a7 frame would make readUInt16LE throw
+        // ERR_OUT_OF_RANGE out of a notification callback that has no
+        // try/catch above it (handleNotification) - a dead process, not a
+        // dropped frame. The weight is still good at this length, so take it
+        // and treat the missing impedance the same way an implausible one is
+        // treated below.
+        const imp = data.length >= IMPEDANCE_OFFSET + 2 ? data.readUInt16LE(IMPEDANCE_OFFSET) : 0;
         if (imp >= IMPEDANCE_MIN_OHM && imp <= IMPEDANCE_MAX_OHM) {
           this.cachedImpedance = imp;
         } else {

--- a/tests/ble/esphome-proxy/gatt.test.ts
+++ b/tests/ble/esphome-proxy/gatt.test.ts
@@ -356,6 +356,56 @@ describe('openGattSession', () => {
     await session.close();
   });
 
+  // fireDisconnect() is what lets a caller that gave up on a timeout tell the
+  // abandoned waitForRawReading to tear itself down. Without it the wait keeps
+  // its notify unsubscribers and its unlock interval forever and never calls
+  // the adapter's onSessionEnd, because on this transport the disconnect
+  // callback is driven purely by the proxy's connection frames - and a proxy
+  // that dropped off Wi-Fi sends none.
+  it('fireDisconnect() invokes the disconnect callback without a peer frame', async () => {
+    const conn = fakeConnection();
+    const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01');
+    const onDis = vi.fn();
+    session.device.onDisconnect(onDis);
+
+    session.device.fireDisconnect();
+    expect(onDis).toHaveBeenCalledTimes(1);
+
+    // A real frame arriving afterwards must not double-fire it.
+    conn.emit('message.BluetoothDeviceConnectionResponse', { address: ADDR, connected: false });
+    expect(onDis).toHaveBeenCalledTimes(1);
+    await session.close();
+  });
+
+  it('fireDisconnect() is idempotent and survives the reverse order', async () => {
+    const conn = fakeConnection();
+    const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01');
+    const onDis = vi.fn();
+    session.device.onDisconnect(onDis);
+
+    conn.emit('message.BluetoothDeviceConnectionResponse', { address: ADDR, connected: false });
+    session.device.fireDisconnect();
+    session.device.fireDisconnect();
+    expect(onDis).toHaveBeenCalledTimes(1);
+    await session.close();
+  });
+
+  // The latch must not close over an empty slot: a fireDisconnect() before any
+  // onDisconnect() would otherwise swallow the REAL disconnect frame for the
+  // callback registered afterwards.
+  it('fireDisconnect() before onDisconnect() does not swallow the real frame', async () => {
+    const conn = fakeConnection();
+    const session = await openGattSession({ connection: conn } as never, '00:00:00:00:00:01');
+
+    session.device.fireDisconnect();
+
+    const onDis = vi.fn();
+    session.device.onDisconnect(onDis);
+    conn.emit('message.BluetoothDeviceConnectionResponse', { address: ADDR, connected: false });
+    expect(onDis).toHaveBeenCalledTimes(1);
+    await session.close();
+  });
+
   it('throws when the peer fails to connect', async () => {
     const conn = fakeConnection();
     conn.connectBluetoothDeviceService = vi.fn(async () => ({ address: ADDR, connected: false }));

--- a/tests/ble/esphome-proxy/pool.test.ts
+++ b/tests/ble/esphome-proxy/pool.test.ts
@@ -48,7 +48,7 @@ vi.mock('../../../src/ble/handler-esphome-proxy/client.js', () => ({
 vi.mock('../../../src/ble/handler-esphome-proxy/gatt.js', () => ({
   openGattSession: vi.fn(async () => ({
     charMap: new Map(),
-    device: { onDisconnect() {} },
+    device: { onDisconnect() {}, fireDisconnect() {} },
     close: async () => {},
   })),
 }));

--- a/tests/ble/esphome-proxy/scan.test.ts
+++ b/tests/ble/esphome-proxy/scan.test.ts
@@ -63,7 +63,7 @@ vi.mock('../../../src/ble/handler-esphome-proxy/pool.js', () => {
       ]);
       return {
         charMap,
-        device: { onDisconnect: (_cb: () => void) => {} },
+        device: { onDisconnect: (_cb: () => void) => {}, fireDisconnect: () => {} },
         close: closeSpy,
       };
     }

--- a/tests/ble/esphome-proxy/scan.test.ts
+++ b/tests/ble/esphome-proxy/scan.test.ts
@@ -14,6 +14,10 @@ const WRITE = normalizeUuid('2a9c');
 // A fake pool: emits one matching advert for a GATT scale, and connectGatt
 // returns a session whose notify char delivers one complete weight frame.
 const closeSpy = vi.fn(async () => {});
+const fireDisconnectSpy = vi.fn();
+// When set, connectGatt hands back a session that never notifies and whose
+// device never reports a disconnect - an ESP32 that dropped off Wi-Fi mid-read.
+let hangSession = false;
 
 vi.mock('../../../src/ble/handler-esphome-proxy/pool.js', () => {
   class FakeEsphomeProxyPool {
@@ -35,6 +39,25 @@ vi.mock('../../../src/ble/handler-esphome-proxy/pool.js', () => {
       return () => {};
     }
     async connectGatt(_mac: string) {
+      if (hangSession) {
+        const silent: BleChar = {
+          async read() {
+            return Buffer.alloc(0);
+          },
+          async write() {},
+          async subscribe() {
+            return () => {};
+          },
+        };
+        return {
+          charMap: new Map<string, BleChar>([
+            [NOTIFY, silent],
+            [WRITE, silent],
+          ]),
+          device: { onDisconnect: (_cb: () => void) => {}, fireDisconnect: fireDisconnectSpy },
+          close: closeSpy,
+        };
+      }
       let notifyCb: ((d: Buffer) => void) | null = null;
       const notifyChar: BleChar = {
         async read() {
@@ -101,6 +124,41 @@ describe('scanAndReadRaw GATT single-shot (#116)', () => {
     expect(result.reading.weight).toBe(75);
     expect(result.adapter.name).toBe('GattMock');
     expect(closeSpy).toHaveBeenCalled();
+  });
+
+  // The one-shot path had the same unbounded read as the watcher: on this
+  // transport waitForRawReading only settles on a reading, a subscribe failure,
+  // or the proxy's disconnect frame, and a proxy that vanished sends none. The
+  // outer BROADCAST_WAIT_MS race only ABANDONS the promise, so without the
+  // inner bound plus fireDisconnect the wait keeps its notify unsubscribers and
+  // its unlock interval for the life of the process.
+  it('tells an abandoned GATT read to tear itself down after the scan gives up', async () => {
+    closeSpy.mockClear();
+    fireDisconnectSpy.mockClear();
+    vi.useFakeTimers();
+    try {
+      hangSession = true;
+      const scan = scanAndReadRaw({
+        adapters: [gattAdapter()],
+        profile,
+        esphomeProxy: {
+          host: 'p1',
+          port: 6053,
+          client_info: 'x',
+          additional_proxies: [],
+        } as never,
+      }).catch((e: unknown) => e);
+
+      // Past both the 60 s scan window and the 60 s GATT idle bound.
+      await vi.advanceTimersByTimeAsync(130_000);
+
+      await scan;
+      expect(fireDisconnectSpy).toHaveBeenCalled();
+      expect(closeSpy).toHaveBeenCalled();
+    } finally {
+      hangSession = false;
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/tests/ble/esphome-proxy/watcher.test.ts
+++ b/tests/ble/esphome-proxy/watcher.test.ts
@@ -158,8 +158,9 @@ describe('ReadingWatcher GATT continuous (#116)', () => {
       // Past the absolute session cap. Without the bound nothing below happens.
       await vi.advanceTimersByTimeAsync(95_000);
 
-      // Fired BEFORE close(), which splices out the listener the abandoned
-      // wait's own teardown path depends on.
+      // Both run: the abandoned wait is told to tear itself down, and the
+      // session is closed. fireDisconnect goes first, though the order is not
+      // load-bearing - see its doc comment in gatt.ts.
       expect(fireDisconnectSpy).toHaveBeenCalled();
       expect(closeSpy).toHaveBeenCalled();
 

--- a/tests/ble/esphome-proxy/watcher.test.ts
+++ b/tests/ble/esphome-proxy/watcher.test.ts
@@ -12,6 +12,10 @@ const WRITE = normalizeUuid('2a9c');
 
 const closeSpy = vi.fn(async () => {});
 const connectGattSpy = vi.fn();
+const fireDisconnectSpy = vi.fn();
+// When set, connectGatt hands back a session that never notifies and whose
+// device never reports a disconnect - an ESP32 that dropped off Wi-Fi mid-read.
+let hangSession = false;
 
 vi.mock('../../../src/ble/handler-esphome-proxy/pool.js', () => {
   class FakeEsphomeProxyPool {
@@ -30,6 +34,25 @@ vi.mock('../../../src/ble/handler-esphome-proxy/pool.js', () => {
     }
     async connectGatt(mac: string) {
       connectGattSpy(mac);
+      if (hangSession) {
+        const silent: BleChar = {
+          async read() {
+            return Buffer.alloc(0);
+          },
+          async write() {},
+          async subscribe() {
+            return () => {};
+          },
+        };
+        return {
+          charMap: new Map<string, BleChar>([
+            [NOTIFY, silent],
+            [WRITE, silent],
+          ]),
+          device: { onDisconnect: (_cb: () => void) => {}, fireDisconnect: fireDisconnectSpy },
+          close: closeSpy,
+        };
+      }
       let notifyCb: ((d: Buffer) => void) | null = null;
       const notifyChar: BleChar = {
         async read() {
@@ -56,7 +79,7 @@ vi.mock('../../../src/ble/handler-esphome-proxy/pool.js', () => {
           [NOTIFY, notifyChar],
           [WRITE, noop],
         ]),
-        device: { onDisconnect: (_cb: () => void) => {} },
+        device: { onDisconnect: (_cb: () => void) => {}, fireDisconnect: () => {} },
         close: closeSpy,
       };
     }
@@ -108,5 +131,50 @@ describe('ReadingWatcher GATT continuous (#116)', () => {
     expect(closeSpy).toHaveBeenCalled();
 
     await watcher.stop();
+  });
+
+  it('bounds a hung GATT read instead of disabling that scale for the process', async () => {
+    // waitForRawReading only settles on a reading, a subscribe failure, or the
+    // proxy's disconnect frame. An ESP32 that vanishes sends no such frame, so
+    // an unbounded read never returns: the finally never runs, gattInFlight is
+    // never cleared (that scale is never read again) and the session is never
+    // closed (the advertisement watchdog stays disarmed for that endpoint).
+    closeSpy.mockClear();
+    connectGattSpy.mockClear();
+    fireDisconnectSpy.mockClear();
+    vi.useFakeTimers();
+    try {
+      hangSession = true;
+      const watcher = new ReadingWatcher(config, [gattAdapter()]);
+      await watcher.start();
+      const pool = (
+        watcher as unknown as {
+          pool: { emitAdvert: (info: BleDeviceInfo, mac: string) => void };
+        }
+      ).pool;
+      const info: BleDeviceInfo = { localName: 'GATT-scale', serviceUuids: [] };
+      pool.emitAdvert(info, 'AA:BB:CC:DD:EE:03');
+
+      // Past the absolute session cap. Without the bound nothing below happens.
+      await vi.advanceTimersByTimeAsync(95_000);
+
+      // Fired BEFORE close(), which splices out the listener the abandoned
+      // wait's own teardown path depends on.
+      expect(fireDisconnectSpy).toHaveBeenCalled();
+      expect(closeSpy).toHaveBeenCalled();
+
+      // The in-flight guard was released, so the scale is readable again.
+      hangSession = false;
+      pool.emitAdvert(info, 'AA:BB:CC:DD:EE:03');
+      await vi.advanceTimersByTimeAsync(0);
+      const reading = await watcher.nextReading();
+      expect(reading.reading.weight).toBe(82);
+      expect(connectGattSpy).toHaveBeenCalledTimes(2);
+
+      await watcher.stop();
+    } finally {
+      hangSession = false;
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/runtime/processor.test.ts
+++ b/tests/runtime/processor.test.ts
@@ -308,6 +308,37 @@ describe('processReading: multi-user', () => {
     expect(updateLastKnownWeight).toHaveBeenCalledWith('/tmp/config.yaml', 'dad', 82, 82);
   });
 
+  it('does not write last_known_weight when every exporter failed', async () => {
+    // The anchor means "the weight we ACTUALLY exported". Writing it after a
+    // total failure poisoned the retry: the scale reconnects, replays the same
+    // frame now carrying a timestamp, and the replay dedup drops it as already
+    // synced. The weigh-in is lost with nothing left to retry from.
+    vi.mocked(dispatchExports).mockResolvedValueOnce({ success: false, details: [] });
+    const ctx = makeCtx([dad, mom], { configSource: 'yaml', configPath: '/tmp/config.yaml' });
+    const ok = await processReading(ctx, rawReading({ weight: 82, impedance: 500 }), {
+      getExportersForUser: () => [fakeExporter()],
+    });
+    expect(ok).toBe(false);
+    expect(updateLastKnownWeight).not.toHaveBeenCalled();
+  });
+
+  it('does not set the single-user replay anchor when every exporter failed', async () => {
+    vi.mocked(dispatchExports).mockResolvedValueOnce({ success: false, details: [] });
+    const ctx = makeCtx([dad]);
+    await processReading(ctx, rawReading({ weight: 82, impedance: 500 }), {
+      singleUserExporters: [fakeExporter()],
+    });
+    expect(ctx.lastExportedWeights.has('dad')).toBe(false);
+  });
+
+  it('sets the single-user replay anchor when the export succeeds', async () => {
+    const ctx = makeCtx([dad]);
+    await processReading(ctx, rawReading({ weight: 82, impedance: 500 }), {
+      singleUserExporters: [fakeExporter()],
+    });
+    expect(ctx.lastExportedWeights.get('dad')).toBe(82);
+  });
+
   it('does not write last_known_weight when configSource is env', async () => {
     const ctx = makeCtx([dad, mom], { configSource: 'env' });
     await processReading(ctx, rawReading({ weight: 82, impedance: 500 }), {

--- a/tests/runtime/processor.test.ts
+++ b/tests/runtime/processor.test.ts
@@ -331,6 +331,9 @@ describe('processReading: multi-user', () => {
     expect(ctx.lastExportedWeights.has('dad')).toBe(false);
   });
 
+  // Not a regression test: this one passes with or without the fix. It is here
+  // as a guard so a later change cannot quietly stop anchoring altogether,
+  // which the two tests above would not catch (they only assert the negative).
   it('sets the single-user replay anchor when the export succeeds', async () => {
     const ctx = makeCtx([dad]);
     await processReading(ctx, rawReading({ weight: 82, impedance: 500 }), {

--- a/tests/scales/speediance.test.ts
+++ b/tests/scales/speediance.test.ts
@@ -73,6 +73,11 @@ describe('SpeedianceAdapter', () => {
       // the notify callback, which has no try/catch above it: a dead process,
       // not a dropped frame. The weight is complete at this length, so it is
       // still taken and the missing impedance is reported as absent.
+      //
+      // Synthetic on purpose, and the exception to the byte-for-byte fixture
+      // rule: no capture shows a short A7 frame, so this is the length guard
+      // being exercised rather than an observed device behaviour. The real
+      // 20-byte capture is covered by the test above.
       const short = Buffer.from('4d2300a76a96d1ff25012a3e0013', 'hex');
       expect(short.length).toBe(14);
       expect(() => adapter.parseCharNotification(uuid16(0xffb3), short)).not.toThrow();

--- a/tests/scales/speediance.test.ts
+++ b/tests/scales/speediance.test.ts
@@ -66,6 +66,22 @@ describe('SpeedianceAdapter', () => {
       expect(adapter.isComplete(reading!)).toBe(true);
     });
 
+    it('survives an A7 frame too short to hold the impedance field', () => {
+      const adapter = makeAdapter();
+      // The frame walk only guarantees 12 bytes, but the impedance field ends
+      // at byte 17. Reading it unguarded threw ERR_OUT_OF_RANGE straight out of
+      // the notify callback, which has no try/catch above it: a dead process,
+      // not a dropped frame. The weight is complete at this length, so it is
+      // still taken and the missing impedance is reported as absent.
+      const short = Buffer.from('4d2300a76a96d1ff25012a3e0013', 'hex');
+      expect(short.length).toBe(14);
+      expect(() => adapter.parseCharNotification(uuid16(0xffb3), short)).not.toThrow();
+      const reading = adapter.parseCharNotification(uuid16(0xffb3), short);
+      expect(reading).not.toBeNull();
+      expect(reading!.weight).toBeCloseTo(76.35, 2);
+      expect(reading!.impedance).toBe(0);
+    });
+
     it('accepts an impedance inside the plausible whole-body range', () => {
       const adapter = makeAdapter();
       const frame = Buffer.from('4d2300a76a96d1ff25012a3e000a002e01970b2a', 'hex');


### PR DESCRIPTION
Three independent defects found in a codebase audit. Each is a silent failure: nothing in the logs says what went wrong.

## 1. Speediance: out-of-bounds read kills the process

`parseCharNotification` guards `data.length < 12`, then reads the impedance at offset 15..16. A short A7 frame throws `ERR_OUT_OF_RANGE` straight out of the notify callback, which has no `try/catch` above it (`handleNotification`) - the same shape as #138.

The weight is complete at the guarded length, so it is taken and the absent impedance is handled exactly like an implausible one. Robi S9, the sibling this frame walk was copied from, never had the problem because it reads no further than byte 7.

## 2. Replay dedup anchored on a failed export -> lost weigh-in

The dedup anchor and `last_known_weight` both mean "the weight we actually exported" (`context.ts` says so), but both were gated on `latestPayload`, set *before* `dispatchExports`. `dispatchExports` returns `false` when every exporter fails - it does not throw - so a total failure still moved the anchor.

The scale then reconnects, replays the same frame now carrying a timestamp, and the replay dedup drops it as already synced. **The weigh-in is lost with nothing left to retry from.** In multi-user mode the same write also corrupts the persisted `last_known_weight` that tie-breaks the next match.

Both writes now gate on the dispatch outcome. A partial success still anchors.

## 3. ESPHome GATT read had no timeout -> scale disabled for the process

`waitForRawReading` settles on a reading, a subscribe failure, or the disconnect callback - and on this transport that callback is driven purely by the proxy's `BluetoothDeviceConnectionResponse`. An ESP32 that drops off Wi-Fi mid-session never sends one, so the read hangs forever and the `finally` never runs:

- `gattInFlight` keeps its entry, so that scale is never read again
- the session never closes, so `noteGattEnd` never fires: the #303 advertisement watchdog stays disarmed for that endpoint while `sweepLiveness` keeps re-stamping its timestamp

Every other transport already bounds this call - the ESPHome watcher was the only one that did not. Now uses the same `withTimeout(withIdleTimeout(...))` pair as the mqtt-proxy watcher, in the one-shot scan path too.

A timeout only abandons the promise, so the abandoned wait is also told to tear itself down (otherwise it keeps its notify unsubscribers and unlock interval and never calls `onSessionEnd`). The device gains `fireDisconnect()`, fired before `close()` - which splices out the very listener the disconnect path needs.

## Verification

Three of the four new tests were confirmed to FAIL against the unfixed code. The fourth ("sets the single-user replay anchor when the export succeeds") passes either way and is a guard against the anchor being dropped altogether, not a regression test; it is now labelled as such. An earlier version of this line claimed all four, which was wrong.

- `npx tsc --noEmit`, `npm run lint`, `npm run format:check` clean
- `npm test`: 157 files, 2809 tests passing
