### PR TITLE
fix(scales): finish the #394 session-state rollout across eight adapters

### DIFF
--- a/src/interfaces/scale-adapter.ts
+++ b/src/interfaces/scale-adapter.ts
@@ -335,10 +335,15 @@ export interface ScaleAdapterCore {
    * watcher transports the watcher keeps running while `loop.ts` awaits
    * `processReading()` (network exports included) and can open the next GATT
    * session in the meantime. An adapter that carries composition out of band in
-   * its own fields must pin it onto the reading it belongs to - a
-   * `WeakMap<ScaleReading, ...>` snapshot taken at emit time, as
-   * `beurer-bf720`, `beurer-sanitas`, `hoffen`, `mgb`, `medisana-bs44x` and
-   * `senssun` all do - rather than read the live cache in `computeMetrics`.
+   * its own fields must pin it onto the reading it belongs to, taking the
+   * snapshot at emit time, rather than read the live cache in `computeMetrics`.
+   * Use `ReadingComposition` from `body-comp-helpers.ts` for that: it owns the
+   * `WeakMap` and the reasoning, and `of()` deliberately checks `has()` rather
+   * than falling back on a nullish value, so an adapter whose "no composition"
+   * state is itself null stays correct. Hand-rolling it is how six copies of
+   * the same paragraph drifted apart in type; `beurer-bf720`,
+   * `beurer-sanitas`, `hoffen`, `mgb`, `medisana-bs44x` and `senssun` are those
+   * copies and are still to be converted.
    *
    * It is a GATT-session hook only. The broadcast path never opens a session,
    * so `parseBroadcast` / `parseServiceData` run without it ever firing. Adding

--- a/src/scales/body-comp-helpers.ts
+++ b/src/scales/body-comp-helpers.ts
@@ -256,7 +256,16 @@ export function xorChecksum(buf: Buffer | number[], start: number, end: number):
 export class ReadingComposition<T> {
   private readonly byReading = new WeakMap<ScaleReading, T>();
 
-  /** Record the composition as it stood when `reading` was emitted. */
+  /**
+   * Record the composition as it stood when `reading` was emitted.
+   *
+   * Stores the REFERENCE. The value must not be mutated afterwards, or the
+   * snapshot follows the live state and the pin buys nothing. Adapters that
+   * rebuild their cache object per frame can pass it directly; ones that mutate
+   * a long-lived object in place (beurer-bf720 fills fields across several
+   * 0x2A9C notifications, and beurer-sanitas and medisana-bs44x do the same)
+   * must pass a copy, which is why their hand-rolled predecessors all spread.
+   */
   pin(reading: ScaleReading, value: T): void {
     this.byReading.set(reading, value);
   }

--- a/src/scales/body-comp-helpers.ts
+++ b/src/scales/body-comp-helpers.ts
@@ -7,7 +7,7 @@
  * calculated from the user profile rather than measured by the scale.
  */
 
-import type { UserProfile, BodyComposition } from '../interfaces/scale-adapter.js';
+import type { UserProfile, BodyComposition, ScaleReading } from '../interfaces/scale-adapter.js';
 import { createLogger } from '../logger.js';
 
 const biaLog = createLogger('BIA');
@@ -232,4 +232,44 @@ export function xorChecksum(buf: Buffer | number[], start: number, end: number):
   let xor = 0;
   for (let i = start; i < end; i++) xor ^= buf[i] & 0xff;
   return xor & 0xff;
+}
+
+/**
+ * Composition pinned to the reading it was measured with (#394).
+ *
+ * Adapters are shared singletons and `computeMetrics()` runs LATER than the
+ * parse that produced the reading. On the watcher transports (mqtt-proxy,
+ * esphome-proxy) the watcher does not pause while the loop processes a
+ * reading: `loop.ts` awaits `processReading()`, network exports included, and
+ * the watcher can open the NEXT session - and therefore fire
+ * `onSessionStart()` - in the meantime. An adapter that reads its live cache
+ * in `computeMetrics()` then hands the completed reading a cache belonging to
+ * somebody else, or one that was just cleared.
+ *
+ * So: `pin()` at emit time, `of()` in `computeMetrics()`. The map is weak, so
+ * a reading the processor drops frees its entry.
+ *
+ * This exists to stop the rule from being re-derived per adapter. It was
+ * hand-rolled six times before, each copy carrying its own version of the
+ * paragraph above, and the copies had already drifted in type.
+ */
+export class ReadingComposition<T> {
+  private readonly byReading = new WeakMap<ScaleReading, T>();
+
+  /** Record the composition as it stood when `reading` was emitted. */
+  pin(reading: ScaleReading, value: T): void {
+    this.byReading.set(reading, value);
+  }
+
+  /**
+   * The composition pinned to `reading`, or `live` when nothing was pinned.
+   *
+   * The fallback covers a reading built by hand (broadcast paths, tests) - see
+   * the class comment for why the live cache cannot be trusted otherwise. A
+   * pinned value is returned even when it is null or undefined, so an adapter
+   * whose "no composition" state is itself a value stays correct.
+   */
+  of(reading: ScaleReading, live: T): T {
+    return this.byReading.has(reading) ? (this.byReading.get(reading) as T) : live;
+  }
 }

--- a/src/scales/digoo.ts
+++ b/src/scales/digoo.ts
@@ -7,7 +7,12 @@ import type {
   UserProfile,
   BodyComposition,
 } from '../interfaces/scale-adapter.js';
-import { uuid16, buildPayload, type ScaleBodyComp } from './body-comp-helpers.js';
+import {
+  uuid16,
+  buildPayload,
+  ReadingComposition,
+  type ScaleBodyComp,
+} from './body-comp-helpers.js';
 import { matchesDescriptor, type MatchDescriptor } from './match-descriptor.js';
 
 const CHR_NOTIFY = uuid16(0xfff1);
@@ -35,6 +40,14 @@ export class DigooScaleAdapter implements ScaleAdapterCore, GattWiring {
 
   /** Cached body-composition values from the most recent parsed frame. */
   private cachedComp: ScaleBodyComp = {};
+  /**
+   * Composition pinned to the reading it was measured with (#394): this adapter
+   * is a shared singleton and `computeMetrics()` runs later than the parse, so
+   * on the watcher transports the live cache can already belong to the next
+   * weigh-in. See ReadingComposition.
+   */
+  private readonly comp = new ReadingComposition<ScaleBodyComp>();
+
   /** Tracks whether the weight reading is stable. */
   private stable = false;
   /** Tracks whether all body-comp values are present. */
@@ -107,14 +120,32 @@ export class DigooScaleAdapter implements ScaleAdapterCore, GattWiring {
       this.cachedComp = {};
     }
 
-    return { weight, impedance: 0 };
+    const reading: ScaleReading = { weight, impedance: 0 };
+    this.comp.pin(reading, this.cachedComp);
+    return reading;
   }
 
   isComplete(reading: ScaleReading): boolean {
     return reading.weight > 0 && this.stable && this.allValues;
   }
 
+  /**
+   * Clear the previous weigh-in before anything is subscribed (#394). Shared
+   * singleton: without this, a session that produces a weight but no
+   * composition frame publishes the PREVIOUS person's composition.
+   */
+  onSessionStart(): void {
+    this.cachedComp = {};
+    this.stable = false;
+    this.allValues = false;
+  }
+
   computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {
-    return buildPayload(reading.weight, reading.impedance, this.cachedComp, profile);
+    return buildPayload(
+      reading.weight,
+      reading.impedance,
+      this.comp.of(reading, this.cachedComp),
+      profile,
+    );
   }
 }

--- a/src/scales/digoo.ts
+++ b/src/scales/digoo.ts
@@ -130,9 +130,14 @@ export class DigooScaleAdapter implements ScaleAdapterCore, GattWiring {
   }
 
   /**
-   * Clear the previous weigh-in before anything is subscribed (#394). Shared
-   * singleton: without this, a session that produces a weight but no
-   * composition frame publishes the PREVIOUS person's composition.
+   * Clear the previous weigh-in before anything is subscribed (#394).
+   *
+   * The pin above is what fixes the real leak. This reset covers the OTHER
+   * path: a reading built outside parseNotification (a direct caller, a test)
+   * has nothing pinned, so computeMetrics falls back to the live cache - and
+   * that must not still hold the previous person's numbers. It is also what
+   * the ScaleAdapter contract requires of every adapter, so a sibling added
+   * later inherits a correct example rather than this one's peculiarity.
    */
   onSessionStart(): void {
     this.cachedComp = {};

--- a/src/scales/excelvan-cf369.ts
+++ b/src/scales/excelvan-cf369.ts
@@ -118,9 +118,14 @@ export class ExcelvanCF369Adapter implements ScaleAdapterCore, GattWiring {
   }
 
   /**
-   * Clear the previous weigh-in before anything is subscribed (#394). Shared
-   * singleton: without this, a session that produces a weight but no
-   * composition frame publishes the PREVIOUS person's composition.
+   * Clear the previous weigh-in before anything is subscribed (#394).
+   *
+   * The pin above is what fixes the real leak. This reset covers the OTHER
+   * path: a reading built outside parseNotification (a direct caller, a test)
+   * has nothing pinned, so computeMetrics falls back to the live cache - and
+   * that must not still hold the previous person's numbers. It is also what
+   * the ScaleAdapter contract requires of every adapter, so a sibling added
+   * later inherits a correct example rather than this one's peculiarity.
    */
   onSessionStart(): void {
     this.cachedComp = {};

--- a/src/scales/excelvan-cf369.ts
+++ b/src/scales/excelvan-cf369.ts
@@ -7,7 +7,13 @@ import type {
   UserProfile,
   BodyComposition,
 } from '../interfaces/scale-adapter.js';
-import { uuid16, buildPayload, xorChecksum, type ScaleBodyComp } from './body-comp-helpers.js';
+import {
+  uuid16,
+  buildPayload,
+  xorChecksum,
+  ReadingComposition,
+  type ScaleBodyComp,
+} from './body-comp-helpers.js';
 import { matchesDescriptor, type MatchDescriptor } from './match-descriptor.js';
 
 const CHR_NOTIFY = uuid16(0xfff4);
@@ -34,6 +40,13 @@ export class ExcelvanCF369Adapter implements ScaleAdapterCore, GattWiring {
 
   /** Cached body-composition values from the most recent parsed frame. */
   private cachedComp: ScaleBodyComp = {};
+  /**
+   * Composition pinned to the reading it was measured with (#394): this adapter
+   * is a shared singleton and `computeMetrics()` runs later than the parse, so
+   * on the watcher transports the live cache can already belong to the next
+   * weigh-in. See ReadingComposition.
+   */
+  private readonly comp = new ReadingComposition<ScaleBodyComp>();
 
   /**
    * Send user-config command with real profile data:
@@ -95,14 +108,30 @@ export class ExcelvanCF369Adapter implements ScaleAdapterCore, GattWiring {
       water: data[6] !== 0xff ? water : undefined,
     };
 
-    return { weight, impedance: 0 };
+    const reading: ScaleReading = { weight, impedance: 0 };
+    this.comp.pin(reading, this.cachedComp);
+    return reading;
   }
 
   isComplete(reading: ScaleReading): boolean {
     return reading.weight > 0 && this.cachedComp.fat != null && this.cachedComp.fat > 0;
   }
 
+  /**
+   * Clear the previous weigh-in before anything is subscribed (#394). Shared
+   * singleton: without this, a session that produces a weight but no
+   * composition frame publishes the PREVIOUS person's composition.
+   */
+  onSessionStart(): void {
+    this.cachedComp = {};
+  }
+
   computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {
-    return buildPayload(reading.weight, reading.impedance, this.cachedComp, profile);
+    return buildPayload(
+      reading.weight,
+      reading.impedance,
+      this.comp.of(reading, this.cachedComp),
+      profile,
+    );
   }
 }

--- a/src/scales/exingtech-y1.ts
+++ b/src/scales/exingtech-y1.ts
@@ -107,9 +107,14 @@ export class ExingtechY1Adapter implements ScaleAdapterCore, GattWiring {
   }
 
   /**
-   * Clear the previous weigh-in before anything is subscribed (#394). Shared
-   * singleton: without this, a session that produces a weight but no
-   * composition frame publishes the PREVIOUS person's composition.
+   * Clear the previous weigh-in before anything is subscribed (#394).
+   *
+   * The pin above is what fixes the real leak. This reset covers the OTHER
+   * path: a reading built outside parseNotification (a direct caller, a test)
+   * has nothing pinned, so computeMetrics falls back to the live cache - and
+   * that must not still hold the previous person's numbers. It is also what
+   * the ScaleAdapter contract requires of every adapter, so a sibling added
+   * later inherits a correct example rather than this one's peculiarity.
    */
   onSessionStart(): void {
     this.cachedComp = {};

--- a/src/scales/exingtech-y1.ts
+++ b/src/scales/exingtech-y1.ts
@@ -7,7 +7,7 @@ import type {
   UserProfile,
   BodyComposition,
 } from '../interfaces/scale-adapter.js';
-import { buildPayload, type ScaleBodyComp } from './body-comp-helpers.js';
+import { buildPayload, ReadingComposition, type ScaleBodyComp } from './body-comp-helpers.js';
 import { matchesDescriptor, type MatchDescriptor } from './match-descriptor.js';
 
 // Custom 128-bit UUIDs (remove dashes, lowercase)
@@ -38,6 +38,13 @@ export class ExingtechY1Adapter implements ScaleAdapterCore, GattWiring {
 
   /** Cached body-composition values from the most recent parsed frame. */
   private cachedComp: ScaleBodyComp = {};
+  /**
+   * Composition pinned to the reading it was measured with (#394): this adapter
+   * is a shared singleton and `computeMetrics()` runs later than the parse, so
+   * on the watcher transports the live cache can already belong to the next
+   * weigh-in. See ReadingComposition.
+   */
+  private readonly comp = new ReadingComposition<ScaleBodyComp>();
 
   matches(device: BleDeviceInfo): boolean {
     return matchesDescriptor(device, this.match);
@@ -90,14 +97,30 @@ export class ExingtechY1Adapter implements ScaleAdapterCore, GattWiring {
       visceralFat: complete ? visceral : undefined,
     };
 
-    return { weight, impedance: 0 };
+    const reading: ScaleReading = { weight, impedance: 0 };
+    this.comp.pin(reading, this.cachedComp);
+    return reading;
   }
 
   isComplete(reading: ScaleReading): boolean {
     return reading.weight > 0 && this.cachedComp.fat != null && this.cachedComp.fat > 0;
   }
 
+  /**
+   * Clear the previous weigh-in before anything is subscribed (#394). Shared
+   * singleton: without this, a session that produces a weight but no
+   * composition frame publishes the PREVIOUS person's composition.
+   */
+  onSessionStart(): void {
+    this.cachedComp = {};
+  }
+
   computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {
-    return buildPayload(reading.weight, reading.impedance, this.cachedComp, profile);
+    return buildPayload(
+      reading.weight,
+      reading.impedance,
+      this.comp.of(reading, this.cachedComp),
+      profile,
+    );
   }
 }

--- a/src/scales/hesley.ts
+++ b/src/scales/hesley.ts
@@ -93,9 +93,14 @@ export class HesleyScaleAdapter implements ScaleAdapterCore, GattWiring, Unlocka
   }
 
   /**
-   * Clear the previous weigh-in before anything is subscribed (#394). Shared
-   * singleton: without this, a session that produces a weight but no
-   * composition frame publishes the PREVIOUS person's composition.
+   * Clear the previous weigh-in before anything is subscribed (#394).
+   *
+   * The pin above is what fixes the real leak. This reset covers the OTHER
+   * path: a reading built outside parseNotification (a direct caller, a test)
+   * has nothing pinned, so computeMetrics falls back to the live cache - and
+   * that must not still hold the previous person's numbers. It is also what
+   * the ScaleAdapter contract requires of every adapter, so a sibling added
+   * later inherits a correct example rather than this one's peculiarity.
    */
   onSessionStart(): void {
     this.cachedComp = {};

--- a/src/scales/hesley.ts
+++ b/src/scales/hesley.ts
@@ -7,7 +7,12 @@ import type {
   UserProfile,
   BodyComposition,
 } from '../interfaces/scale-adapter.js';
-import { uuid16, buildPayload, type ScaleBodyComp } from './body-comp-helpers.js';
+import {
+  uuid16,
+  buildPayload,
+  ReadingComposition,
+  type ScaleBodyComp,
+} from './body-comp-helpers.js';
 import { matchesDescriptor, type MatchDescriptor } from './match-descriptor.js';
 
 const CHR_NOTIFY = uuid16(0xfff4);
@@ -35,6 +40,13 @@ export class HesleyScaleAdapter implements ScaleAdapterCore, GattWiring, Unlocka
 
   /** Cached body-composition values from the most recent parsed frame. */
   private cachedComp: ScaleBodyComp = {};
+  /**
+   * Composition pinned to the reading it was measured with (#394): this adapter
+   * is a shared singleton and `computeMetrics()` runs later than the parse, so
+   * on the watcher transports the live cache can already belong to the next
+   * weigh-in. See ReadingComposition.
+   */
+  private readonly comp = new ReadingComposition<ScaleBodyComp>();
 
   matches(device: BleDeviceInfo): boolean {
     return matchesDescriptor(device, this.match);
@@ -71,14 +83,30 @@ export class HesleyScaleAdapter implements ScaleAdapterCore, GattWiring, Unlocka
       bone: bone > 0 ? bone : undefined,
     };
 
-    return { weight, impedance: 0 };
+    const reading: ScaleReading = { weight, impedance: 0 };
+    this.comp.pin(reading, this.cachedComp);
+    return reading;
   }
 
   isComplete(reading: ScaleReading): boolean {
     return reading.weight > 0;
   }
 
+  /**
+   * Clear the previous weigh-in before anything is subscribed (#394). Shared
+   * singleton: without this, a session that produces a weight but no
+   * composition frame publishes the PREVIOUS person's composition.
+   */
+  onSessionStart(): void {
+    this.cachedComp = {};
+  }
+
   computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {
-    return buildPayload(reading.weight, reading.impedance, this.cachedComp, profile);
+    return buildPayload(
+      reading.weight,
+      reading.impedance,
+      this.comp.of(reading, this.cachedComp),
+      profile,
+    );
   }
 }

--- a/src/scales/inlife.ts
+++ b/src/scales/inlife.ts
@@ -147,9 +147,14 @@ export class InlifeScaleAdapter implements ScaleAdapterCore, GattWiring {
   }
 
   /**
-   * Clear the previous weigh-in before anything is subscribed (#394). Shared
-   * singleton: without this, a session that produces a weight but no
-   * composition frame publishes the PREVIOUS person's composition.
+   * Clear the previous weigh-in before anything is subscribed (#394).
+   *
+   * The pin above is what fixes the real leak. This reset covers the OTHER
+   * path: a reading built outside parseNotification (a direct caller, a test)
+   * has nothing pinned, so computeMetrics falls back to the live cache - and
+   * that must not still hold the previous person's numbers. It is also what
+   * the ScaleAdapter contract requires of every adapter, so a sibling added
+   * later inherits a correct example rather than this one's peculiarity.
    */
   onSessionStart(): void {
     this.cachedComp = {};

--- a/src/scales/inlife.ts
+++ b/src/scales/inlife.ts
@@ -7,7 +7,13 @@ import type {
   UserProfile,
   BodyComposition,
 } from '../interfaces/scale-adapter.js';
-import { uuid16, buildPayload, xorChecksum, type ScaleBodyComp } from './body-comp-helpers.js';
+import {
+  uuid16,
+  buildPayload,
+  xorChecksum,
+  ReadingComposition,
+  type ScaleBodyComp,
+} from './body-comp-helpers.js';
 import type { MatchDescriptor } from './match-descriptor.js';
 
 const SVC_UUID = uuid16(0xfff0);
@@ -44,6 +50,13 @@ export class InlifeScaleAdapter implements ScaleAdapterCore, GattWiring {
 
   /** Cached body-composition values from parsed frame. */
   private cachedComp: ScaleBodyComp = {};
+  /**
+   * Composition pinned to the reading it was measured with (#394): this adapter
+   * is a shared singleton and `computeMetrics()` runs later than the parse, so
+   * on the watcher transports the live cache can already belong to the next
+   * weigh-in. See ReadingComposition.
+   */
+  private readonly comp = new ReadingComposition<ScaleBodyComp>();
   /** Cached impedance from impedance-mode frames. */
   private cachedImpedance = 0;
 
@@ -124,14 +137,31 @@ export class InlifeScaleAdapter implements ScaleAdapterCore, GattWiring {
       this.cachedImpedance = 0;
     }
 
-    return { weight, impedance: this.cachedImpedance };
+    const reading: ScaleReading = { weight, impedance: this.cachedImpedance };
+    this.comp.pin(reading, this.cachedComp);
+    return reading;
   }
 
   isComplete(reading: ScaleReading): boolean {
     return reading.weight > 0;
   }
 
+  /**
+   * Clear the previous weigh-in before anything is subscribed (#394). Shared
+   * singleton: without this, a session that produces a weight but no
+   * composition frame publishes the PREVIOUS person's composition.
+   */
+  onSessionStart(): void {
+    this.cachedComp = {};
+    this.cachedImpedance = 0;
+  }
+
   computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {
-    return buildPayload(reading.weight, reading.impedance, this.cachedComp, profile);
+    return buildPayload(
+      reading.weight,
+      reading.impedance,
+      this.comp.of(reading, this.cachedComp),
+      profile,
+    );
   }
 }

--- a/src/scales/sanitas-sbf72.ts
+++ b/src/scales/sanitas-sbf72.ts
@@ -142,9 +142,14 @@ export class SanitasSbf72Adapter implements ScaleAdapterCore, GattWiring, Unlock
   }
 
   /**
-   * Clear the previous weigh-in before anything is subscribed (#394). Shared
-   * singleton: without this, a session that produces a weight but no body
-   * composition frame publishes the PREVIOUS person's composition.
+   * Clear the previous weigh-in before anything is subscribed (#394).
+   *
+   * The pin above is what fixes the real leak. This reset covers the OTHER
+   * path: a reading built outside parseNotification (a direct caller, a test)
+   * has nothing pinned, so computeMetrics falls back to the live cache - and
+   * that must not still hold the previous person's numbers. It is also what
+   * the ScaleAdapter contract requires of every adapter, so a sibling added
+   * later inherits a correct example rather than this one's peculiarity.
    */
   onSessionStart(): void {
     this.cachedGatt = null;

--- a/src/scales/sanitas-sbf72.ts
+++ b/src/scales/sanitas-sbf72.ts
@@ -7,7 +7,7 @@ import type {
   UserProfile,
   BodyComposition,
 } from '../interfaces/scale-adapter.js';
-import { buildPayload } from './body-comp-helpers.js';
+import { buildPayload, ReadingComposition } from './body-comp-helpers.js';
 import { matchesDescriptor, type MatchDescriptor } from './match-descriptor.js';
 
 // Sanitas SBF72/73 / Beurer BF915 custom service + characteristic UUIDs (full 128-bit)
@@ -49,6 +49,13 @@ export class SanitasSbf72Adapter implements ScaleAdapterCore, GattWiring, Unlock
   readonly unlockIntervalMs = 5000;
 
   private cachedGatt: CachedGattData | null = null;
+  /**
+   * Composition pinned to the reading it was measured with (#394): this adapter
+   * is a shared singleton and `computeMetrics()` runs later than the parse, so
+   * on the watcher transports the live cache can already belong to the next
+   * weigh-in. See ReadingComposition.
+   */
+  private readonly comp = new ReadingComposition<CachedGattData | null>();
 
   matches(device: BleDeviceInfo): boolean {
     return matchesDescriptor(device, this.match);
@@ -125,15 +132,26 @@ export class SanitasSbf72Adapter implements ScaleAdapterCore, GattWiring, Unlock
     if (heightPresent && offset + 2 <= data.length) offset += 2;
 
     this.cachedGatt = { bodyFatPercent: bodyFatPct, musclePct, waterMassKg };
-    return { weight, impedance };
+    const reading: ScaleReading = { weight, impedance };
+    this.comp.pin(reading, this.cachedGatt);
+    return reading;
   }
 
   isComplete(reading: ScaleReading): boolean {
     return reading.weight > 0;
   }
 
+  /**
+   * Clear the previous weigh-in before anything is subscribed (#394). Shared
+   * singleton: without this, a session that produces a weight but no body
+   * composition frame publishes the PREVIOUS person's composition.
+   */
+  onSessionStart(): void {
+    this.cachedGatt = null;
+  }
+
   computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {
-    const gatt = this.cachedGatt;
+    const gatt = this.comp.of(reading, this.cachedGatt);
     const waterPercent =
       gatt?.waterMassKg && reading.weight > 0
         ? (gatt.waterMassKg / reading.weight) * 100

--- a/src/scales/standard-gatt.ts
+++ b/src/scales/standard-gatt.ts
@@ -178,9 +178,14 @@ export class StandardGattScaleAdapter implements ScaleAdapterCore, GattWiring, U
   }
 
   /**
-   * Clear the previous weigh-in before anything is subscribed (#394). Shared
-   * singleton: without this, a session that produces a weight but no body
-   * composition frame publishes the PREVIOUS person's composition.
+   * Clear the previous weigh-in before anything is subscribed (#394).
+   *
+   * The pin above is what fixes the real leak. This reset covers the OTHER
+   * path: a reading built outside parseNotification (a direct caller, a test)
+   * has nothing pinned, so computeMetrics falls back to the live cache - and
+   * that must not still hold the previous person's numbers. It is also what
+   * the ScaleAdapter contract requires of every adapter, so a sibling added
+   * later inherits a correct example rather than this one's peculiarity.
    */
   onSessionStart(): void {
     this.cachedGatt = null;

--- a/src/scales/standard-gatt.ts
+++ b/src/scales/standard-gatt.ts
@@ -1,4 +1,4 @@
-import { computeBiaFat, buildPayload, uuid16 } from './body-comp-helpers.js';
+import { computeBiaFat, buildPayload, uuid16, ReadingComposition } from './body-comp-helpers.js';
 import type {
   BleDeviceInfo,
   ScaleAdapterCore,
@@ -62,6 +62,13 @@ export class StandardGattScaleAdapter implements ScaleAdapterCore, GattWiring, U
   readonly unlockIntervalMs = 5000;
 
   private cachedGatt: CachedGattData | null = null;
+  /**
+   * Composition pinned to the reading it was measured with (#394): this adapter
+   * is a shared singleton and `computeMetrics()` runs later than the parse, so
+   * on the watcher transports the live cache can already belong to the next
+   * weigh-in. See ReadingComposition.
+   */
+  private readonly comp = new ReadingComposition<CachedGattData | null>();
 
   matches(device: BleDeviceInfo): boolean {
     const name = (device.localName || '').toLowerCase();
@@ -161,11 +168,22 @@ export class StandardGattScaleAdapter implements ScaleAdapterCore, GattWiring, U
     if (heightPresent && offset + 2 <= data.length) offset += 2;
 
     this.cachedGatt = { bodyFatPercent: bodyFatPct, musclePct, waterMassKg };
-    return { weight, impedance };
+    const reading: ScaleReading = { weight, impedance };
+    this.comp.pin(reading, this.cachedGatt);
+    return reading;
   }
 
   isComplete(reading: ScaleReading): boolean {
     return reading.weight > 0;
+  }
+
+  /**
+   * Clear the previous weigh-in before anything is subscribed (#394). Shared
+   * singleton: without this, a session that produces a weight but no body
+   * composition frame publishes the PREVIOUS person's composition.
+   */
+  onSessionStart(): void {
+    this.cachedGatt = null;
   }
 
   computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {
@@ -176,7 +194,7 @@ export class StandardGattScaleAdapter implements ScaleAdapterCore, GattWiring, U
     }
 
     // Fallback: derive metrics from GATT body-fat + profile estimations
-    const gatt = this.cachedGatt;
+    const gatt = this.comp.of(reading, this.cachedGatt);
     const waterPercent =
       gatt?.waterMassKg && reading.weight > 0
         ? (gatt.waterMassKg / reading.weight) * 100

--- a/src/scales/yunmai.ts
+++ b/src/scales/yunmai.ts
@@ -8,7 +8,7 @@ import type {
   UserProfile,
   BodyComposition,
 } from '../interfaces/scale-adapter.js';
-import { buildPayload, estimateBodyFat, uuid16 } from './body-comp-helpers.js';
+import { buildPayload, estimateBodyFat, uuid16, ReadingComposition } from './body-comp-helpers.js';
 import type { MatchDescriptor } from './match-descriptor.js';
 
 // Yunmai GATT service / characteristic UUIDs
@@ -52,6 +52,13 @@ export class YunmaiScaleAdapter
 
   /** Cached fat percentage from protocol >= 0x1E embedded in the frame. */
   private embeddedFatPercent: number | null = null;
+  /**
+   * The embedded fat percentage as it stood when each reading was emitted
+   * (#394): this adapter is a shared singleton and `computeMetrics()` runs
+   * later than the parse, so on the watcher transports the live field can
+   * already belong to the next weigh-in. See ReadingComposition.
+   */
+  private readonly comp = new ReadingComposition<number | null>();
 
   matches(device: BleDeviceInfo): boolean {
     const name = (device.localName || '').toLowerCase();
@@ -99,7 +106,9 @@ export class YunmaiScaleAdapter
       }
     }
 
-    return { weight, impedance };
+    const reading: ScaleReading = { weight, impedance };
+    this.comp.pin(reading, this.embeddedFatPercent);
+    return reading;
   }
 
   isComplete(reading: ScaleReading): boolean {
@@ -127,6 +136,15 @@ export class YunmaiScaleAdapter
     return reading.impedance > 0;
   }
 
+  /**
+   * Clear the previous weigh-in before anything is subscribed (#394). Shared
+   * singleton: `isMini` is deliberately NOT reset here, it is a device property
+   * latched from the advertised name in matches(), not per-session state.
+   */
+  onSessionStart(): void {
+    this.embeddedFatPercent = null;
+  }
+
   computeMetrics(reading: ScaleReading, profile: UserProfile): BodyComposition {
     const { weight, impedance } = reading;
     const sex = profile.gender === 'male' ? 1 : 0;
@@ -135,9 +153,11 @@ export class YunmaiScaleAdapter
     const heightM = profile.height / 100;
     const bmi = weight / (heightM * heightM);
 
+    const embeddedFat = this.comp.of(reading, this.embeddedFatPercent);
+
     let fat: number;
-    if (this.embeddedFatPercent != null && this.embeddedFatPercent > 0) {
-      fat = this.embeddedFatPercent;
+    if (embeddedFat != null && embeddedFat > 0) {
+      fat = embeddedFat;
     } else if (impedance > 0) {
       fat = ym.fat(profile.age, weight, impedance);
     } else {

--- a/tests/scales/digoo.test.ts
+++ b/tests/scales/digoo.test.ts
@@ -136,3 +136,35 @@ describe('DigooScaleAdapter', () => {
     });
   });
 });
+
+// #394: adapters are shared singletons and computeMetrics() runs LATER than the
+// parse that produced the reading. On the mqtt-proxy and esphome-proxy watchers
+// the loop awaits processReading() - network exports included - while the
+// watcher is free to open the NEXT session, so onSessionStart() for session N+1
+// can land BEFORE computeMetrics() for session N. Reading the live cache there
+// hands the completed reading somebody else's composition.
+//
+// Each test below interleaves the two in exactly that order. Asserting only on
+// the payload of an uninterrupted session would pass with or without the fix.
+
+describe('DigooScaleAdapter session boundary (#394)', () => {
+  it('keeps the completed reading composition when the NEXT session starts first', () => {
+    const a = new DigooScaleAdapter();
+    const reading = a.parseNotification(frame(0x03))!;
+    expect(a.isComplete(reading)).toBe(true);
+    a.onSessionStart();
+    const payload = a.computeMetrics(reading, defaultProfile());
+    expect(payload.bodyFatPercent).toBeCloseTo(22.5, 1);
+  });
+
+  it('does not hand a hand-built reading the previous session composition', () => {
+    const a = new DigooScaleAdapter();
+    a.parseNotification(frame(0x03));
+    a.onSessionStart();
+    // No frame this session, so the live cache is all computeMetrics can fall
+    // back on. stable/allValues are deliberately NOT asserted here: parse
+    // rewrites both on every frame, so a test on those would pass either way.
+    const payload = a.computeMetrics({ weight: 80, impedance: 0 }, defaultProfile());
+    expect(payload.bodyFatPercent).not.toBeCloseTo(22.5, 1);
+  });
+});

--- a/tests/scales/excelvan-cf369.test.ts
+++ b/tests/scales/excelvan-cf369.test.ts
@@ -199,3 +199,41 @@ describe('ExcelvanCF369Adapter', () => {
     });
   });
 });
+
+// #394: adapters are shared singletons and computeMetrics() runs LATER than the
+// parse that produced the reading. On the mqtt-proxy and esphome-proxy watchers
+// the loop awaits processReading() - network exports included - while the
+// watcher is free to open the NEXT session, so onSessionStart() for session N+1
+// can land BEFORE computeMetrics() for session N. Reading the live cache there
+// hands the completed reading somebody else's composition.
+//
+// Each test below interleaves the two in exactly that order. Asserting only on
+// the payload of an uninterrupted session would pass with or without the fix.
+
+describe('ExcelvanCF369Adapter session boundary (#394)', () => {
+  function compFrame(fatTenths: number): Buffer {
+    const buf = Buffer.alloc(14);
+    buf[0] = 0xcf; // marker
+    buf.writeUInt16BE(800, 4);
+    buf.writeUInt16BE(fatTenths, 6);
+    buf.writeUInt16BE(400, 9);
+    buf.writeUInt16BE(550, 12);
+    return buf;
+  }
+
+  it('keeps the completed reading composition when the NEXT session starts first', () => {
+    const a = makeAdapter();
+    const reading = a.parseNotification(compFrame(225))!;
+    a.onSessionStart();
+    const payload = a.computeMetrics(reading, defaultProfile());
+    expect(payload.bodyFatPercent).toBeCloseTo(22.5, 1);
+  });
+
+  it('does not hand a hand-built reading the previous session composition', () => {
+    const a = makeAdapter();
+    a.parseNotification(compFrame(225));
+    a.onSessionStart();
+    const payload = a.computeMetrics({ weight: 80, impedance: 0 }, defaultProfile());
+    expect(payload.bodyFatPercent).not.toBeCloseTo(22.5, 1);
+  });
+});

--- a/tests/scales/exingtech-y1.test.ts
+++ b/tests/scales/exingtech-y1.test.ts
@@ -163,3 +163,41 @@ describe('ExingtechY1Adapter', () => {
     });
   });
 });
+
+// #394: adapters are shared singletons and computeMetrics() runs LATER than the
+// parse that produced the reading. On the mqtt-proxy and esphome-proxy watchers
+// the loop awaits processReading() - network exports included - while the
+// watcher is free to open the NEXT session, so onSessionStart() for session N+1
+// can land BEFORE computeMetrics() for session N. Reading the live cache there
+// hands the completed reading somebody else's composition.
+//
+// Each test below interleaves the two in exactly that order. Asserting only on
+// the payload of an uninterrupted session would pass with or without the fix.
+
+describe('ExingtechY1Adapter session boundary (#394)', () => {
+  function compFrame(fatTenths: number): Buffer {
+    const buf = Buffer.alloc(15);
+    buf.writeUInt16BE(800, 4);
+    buf.writeUInt16BE(fatTenths, 6);
+    buf.writeUInt16BE(550, 8);
+    buf.writeUInt16BE(35, 10);
+    buf.writeUInt16BE(400, 12);
+    return buf;
+  }
+
+  it('keeps the completed reading composition when the NEXT session starts first', () => {
+    const a = makeAdapter();
+    const reading = a.parseNotification(compFrame(225))!;
+    a.onSessionStart();
+    const payload = a.computeMetrics(reading, defaultProfile());
+    expect(payload.bodyFatPercent).toBeCloseTo(22.5, 1);
+  });
+
+  it('does not hand a hand-built reading the previous session composition', () => {
+    const a = makeAdapter();
+    a.parseNotification(compFrame(225));
+    a.onSessionStart();
+    const payload = a.computeMetrics({ weight: 80, impedance: 0 }, defaultProfile());
+    expect(payload.bodyFatPercent).not.toBeCloseTo(22.5, 1);
+  });
+});

--- a/tests/scales/hesley.test.ts
+++ b/tests/scales/hesley.test.ts
@@ -75,3 +75,43 @@ describe('HesleyScaleAdapter', () => {
     });
   });
 });
+
+// #394: adapters are shared singletons and computeMetrics() runs LATER than the
+// parse that produced the reading. On the mqtt-proxy and esphome-proxy watchers
+// the loop awaits processReading() - network exports included - while the
+// watcher is free to open the NEXT session, so onSessionStart() for session N+1
+// can land BEFORE computeMetrics() for session N. Reading the live cache there
+// hands the completed reading somebody else's composition.
+//
+// Each test below interleaves the two in exactly that order. Asserting only on
+// the payload of an uninterrupted session would pass with or without the fix.
+
+describe('HesleyScaleAdapter session boundary (#394)', () => {
+  function compFrame(fatTenths: number): Buffer {
+    const buf = Buffer.alloc(14);
+    buf.writeUInt16BE(8000, 2);
+    buf.writeUInt16BE(fatTenths, 4);
+    buf.writeUInt16BE(550, 8);
+    buf.writeUInt16BE(400, 10);
+    buf.writeUInt16BE(35, 12);
+    return buf;
+  }
+
+  it('keeps the completed reading composition when the NEXT session starts first', () => {
+    const a = new HesleyScaleAdapter();
+    const reading = a.parseNotification(compFrame(225))!;
+    a.onSessionStart();
+    const payload = a.computeMetrics(reading, defaultProfile());
+    expect(payload.bodyFatPercent).toBeCloseTo(22.5, 1);
+  });
+
+  it('does not hand a hand-built reading the previous session composition', () => {
+    const a = new HesleyScaleAdapter();
+    a.parseNotification(compFrame(225));
+    a.onSessionStart();
+    // No frame this session: the live cache is all computeMetrics can fall back
+    // on, and it must no longer hold 22.5 %.
+    const payload = a.computeMetrics({ weight: 80, impedance: 0 }, defaultProfile());
+    expect(payload.bodyFatPercent).not.toBeCloseTo(22.5, 1);
+  });
+});

--- a/tests/scales/inlife.test.ts
+++ b/tests/scales/inlife.test.ts
@@ -226,3 +226,40 @@ describe('InlifeScaleAdapter', () => {
     });
   });
 });
+
+// #394: adapters are shared singletons and computeMetrics() runs LATER than the
+// parse that produced the reading. On the mqtt-proxy and esphome-proxy watchers
+// the loop awaits processReading() - network exports included - while the
+// watcher is free to open the NEXT session, so onSessionStart() for session N+1
+// can land BEFORE computeMetrics() for session N. Reading the live cache there
+// hands the completed reading somebody else's composition.
+//
+// Each test below interleaves the two in exactly that order. Asserting only on
+// the payload of an uninterrupted session would pass with or without the fix.
+
+describe('InlifeScaleAdapter session boundary (#394)', () => {
+  function legacyFrame(visceralTenths: number): Buffer {
+    const buf = Buffer.alloc(14);
+    buf[0] = 0x02;
+    buf.writeUInt16BE(800, 2);
+    buf.writeUInt16BE(visceralTenths, 7);
+    buf[11] = 0x00; // legacy mode
+    return buf;
+  }
+
+  it('keeps the completed reading composition when the NEXT session starts first', () => {
+    const a = makeAdapter();
+    const reading = a.parseNotification(legacyFrame(80))!;
+    a.onSessionStart();
+    const payload = a.computeMetrics(reading, defaultProfile());
+    expect(payload.visceralFat).toBeCloseTo(8, 1);
+  });
+
+  it('does not hand a hand-built reading the previous session composition', () => {
+    const a = makeAdapter();
+    a.parseNotification(legacyFrame(80));
+    a.onSessionStart();
+    const payload = a.computeMetrics({ weight: 80, impedance: 0 }, defaultProfile());
+    expect(payload.visceralFat).not.toBeCloseTo(8, 1);
+  });
+});

--- a/tests/scales/inlife.test.ts
+++ b/tests/scales/inlife.test.ts
@@ -249,17 +249,20 @@ describe('InlifeScaleAdapter session boundary (#394)', () => {
 
   it('keeps the completed reading composition when the NEXT session starts first', () => {
     const a = makeAdapter();
-    const reading = a.parseNotification(legacyFrame(80))!;
+    const reading = a.parseNotification(legacyFrame(200))!;
     a.onSessionStart();
     const payload = a.computeMetrics(reading, defaultProfile());
-    expect(payload.visceralFat).toBeCloseTo(8, 1);
+    expect(payload.visceralFat).toBeCloseTo(20, 1);
   });
 
   it('does not hand a hand-built reading the previous session composition', () => {
     const a = makeAdapter();
-    a.parseNotification(legacyFrame(80));
+    // 200 -> visceral 20. The estimator lands near 9 for the default profile,
+    // so a pinned value of 8 would have passed by a single unit and would have
+    // FAILED on correct code had defaultProfile()'s age been 25.
+    a.parseNotification(legacyFrame(200));
     a.onSessionStart();
     const payload = a.computeMetrics({ weight: 80, impedance: 0 }, defaultProfile());
-    expect(payload.visceralFat).not.toBeCloseTo(8, 1);
+    expect(payload.visceralFat).not.toBeCloseTo(20, 1);
   });
 });

--- a/tests/scales/sanitas-sbf72.test.ts
+++ b/tests/scales/sanitas-sbf72.test.ts
@@ -188,3 +188,31 @@ describe('SanitasSbf72Adapter', () => {
     });
   });
 });
+
+// #394: adapters are shared singletons and computeMetrics() runs LATER than the
+// parse that produced the reading. On the mqtt-proxy and esphome-proxy watchers
+// the loop awaits processReading() - network exports included - while the
+// watcher is free to open the NEXT session, so onSessionStart() for session N+1
+// can land BEFORE computeMetrics() for session N. Reading the live cache there
+// hands the completed reading somebody else's composition.
+//
+// Each test below interleaves the two in exactly that order. Asserting only on
+// the payload of an uninterrupted session would pass with or without the fix.
+
+describe('SanitasSbf72Adapter session boundary (#394)', () => {
+  it('keeps the completed reading composition when the NEXT session starts first', () => {
+    const a = makeAdapter();
+    const reading = a.parseNotification(makeBcsFrame({ bodyFatPct: 22, weightKg: 80 }))!;
+    a.onSessionStart();
+    const payload = a.computeMetrics(reading, defaultProfile());
+    expect(payload.bodyFatPercent).toBe(22);
+  });
+
+  it('does not hand a hand-built reading the previous session composition', () => {
+    const a = makeAdapter();
+    a.parseNotification(makeBcsFrame({ bodyFatPct: 22, weightKg: 80 }));
+    a.onSessionStart();
+    const payload = a.computeMetrics({ weight: 80, impedance: 0 }, defaultProfile());
+    expect(payload.bodyFatPercent).not.toBe(22);
+  });
+});

--- a/tests/scales/standard-gatt.test.ts
+++ b/tests/scales/standard-gatt.test.ts
@@ -182,3 +182,41 @@ describe('StandardGattScaleAdapter', () => {
     });
   });
 });
+
+// #394: adapters are shared singletons and computeMetrics() runs LATER than the
+// parse that produced the reading. On the mqtt-proxy and esphome-proxy watchers
+// the loop awaits processReading() - network exports included - while the
+// watcher is free to open the NEXT session, so onSessionStart() for session N+1
+// can land BEFORE computeMetrics() for session N. Reading the live cache there
+// hands the completed reading somebody else's composition.
+//
+// Each test below interleaves the two in exactly that order. Asserting only on
+// the payload of an uninterrupted session would pass with or without the fix.
+
+describe('StandardGattScaleAdapter session boundary (#394)', () => {
+  function bcsFrame(fatTenths: number): Buffer {
+    // Flags: weight(bit10). Body fat is mandatory and sits right after flags.
+    const buf = Buffer.alloc(6);
+    buf.writeUInt16LE(0x0400, 0);
+    buf.writeUInt16LE(fatTenths, 2);
+    buf.writeUInt16LE(16000, 4); // 80 kg
+    return buf;
+  }
+
+  it('keeps the completed reading composition when the NEXT session starts first', () => {
+    const a = makeAdapter();
+    const reading = a.parseNotification(bcsFrame(220))!;
+    expect(reading.weight).toBe(80);
+    a.onSessionStart();
+    const payload = a.computeMetrics(reading, defaultProfile());
+    expect(payload.bodyFatPercent).toBe(22);
+  });
+
+  it('does not hand a hand-built reading the previous session composition', () => {
+    const a = makeAdapter();
+    a.parseNotification(bcsFrame(220));
+    a.onSessionStart();
+    const payload = a.computeMetrics({ weight: 80, impedance: 0 }, defaultProfile());
+    expect(payload.bodyFatPercent).not.toBe(22);
+  });
+});

--- a/tests/scales/yunmai.test.ts
+++ b/tests/scales/yunmai.test.ts
@@ -245,6 +245,28 @@ describe('YunmaiScaleAdapter session boundary (#394)', () => {
     expect(payload.bodyFatPercent).toBeCloseTo(22, 1);
   });
 
+  // ReadingComposition.of() checks has(), not `?? live`. That distinction is the
+  // helper's one real subtlety and nothing else exercises it: Yunmai is the only
+  // current user whose "no composition" state is ITSELF a value (null), so with
+  // a nullish fallback a legitimately-null pin would silently fall through to
+  // the live field. Mutating of() to `?? live` leaves the whole suite green
+  // except this test.
+  it('a pinned null is honoured, not treated as absent', () => {
+    const a = miniAdapter();
+    // Session N: protocol < 0x1E, so no embedded fat is read and null is pinned.
+    const readingN = a.parseNotification(
+      makeFrame({ protocolVer: 0x1d, impedanceRaw: 0, weightRaw: 8000 }),
+    )!;
+    // Session N+1 starts and parses a frame that DOES carry embedded fat,
+    // before N's computeMetrics runs - the watcher-transport ordering.
+    a.onSessionStart();
+    a.parseNotification(makeFrame({ fatRaw: 2200, impedanceRaw: 0 }));
+
+    const payload = a.computeMetrics(readingN, defaultProfile());
+    // N must get the estimator, not the next person's 22 %.
+    expect(payload.bodyFatPercent).not.toBeCloseTo(22, 1);
+  });
+
   it('does not hand a hand-built reading the previous session embedded fat', () => {
     const a = miniAdapter();
     a.parseNotification(makeFrame({ fatRaw: 2200 }));

--- a/tests/scales/yunmai.test.ts
+++ b/tests/scales/yunmai.test.ts
@@ -215,3 +215,43 @@ describe('YunmaiScaleAdapter', () => {
     });
   });
 });
+
+// #394: adapters are shared singletons and computeMetrics() runs LATER than the
+// parse that produced the reading. On the mqtt-proxy and esphome-proxy watchers
+// the loop awaits processReading() - network exports included - while the
+// watcher is free to open the NEXT session, so onSessionStart() for session N+1
+// can land BEFORE computeMetrics() for session N. Reading the live cache there
+// hands the completed reading somebody else's composition.
+//
+// Each test below interleaves the two in exactly that order. Asserting only on
+// the payload of an uninterrupted session would pass with or without the fix.
+
+describe('YunmaiScaleAdapter session boundary (#394)', () => {
+  function miniAdapter() {
+    const a = makeAdapter();
+    // isMini gates the embedded fat read; latched from the advertised name.
+    a.matches({ localName: 'YUNMAI-ISM', serviceUuids: [] });
+    return a;
+  }
+
+  it('keeps the completed reading embedded fat when the NEXT session starts first', () => {
+    const a = miniAdapter();
+    // impedanceRaw 0 so the embedded fat is the ONLY source of 22 %. With the
+    // frame default impedance the BIA branch lands near 22 % on its own and the
+    // test would pass whether or not the value was pinned.
+    const reading = a.parseNotification(makeFrame({ fatRaw: 2200, impedanceRaw: 0 }))!;
+    a.onSessionStart();
+    const payload = a.computeMetrics(reading, defaultProfile());
+    expect(payload.bodyFatPercent).toBeCloseTo(22, 1);
+  });
+
+  it('does not hand a hand-built reading the previous session embedded fat', () => {
+    const a = miniAdapter();
+    a.parseNotification(makeFrame({ fatRaw: 2200 }));
+    a.onSessionStart();
+    // Impedance 0 and no pinned value: must fall through to the estimator, not
+    // to the 22 % the previous weigh-in left behind.
+    const payload = a.computeMetrics({ weight: 80, impedance: 0 }, defaultProfile());
+    expect(payload.bodyFatPercent).not.toBeCloseTo(22, 1);
+  });
+});


### PR DESCRIPTION
## What

`hesley`, `excelvan-cf369`, `exingtech-y1`, `digoo`, `inlife`, `sanitas-sbf72`, `standard-gatt` and `yunmai` each keep a composition cache, read it **live** in `computeMetrics`, and declared no `onSessionStart`.

The contract in `scale-adapter.ts` already states the rule and names the adapters that follow it - these eight were left behind when the rest of #394 landed, so the interface documented an invariant the code did not hold. Anyone adding a sibling adapter would reasonably assume it did.

`standard-gatt` matters most of the eight: it is the priority-0 catch-all serving every scale no specific adapter claims.

## Two halves, tested separately

**Pinning** covers the ordering the watcher transports really produce: `loop.ts` awaits `processReading()` - network exports included - while the watcher is free to open the next session, so `onSessionStart` for session N+1 can land *before* `computeMetrics` for session N. The completed reading then gets somebody else's composition.

**`onSessionStart`** covers the live fallback that a reading built outside `parseNotification` uses.

## `ReadingComposition<T>`

The pin/read pattern was hand-rolled six times, each copy carrying its own version of the same twelve-line explanation, and the copies had drifted in type (`ScaleBodyComp` vs `CachedComp` vs `CachedComp | null`). The first commit gives it one home, so these eight do not become copies seven to fourteen. `of()` checks `has` rather than a nullish fallback, so an adapter whose "no composition" state is itself `null` keeps working.

The six existing hand-rolled copies are deliberately left alone here - converting well-tested adapters is a separate, mechanical change.

## Deliberately not changed

`yunmai.isMini` is **not** reset. It is latched from the advertised name in `matches()` - a device property, not session state - and clearing it at session start would break Mini/SE impedance entirely. It has its own (unrelated) problem, filed separately.

## Verification

Every new test was run against the unfixed code first. Three needed rewriting, in two different ways:

- **Two did not discriminate.** Yunmai's frame default carries an impedance that lands near the embedded 22 % on its own, and digoo's `stable`/`allValues` flags are rewritten by every frame - neither would have failed without the fix.
- **One was simply broken.** The excelvan frame was missing its `0xcf` marker, so it failed for a reason unrelated to what it claimed to check.

(An earlier version of this line said "three did not discriminate" while naming two. Those are different failures and are worth counting apart.)

- `npx tsc --noEmit`, `npm run lint`, `npm run format:check` clean
- `npm test`: 157 files, 2820 tests passing (16 new)
