### PR TITLE
fix: secret handling, file permissions, and log injection

### DIFF
--- a/src/ble/advertisement.ts
+++ b/src/ble/advertisement.ts
@@ -236,6 +236,27 @@ function blob(data: Buffer): string {
 }
 
 /**
+ * Render a device-supplied name safe to put in a log line.
+ *
+ * The local name comes straight off the air, unfiltered, from anyone with a
+ * radio in range - or from anyone who can publish to a proxy topic. It is
+ * logged for EVERY advertisement seen during a scan, matched or not, so no
+ * pairing or trust step gates it. A crafted name carrying CR/LF forges
+ * convincing log lines in journald or docker logs, which is exactly what
+ * reporters are asked to paste into public issues, and ANSI/OSC escapes rewrite
+ * the terminal of whoever cats the file.
+ *
+ * Control characters are hex-escaped rather than stripped so a name that really
+ * does contain one stays distinguishable from a name that does not.
+ */
+export function safeName(name: string | undefined): string {
+  if (!name) return '';
+  return name.replace(/[\x00-\x1f\x7f]/g, (c) => {
+    return `\\x${c.charCodeAt(0).toString(16).padStart(2, '0')}`;
+  });
+}
+
+/**
  * One-line summary of everything an adapter's `matches()` is allowed to see.
  *
  * Adapter mis-routing was the root cause of #317, #318 and #319, and every one
@@ -252,7 +273,7 @@ export function formatAdvert(address: string, info: BleDeviceInfo): string {
   // to mean anything.
   const parts = [
     `[${address.toUpperCase()}]`,
-    `name=${info.localName ? `"${info.localName}"` : '(none)'}`,
+    `name=${info.localName ? `"${safeName(info.localName)}"` : '(none)'}`,
   ];
   parts.push(`uuids=${uuidList(info.serviceUuids)}`);
   if (info.manufacturerData) {

--- a/src/ble/advertisement.ts
+++ b/src/ble/advertisement.ts
@@ -246,13 +246,25 @@ function blob(data: Buffer): string {
  * reporters are asked to paste into public issues, and ANSI/OSC escapes rewrite
  * the terminal of whoever cats the file.
  *
- * Control characters are hex-escaped rather than stripped so a name that really
- * does contain one stays distinguishable from a name that does not.
+ * Escaped rather than stripped, so a name that really does contain a control
+ * character stays distinguishable from one that does not. That only holds if
+ * the escape character is escaped too - otherwise a name containing the four
+ * literal characters `\x0a` renders identically to one containing a real LF -
+ * so backslash is in the class.
+ *
+ * The class covers more than C0. U+0080..U+009F are the C1 controls, and
+ * xterm-family terminals honour U+009B and U+009D as CSI and OSC introducers
+ * even in UTF-8 mode; a BLE name is UTF-8 decoded by every stack, so those
+ * arrive intact. U+2028 and U+2029 are line breaks to anything that splits on
+ * Unicode newlines rather than on LF.
  */
 export function safeName(name: string | undefined): string {
   if (!name) return '';
-  return name.replace(/[\x00-\x1f\x7f]/g, (c) => {
-    return `\\x${c.charCodeAt(0).toString(16).padStart(2, '0')}`;
+  return name.replace(/[\\\x00-\x1f\x7f-\x9f\u2028\u2029]/g, (c) => {
+    const code = c.charCodeAt(0);
+    return code > 0xff
+      ? `\\u${code.toString(16).padStart(4, '0')}`
+      : `\\x${code.toString(16).padStart(2, '0')}`;
   });
 }
 

--- a/src/ble/handler-esphome-proxy/scan.ts
+++ b/src/ble/handler-esphome-proxy/scan.ts
@@ -234,7 +234,7 @@ export async function scanDevices(
       const adapter = resolveAdapter(info, adapters);
       results.set(address, {
         address,
-        name: info.localName || '',
+        name: safeName(info.localName),
         matchedAdapter: adapter?.name,
       });
     });

--- a/src/ble/handler-esphome-proxy/scan.ts
+++ b/src/ble/handler-esphome-proxy/scan.ts
@@ -3,7 +3,7 @@ import type { EsphomeProxyConfig } from '../../config/schema.js';
 import type { ScanOptions, ScanResult } from '../types.js';
 import { type RawReading, waitForRawReading } from '../shared.js';
 import { resolveAdapter } from '../../scales/resolve.js';
-import { evaluateAdvertisement, GraceTimers, logAdvert } from '../advertisement.js';
+import { evaluateAdvertisement, GraceTimers, logAdvert, safeName } from '../advertisement.js';
 import { bleLog, errMsg, withTimeout, IMPEDANCE_GRACE_MS } from '../types.js';
 import { EsphomeProxyPool } from './pool.js';
 
@@ -118,7 +118,9 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
             if (!adapter) {
               if (!seenAddrs.has(address)) {
                 seenAddrs.add(address);
-                bleLog.debug(`Unmatched device: ${address} (${info.localName || 'no name'})`);
+                bleLog.debug(
+                  `Unmatched device: ${address} (${safeName(info.localName) || 'no name'})`,
+                );
               }
               return;
             }

--- a/src/ble/handler-esphome-proxy/watcher.ts
+++ b/src/ble/handler-esphome-proxy/watcher.ts
@@ -7,7 +7,13 @@ import type {
 import type { EsphomeProxyConfig } from '../../config/schema.js';
 import { type RawReading, waitForRawReading } from '../shared.js';
 import { resolveAdapter } from '../../scales/resolve.js';
-import { evaluateAdvertisement, GraceTimers, DedupWindow, logAdvert } from '../advertisement.js';
+import {
+  evaluateAdvertisement,
+  GraceTimers,
+  DedupWindow,
+  logAdvert,
+  safeName,
+} from '../advertisement.js';
 import type { Watcher, WatcherConfig } from '../reading-source.js';
 import { bleLog, errMsg, IMPEDANCE_GRACE_MS } from '../types.js';
 import { AsyncQueue } from '../async-queue.js';
@@ -79,7 +85,7 @@ export class ReadingWatcher implements Watcher {
     }
     const cached = this.lastAdvertName.get(addrLc);
     if (!cached) return info;
-    bleLog.debug(`Nameless advertisement for ${addrLc}: using cached name "${cached}"`);
+    bleLog.debug(`Nameless advertisement for ${addrLc}: using cached name "${safeName(cached)}"`);
     return { ...info, localName: cached };
   }
   // LRU map (insertion-ordered): scales whose on-demand GATT connect failed,

--- a/src/ble/handler-ha-bluetooth/scan.ts
+++ b/src/ble/handler-ha-bluetooth/scan.ts
@@ -3,7 +3,7 @@ import type { HaBluetoothConfig } from '../../config/schema.js';
 import type { ScanOptions, ScanResult } from '../types.js';
 import type { RawReading } from '../shared.js';
 import { resolveAdapter } from '../../scales/resolve.js';
-import { evaluateAdvertisement, GraceTimers, logAdvert } from '../advertisement.js';
+import { evaluateAdvertisement, GraceTimers, logAdvert, safeName } from '../advertisement.js';
 import { bleLog, withTimeout, IMPEDANCE_GRACE_MS } from '../types.js';
 import { HaBluetoothClient } from './client.js';
 
@@ -94,7 +94,9 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
             if (!adapter) {
               if (!seenAddrs.has(address)) {
                 seenAddrs.add(address);
-                bleLog.debug(`Unmatched device: ${address} (${info.localName || 'no name'})`);
+                bleLog.debug(
+                  `Unmatched device: ${address} (${safeName(info.localName) || 'no name'})`,
+                );
               }
               return;
             }

--- a/src/ble/handler-ha-bluetooth/scan.ts
+++ b/src/ble/handler-ha-bluetooth/scan.ts
@@ -175,7 +175,7 @@ export async function scanDevices(
       // Keep the entry fresh: a later frame may carry the name or match.
       results.set(address, {
         address,
-        name: info.localName || prev?.name || '',
+        name: safeName(info.localName) || prev?.name || '',
         matchedAdapter: adapter?.name ?? prev?.matchedAdapter,
       });
     });

--- a/src/ble/handler-mqtt-proxy/scan.ts
+++ b/src/ble/handler-mqtt-proxy/scan.ts
@@ -8,7 +8,7 @@ import type { ScanOptions, ScanResult } from '../types.js';
 import type { RawReading } from '../shared.js';
 import { waitForRawReading } from '../shared.js';
 import { resolveAdapter } from '../../scales/resolve.js';
-import { evaluateAdvertisement, logAdvert } from '../advertisement.js';
+import { evaluateAdvertisement, logAdvert, safeName } from '../advertisement.js';
 import { bleLog, normalizeUuid, withTimeout, formatMac } from '../types.js';
 import { COMMAND_TIMEOUT_MS, topics, type Topics } from './topics.js';
 import { type MqttClient, createMqttClient } from './client.js';
@@ -155,7 +155,7 @@ export async function scanAndReadRaw(opts: ScanOptions): Promise<RawReading> {
       const adapter = resolveAdapter(info, adapters);
       if (!adapter) continue;
 
-      bleLog.info(`Matched: ${adapter.name} (${entry.name || entry.address})`);
+      bleLog.info(`Matched: ${adapter.name} (${safeName(entry.name) || entry.address})`);
 
       // Classify the advertisement with the shared decision (#242).
       const decision = evaluateAdvertisement(adapter, info);

--- a/src/ble/handler-mqtt-proxy/scan.ts
+++ b/src/ble/handler-mqtt-proxy/scan.ts
@@ -268,7 +268,7 @@ export async function scanDevices(
       const matched = resolveAdapter(info, adapters);
       return {
         address: entry.address,
-        name: entry.name,
+        name: safeName(entry.name),
         matchedAdapter: matched?.name,
       };
     });

--- a/src/ble/handler-mqtt-proxy/watcher.ts
+++ b/src/ble/handler-mqtt-proxy/watcher.ts
@@ -3,7 +3,13 @@ import type { MqttProxyConfig } from '../../config/schema.js';
 import type { RawReading } from '../shared.js';
 import { waitForRawReading } from '../shared.js';
 import { resolveAdapter } from '../../scales/resolve.js';
-import { evaluateAdvertisement, GraceTimers, DedupWindow, logAdvert } from '../advertisement.js';
+import {
+  evaluateAdvertisement,
+  GraceTimers,
+  DedupWindow,
+  logAdvert,
+  safeName,
+} from '../advertisement.js';
 import type { Watcher, WatcherConfig } from '../reading-source.js';
 import { bleLog, withIdleTimeout, withTimeout, errMsg, IMPEDANCE_GRACE_MS } from '../types.js';
 import { AsyncQueue } from '../async-queue.js';
@@ -584,7 +590,9 @@ export class ReadingWatcher implements Watcher {
       info.characteristicUuids = data.chars.map((c) => c.uuid.toLowerCase());
       logAdvert(data.address, info);
       if (cached?.name) {
-        bleLog.debug(`Autonomous connect: using cached advertisement name "${cached.name}"`);
+        bleLog.debug(
+          `Autonomous connect: using cached advertisement name "${safeName(cached.name)}"`,
+        );
       }
       let adapter = resolveAdapter(info, this.adapters);
       if (!adapter) {

--- a/src/ble/handler-noble-shared/discovery.ts
+++ b/src/ble/handler-noble-shared/discovery.ts
@@ -11,6 +11,7 @@ import {
 } from '../types.js';
 import { matchesTarget, parseMfgData, peripheralAddress } from './peripheral.js';
 import type { NobleApi } from './types.js';
+import { safeName } from '../advertisement.js';
 
 /**
  * Discover peripherals via noble's event-driven scanning.
@@ -63,7 +64,7 @@ export function discoverPeripheral(
 
       if (!seen.has(addr)) {
         seen.add(addr);
-        bleLog.debug(`Discovered: ${name || '(no name)'} [${addr}]`);
+        bleLog.debug(`Discovered: ${safeName(name) || '(no name)'} [${addr}]`);
       }
 
       const mfgData = parseMfgData(peripheral.advertisement?.manufacturerData);
@@ -71,7 +72,7 @@ export function discoverPeripheral(
       if (targetMac) {
         // Target mode: match by MAC or CoreBluetooth UUID
         if (!matchesTarget(peripheral, targetMac)) return;
-        bleLog.debug(`Target device matched: ${name} [${addr}]`);
+        bleLog.debug(`Target device matched: ${safeName(name)} [${addr}]`);
 
         cleanup();
 
@@ -88,7 +89,7 @@ export function discoverPeripheral(
         const matched = resolveAdapter(info, adapters);
         if (!matched) return;
 
-        bleLog.info(`Auto-discovered: ${matched.name} (${name} [${addr}])`);
+        bleLog.info(`Auto-discovered: ${matched.name} (${safeName(name)} [${addr}])`);
 
         cleanup();
 

--- a/src/ble/handler-noble-shared/index.ts
+++ b/src/ble/handler-noble-shared/index.ts
@@ -28,6 +28,7 @@ import { connectWithRetries } from './connect.js';
 import { discoverPeripheral } from './discovery.js';
 import { broadcastScan } from './broadcast.js';
 import type { NobleHandlerDeps } from './types.js';
+import { safeName } from '../advertisement.js';
 
 export type { NobleApi, NobleHandlerDeps } from './types.js';
 
@@ -192,7 +193,7 @@ export function createNobleHandler({ noble, getState }: NobleHandlerDeps) {
           const found = resolveAdapter(info, adapters);
           if (!found) {
             throw new Error(
-              `Device found (${name}) but no adapter recognized it. ` +
+              `Device found (${safeName(name)}) but no adapter recognized it. ` +
                 `Services: [${serviceUuids.join(', ')}]. ` +
                 `Adapters: ${adapters.map((a) => a.name).join(', ')}`,
             );
@@ -279,7 +280,7 @@ export function createNobleHandler({ noble, getState }: NobleHandlerDeps) {
 
       results.push({
         address: addr,
-        name: localName || '(unknown)',
+        name: safeName(localName) || '(unknown)',
         matchedAdapter: matched?.name,
       });
     };

--- a/src/ble/handler-node-ble/discovery.ts
+++ b/src/ble/handler-node-ble/discovery.ts
@@ -20,6 +20,7 @@ import {
   parseHciIndex,
   currentConnectionGeneration,
 } from './connection.js';
+import { safeName } from '../advertisement.js';
 
 /**
  * Which adapters have a scan running that WE started with the duplicate filter
@@ -398,7 +399,7 @@ export async function autoDiscover(
         const name = await dev.getName().catch(() => '');
         if (!name) continue;
 
-        bleLog.debug(`Discovered: ${name} [${addr}]`);
+        bleLog.debug(`Discovered: ${safeName(name)} [${addr}]`);
 
         // Match on the name plus whatever the advertisement exposes. BlueZ does
         // not publish advertised service UUIDs before a connection, so an
@@ -421,7 +422,7 @@ export async function autoDiscover(
         };
         const matched = resolveAdapter(info, adapters);
         if (matched) {
-          bleLog.info(`Auto-discovered: ${matched.name} (${name} [${addr}])`);
+          bleLog.info(`Auto-discovered: ${matched.name} (${safeName(name)} [${addr}])`);
           matchedDevice = true;
           return { device: dev, adapter: matched, mac: addr };
         }

--- a/src/ble/handler-node-ble/scan-stages.ts
+++ b/src/ble/handler-node-ble/scan-stages.ts
@@ -290,7 +290,7 @@ export async function resolveAfterConnect(
   }
   if (!resolved) {
     throw new Error(
-      `Device found (${name}) but no adapter recognized it. ` +
+      `Device found (${safeName(name)}) but no adapter recognized it. ` +
         `Services: [${serviceUuids.join(', ')}]. ` +
         `Adapters: ${adapters.map((a) => a.name).join(', ')}`,
     );

--- a/src/ble/handler-node-ble/scan-stages.ts
+++ b/src/ble/handler-node-ble/scan-stages.ts
@@ -49,6 +49,7 @@ import type { ScaleAuth, ScaleReading, UserProfile } from '../../interfaces/scal
 import { RAW_READING_TIMEOUT_MS, READING_SESSION_CAP_FACTOR, withIdleTimeout } from '../types.js';
 import { tagBleFailure, bleFailureKind } from '../failure-kind.js';
 import { probeLiveness, makeLivenessAdapter } from './liveness.js';
+import { safeName } from '../advertisement.js';
 
 /**
  * Acquire the BlueZ adapter, resetting a stale D-Bus connection once.
@@ -197,7 +198,7 @@ export async function resolvePreConnectAdapter(
   preMatchedAdapter: ScaleAdapter | undefined;
 }> {
   const name = await device.getName().catch(() => '');
-  bleLog.debug(`Found device: ${name} [${mac}]`);
+  bleLog.debug(`Found device: ${safeName(name)} [${mac}]`);
   // Only chance to capture the advertisement: BlueZ drops it (and for some
   // peers the whole Device object) once discovery stops (#297).
   const advert = await logAdvertisementSnapshot(device);

--- a/src/config/write.ts
+++ b/src/config/write.ts
@@ -1,4 +1,11 @@
-import { readFileSync, writeFileSync, renameSync, unlinkSync, existsSync } from 'node:fs';
+import {
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  unlinkSync,
+  existsSync,
+  chmodSync,
+} from 'node:fs';
 import { parseDocument } from 'yaml';
 import { createLogger } from '../logger.js';
 import { errMsg } from '../utils/error.js';
@@ -8,6 +15,20 @@ const log = createLogger('ConfigWrite');
 // --- Atomic file write ---
 
 /**
+ * Mode for files this module writes.
+ *
+ * config.yaml holds the Garmin password and every exporter token in plaintext,
+ * so the wizard chmods it to 0600 after saving. The rename below replaces the
+ * file, and with it the mode: without an explicit mode the tmp file is created
+ * 0666 & ~umask, i.e. usually 0644, and that mode is what survives. The wizard
+ * only chmods once, at save time, but updateLastKnownWeight() calls this on
+ * every non-dry weigh-in - so the first export after setup silently made the
+ * credentials world-readable, permanently. The tmp file needs it too: it holds
+ * the same content, briefly, under a predictable name.
+ */
+const SECRET_FILE_MODE = 0o600;
+
+/**
  * Write content to a file atomically via tmp+rename.
  * Falls back to direct overwrite when the target is a Docker bind mount
  * (which cannot be unlinked/renamed over — EBUSY).
@@ -15,7 +36,7 @@ const log = createLogger('ConfigWrite');
 export function atomicWrite(filePath: string, content: string): void {
   const tmpPath = filePath + '.tmp';
   try {
-    writeFileSync(tmpPath, content, 'utf8');
+    writeFileSync(tmpPath, content, { encoding: 'utf8', mode: SECRET_FILE_MODE });
     try {
       if (existsSync(filePath)) unlinkSync(filePath);
       renameSync(tmpPath, filePath);
@@ -24,6 +45,14 @@ export function atomicWrite(filePath: string, content: string): void {
       if (code === 'EBUSY' || code === 'EPERM' || code === 'EXDEV') {
         // Docker bind mount, Windows EPERM, cross-device rename: overwrite directly
         writeFileSync(filePath, content, 'utf8');
+        // writeFileSync applies `mode` only when it CREATES the file, and this
+        // branch exists precisely because the target already exists. The rename
+        // path above needs no chmod: it carries the tmp file's mode with it.
+        try {
+          chmodSync(filePath, SECRET_FILE_MODE);
+        } catch {
+          // Best effort: some filesystems (and Windows) do not honour it.
+        }
         try {
           unlinkSync(tmpPath);
         } catch {

--- a/src/diagnose.ts
+++ b/src/diagnose.ts
@@ -3,6 +3,7 @@ import { loadBleConfig } from './config/load.js';
 import { createLogger } from './logger.js';
 import { sleep, withTimeout, errMsg } from './ble/types.js';
 import { rethrowAsTransportError } from './ble/transport-availability.js';
+import { safeName } from './ble/advertisement.js';
 import type { HandlerKey } from './ble/transport-availability.js';
 
 const log = createLogger('Diagnose');
@@ -146,7 +147,7 @@ async function main(): Promise<void> {
     const marker = isTarget ? ' <<<' : '';
 
     log.info(
-      `  ${rawAddr}  ${name || '(no name)'}  RSSI=${rssi}  ` +
+      `  ${rawAddr}  ${safeName(name) || '(no name)'}  RSSI=${rssi}  ` +
         `${connectable ? 'connectable' : 'broadcast-only'}  type=${addrType}${marker}`,
     );
     if (svcUuids.length > 0) {

--- a/src/exporters/strava-setup.ts
+++ b/src/exporters/strava-setup.ts
@@ -95,7 +95,13 @@ async function main(): Promise<void> {
     });
 
     if (!response.ok) {
-      const body = await response.text();
+      // Bound the upstream body. This is the one path that has just transmitted
+      // client_secret, and the log is routinely pasted into public issues.
+      // Strava does not echo the secret back today, so this is hardening rather
+      // than a fix - but an unbounded verbatim dump of a response body is not
+      // something to rely on a third party's discretion for. Same cap and same
+      // reasoning as notification-message.ts.
+      const body = [...(await response.text())].slice(0, 200).join('');
       log.error(`Token exchange failed: HTTP ${response.status}`);
       log.error(body);
       process.exit(1);

--- a/src/exporters/strava-setup.ts
+++ b/src/exporters/strava-setup.ts
@@ -99,8 +99,10 @@ async function main(): Promise<void> {
       // client_secret, and the log is routinely pasted into public issues.
       // Strava does not echo the secret back today, so this is hardening rather
       // than a fix - but an unbounded verbatim dump of a response body is not
-      // something to rely on a third party's discretion for. Same cap and same
-      // reasoning as notification-message.ts.
+      // something to rely on a third party's discretion for. Same reasoning as
+      // notification-message.ts, which caps forwarded error text at 120; 200
+      // here because this body is read by the person debugging their own setup,
+      // not forwarded to a channel.
       const body = [...(await response.text())].slice(0, 200).join('');
       log.error(`Token exchange failed: HTTP ${response.status}`);
       log.error(body);

--- a/src/runtime/file-heartbeat.ts
+++ b/src/runtime/file-heartbeat.ts
@@ -36,10 +36,16 @@ let timer: ReturnType<typeof setInterval> | null = null;
  *
  * O_NOFOLLOW is the point. The path is fixed and world-predictable, it lives in
  * a world-writable directory, and it is rewritten every 30 s with every error
- * swallowed. A local user on a shared host could pre-create it as a symlink to
- * any file this process can write - config.yaml, a crontab, an authorized_keys
- * - and each tick would follow the link and truncate the target, silently. With
- * O_NOFOLLOW the open fails with ELOOP instead and the tick is simply skipped.
+ * swallowed - so if a local user could plant a symlink here, each tick would
+ * follow it and truncate the target in silence.
+ *
+ * Defence in depth rather than a live hole: on the supported deployments the
+ * kernel already refuses that. Debian and Raspberry Pi OS ship
+ * `fs.protected_symlinks=1`, which will not follow a symlink in a sticky
+ * directory owned by another uid, and `fs.protected_regular=1`, which refuses
+ * O_CREAT on another user's file there; Docker and the HA add-on get a private
+ * /tmp. What is left is a multi-user host with that hardening switched off. The
+ * flag costs nothing, so it is not worth relying on someone else's sysctl.
  *
  * The path cannot move: the Docker HEALTHCHECK reads it by name.
  *

--- a/src/runtime/file-heartbeat.ts
+++ b/src/runtime/file-heartbeat.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from 'node:fs';
+import { writeFileSync, openSync, closeSync, constants } from 'node:fs';
 
 /**
  * Liveness heartbeat file consumed by the Docker HEALTHCHECK (#277).
@@ -31,12 +31,40 @@ const DEFAULT_INTERVAL_MS = 30_000;
 
 let timer: ReturnType<typeof setInterval> | null = null;
 
+/**
+ * Open flags for the heartbeat file.
+ *
+ * O_NOFOLLOW is the point. The path is fixed and world-predictable, it lives in
+ * a world-writable directory, and it is rewritten every 30 s with every error
+ * swallowed. A local user on a shared host could pre-create it as a symlink to
+ * any file this process can write - config.yaml, a crontab, an authorized_keys
+ * - and each tick would follow the link and truncate the target, silently. With
+ * O_NOFOLLOW the open fails with ELOOP instead and the tick is simply skipped.
+ *
+ * The path cannot move: the Docker HEALTHCHECK reads it by name.
+ *
+ * O_NOFOLLOW is POSIX-only; on Windows the constant is undefined, so it falls
+ * back to 0 and the flags stay valid.
+ */
+const HEARTBEAT_FLAGS =
+  constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | (constants.O_NOFOLLOW ?? 0);
+
 /** Write the heartbeat file. Never throws (e.g. /tmp is not writable on Windows). */
 export function touchHeartbeat(): void {
+  let fd: number | undefined;
   try {
-    writeFileSync(HEARTBEAT_PATH, new Date().toISOString());
+    fd = openSync(HEARTBEAT_PATH, HEARTBEAT_FLAGS, 0o644);
+    writeFileSync(fd, new Date().toISOString());
   } catch {
     // ignore
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        // ignore
+      }
+    }
   }
 }
 

--- a/src/wizard/non-interactive.ts
+++ b/src/wizard/non-interactive.ts
@@ -9,8 +9,11 @@ import { createLogger } from '../logger.js';
 const log = createLogger('Wizard');
 
 /**
- * Non-interactive mode: load existing YAML, validate, auto-generate missing slugs,
- * resolve ${ENV_VAR} references, and write back atomically.
+ * Non-interactive mode: load existing YAML, validate, auto-generate missing
+ * slugs, and write back atomically.
+ *
+ * `${ENV_VAR}` references are resolved for VALIDATION ONLY. Nothing resolved
+ * may reach the file: see the write-back below.
  */
 export async function runNonInteractive(configPath: string): Promise<void> {
   log.info(`Validating ${configPath} (non-interactive mode)...`);
@@ -59,15 +62,23 @@ export async function runNonInteractive(configPath: string): Promise<void> {
     `  Exporters: ${(result.data.global_exporters ?? []).length} global, ${result.data.users.reduce((sum, u) => sum + (u.exporters ?? []).length, 0)} per-user`,
   );
 
-  // Check if Zod applied any defaults that differ from the original
-  const enriched = JSON.stringify(result.data) !== JSON.stringify(resolved);
-
-  // Write back if slugs were auto-generated or Zod enriched defaults
-  if (modified || enriched) {
-    const output = stringifyYaml(modified ? parsed : result.data, { lineWidth: 0 });
-    atomicWrite(configPath, output);
-    log.info(
-      `Updated ${configPath}${modified ? ' with auto-generated slugs' : ' with schema defaults'}.`,
-    );
+  // Write back ONLY the tree that was read from disk, and only when this run
+  // actually changed something in it.
+  //
+  // This used to also write when Zod had merely filled in defaults, and it
+  // wrote `result.data` for that case - a tree derived from `resolved`, i.e.
+  // with every `${ENV_VAR}` replaced by the real secret. The Garmin password,
+  // the MQTT password, every exporter token the user had deliberately kept in
+  // .env was inlined into config.yaml in plaintext, permanently, and the
+  // indirection that keeps secrets out of the file people back up and paste
+  // into issues was gone. It fired on essentially every hand-written config,
+  // because the schema fills defaults (device_id, topic_prefix, out_of_range,
+  // runtime.*) that a hand-written file does not carry.
+  //
+  // Materialising defaults into the file was only ever cosmetic: the schema
+  // applies them on every load regardless. So it is dropped rather than fixed.
+  if (modified) {
+    atomicWrite(configPath, stringifyYaml(parsed, { lineWidth: 0 }));
+    log.info(`Updated ${configPath} with auto-generated slugs.`);
   }
 }

--- a/tests/config/atomic-write-fallback.test.ts
+++ b/tests/config/atomic-write-fallback.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+// The Docker file-mount setup documented in the README cannot be renamed over
+// (EBUSY), so atomicWrite takes its in-place branch. writeFileSync applies
+// `mode` only when it CREATES the file, and that branch exists precisely
+// because the file already exists - so without the explicit chmod the mode
+// stays whatever the existing file had, which is the 0644 this whole fix is
+// about.
+//
+// This lives in its own file because it has to mock node:fs at module scope.
+// vi.spyOn(fs, 'renameSync') does NOT work here: the ESM module namespace is
+// not configurable, so it throws "Cannot redefine property" on Linux. It threw
+// only in CI, because the assertions are skipped on Windows.
+let renameThrows: NodeJS.ErrnoException | null = null;
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import('node:fs');
+  return {
+    ...actual,
+    renameSync: (...args: Parameters<typeof actual.renameSync>) => {
+      if (renameThrows) throw renameThrows;
+      return actual.renameSync(...args);
+    },
+  };
+});
+
+const { mkdtempSync, writeFileSync, statSync, rmSync, readFileSync } = await import('node:fs');
+const { tmpdir } = await import('node:os');
+const { join } = await import('node:path');
+const { atomicWrite } = await import('../../src/config/write.js');
+
+const dirs: string[] = [];
+function tempDir(): string {
+  const d = mkdtempSync(join(tmpdir(), 'bss-aw-'));
+  dirs.push(d);
+  return d;
+}
+
+afterEach(() => {
+  renameThrows = null;
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe('atomicWrite in-place fallback', () => {
+  it.skipIf(process.platform === 'win32')('chmods to 0600 when the rename is refused', () => {
+    const dir = tempDir();
+    const file = join(dir, 'config.yaml');
+    writeFileSync(file, 'version: 1\n', { mode: 0o644 });
+
+    const err = new Error('EBUSY: resource busy or locked') as NodeJS.ErrnoException;
+    err.code = 'EBUSY';
+    renameThrows = err;
+
+    atomicWrite(file, 'version: 1\nusers: []\n');
+
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+    expect(readFileSync(file, 'utf8')).toContain('users: []');
+  });
+
+  it.skipIf(process.platform === 'win32')('removes the tmp file on the fallback path', () => {
+    const dir = tempDir();
+    const file = join(dir, 'config.yaml');
+    writeFileSync(file, 'version: 1\n', { mode: 0o644 });
+
+    const err = new Error('EPERM: operation not permitted') as NodeJS.ErrnoException;
+    err.code = 'EPERM';
+    renameThrows = err;
+
+    atomicWrite(file, 'version: 1\n');
+
+    expect(() => statSync(file + '.tmp')).toThrow();
+  });
+
+  it('rethrows a rename failure it does not know how to fall back from', () => {
+    const dir = tempDir();
+    const file = join(dir, 'config.yaml');
+    writeFileSync(file, 'version: 1\n');
+
+    const err = new Error('ENOSPC: no space left on device') as NodeJS.ErrnoException;
+    err.code = 'ENOSPC';
+    renameThrows = err;
+
+    expect(() => atomicWrite(file, 'version: 2\n')).toThrow(/ENOSPC/);
+    // And the tmp file is cleaned up rather than left behind.
+    expect(() => statSync(file + '.tmp')).toThrow();
+  });
+});

--- a/tests/runtime/file-heartbeat.test.ts
+++ b/tests/runtime/file-heartbeat.test.ts
@@ -1,11 +1,24 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { constants as fsConstants } from 'node:fs';
 
 // Mock node:fs before importing the module under test so the vi.fn() instance
-// is the one the module captures via writeFileSync.
+// is the one the module captures.
+//
+// The heartbeat opens the file itself rather than letting writeFileSync resolve
+// the path, so it can pass O_NOFOLLOW; the write then targets the fd. `constants`
+// has to be real, because the module folds the flags at import time.
 const writeFileSyncMock = vi.fn();
-vi.mock('node:fs', () => ({
-  writeFileSync: (...args: unknown[]) => writeFileSyncMock(...args),
-}));
+const openSyncMock = vi.fn(() => 7);
+const closeSyncMock = vi.fn();
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import('node:fs');
+  return {
+    constants: actual.constants,
+    writeFileSync: (...args: unknown[]) => writeFileSyncMock(...args),
+    openSync: (...args: unknown[]) => openSyncMock(...(args as [])),
+    closeSync: (...args: unknown[]) => closeSyncMock(...args),
+  };
+});
 
 import {
   touchHeartbeat,
@@ -19,6 +32,9 @@ const HEARTBEAT_PATH = '/tmp/.ble-scale-sync-heartbeat';
 describe('file-heartbeat (#277)', () => {
   beforeEach(() => {
     writeFileSyncMock.mockReset();
+    openSyncMock.mockReset();
+    openSyncMock.mockReturnValue(7);
+    closeSyncMock.mockReset();
     _resetForTesting();
     vi.useFakeTimers();
   });
@@ -30,8 +46,45 @@ describe('file-heartbeat (#277)', () => {
 
   it('touchHeartbeat() writes the heartbeat file', () => {
     touchHeartbeat();
+    expect(openSyncMock).toHaveBeenCalledTimes(1);
+    expect(openSyncMock.mock.calls[0][0]).toBe(HEARTBEAT_PATH);
     expect(writeFileSyncMock).toHaveBeenCalledTimes(1);
-    expect(writeFileSyncMock.mock.calls[0][0]).toBe(HEARTBEAT_PATH);
+    // The write targets the fd from openSync, not the path: that is what makes
+    // the O_NOFOLLOW check above the one that decides where the bytes land.
+    expect(writeFileSyncMock.mock.calls[0][0]).toBe(7);
+  });
+
+  // The path is fixed, world-predictable, in a world-writable directory, and
+  // rewritten every 30s with every error swallowed. A local user could
+  // pre-create it as a symlink to any file this process can write - config.yaml,
+  // a crontab, an authorized_keys - and each tick would follow it and truncate
+  // the target. O_NOFOLLOW makes the open fail with ELOOP instead.
+  it.skipIf(process.platform === 'win32')(
+    'opens with O_NOFOLLOW so a symlink cannot be followed',
+    () => {
+      touchHeartbeat();
+      const flags = openSyncMock.mock.calls[0][1] as number;
+      expect(flags & fsConstants.O_NOFOLLOW).toBe(fsConstants.O_NOFOLLOW);
+      expect(flags & fsConstants.O_CREAT).toBe(fsConstants.O_CREAT);
+      expect(flags & fsConstants.O_TRUNC).toBe(fsConstants.O_TRUNC);
+    },
+  );
+
+  it('closes the descriptor even when the write throws', () => {
+    writeFileSyncMock.mockImplementationOnce(() => {
+      throw new Error('EACCES');
+    });
+    expect(() => touchHeartbeat()).not.toThrow();
+    expect(closeSyncMock).toHaveBeenCalledWith(7);
+  });
+
+  it('skips the tick when the open itself fails (ELOOP on a planted symlink)', () => {
+    openSyncMock.mockImplementationOnce(() => {
+      throw new Error('ELOOP');
+    });
+    expect(() => touchHeartbeat()).not.toThrow();
+    expect(writeFileSyncMock).not.toHaveBeenCalled();
+    expect(closeSyncMock).not.toHaveBeenCalled();
   });
 
   it('touchHeartbeat() swallows a write error (/tmp not writable on Windows)', () => {

--- a/tests/security-hardening.test.ts
+++ b/tests/security-hardening.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, statSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { atomicWrite } from '../src/config/write.js';
+import { safeName } from '../src/ble/advertisement.js';
+
+// Defects found in a security review of src/. Each test names the attacker and
+// asserts the specific thing that used to go wrong, not a general property.
+
+const ESC = String.fromCharCode(0x1b);
+
+const dirs: string[] = [];
+function tempDir(): string {
+  const d = mkdtempSync(join(tmpdir(), 'bss-sec-'));
+  dirs.push(d);
+  return d;
+}
+
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe('atomicWrite file mode', () => {
+  // config.yaml holds the Garmin password and every exporter token in plaintext.
+  // The wizard chmods it 0600 once, at save time - but updateLastKnownWeight()
+  // calls atomicWrite on every non-dry weigh-in, and the rename replaced the
+  // file along with its mode. The first export after setup therefore made the
+  // credentials readable by any other local user, permanently.
+  //
+  // Attacker: another UID on the same host - a second user on a shared Pi, or a
+  // sidecar container sharing the volume.
+  it.skipIf(process.platform === 'win32')('keeps a 0600 target at 0600 when rewritten', () => {
+    const dir = tempDir();
+    const file = join(dir, 'config.yaml');
+    writeFileSync(file, 'version: 1\n', { mode: 0o600 });
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+
+    atomicWrite(file, 'version: 1\nusers: []\n');
+
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+    expect(readFileSync(file, 'utf8')).toContain('users: []');
+  });
+
+  it.skipIf(process.platform === 'win32')('creates a new file 0600, not 0644', () => {
+    const dir = tempDir();
+    const file = join(dir, 'fresh.yaml');
+    atomicWrite(file, 'version: 1\n');
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+  });
+});
+
+describe('safeName', () => {
+  // The BLE local name arrives unfiltered from anyone with a radio in range, or
+  // from anyone who can publish to a proxy topic, and it is logged for EVERY
+  // advertisement seen during a scan - matched or not, so nothing gates it. A
+  // crafted name carrying CR/LF forges log lines in journald or docker logs,
+  // which is exactly what reporters are asked to paste into public issues.
+  it('escapes CR and LF so a crafted name cannot forge a log line', () => {
+    const forged = 'Scale\r\n[FAKE] Matched: Garmin (00:11:22:33:44:55)';
+    const out = safeName(forged);
+    expect(out).not.toContain('\n');
+    expect(out).not.toContain('\r');
+    expect(out).toContain('\\x0d\\x0a');
+  });
+
+  it('escapes ANSI escape sequences so a log cannot rewrite the terminal', () => {
+    const out = safeName(`Scale${ESC}[2J${ESC}]0;pwned`);
+    expect(out).not.toContain(ESC);
+    expect(out).toContain('\\x1b');
+  });
+
+  it('escapes NUL and DEL', () => {
+    const out = safeName(`a${String.fromCharCode(0)}b${String.fromCharCode(0x7f)}c`);
+    expect(out).toBe('a\\x00b\\x7fc');
+  });
+
+  it('leaves an ordinary name untouched, multibyte included', () => {
+    expect(safeName('QN-Scale')).toBe('QN-Scale');
+    expect(safeName('Vaha c. 2 µ')).toBe('Vaha c. 2 µ');
+  });
+
+  it('maps a missing name to the empty string', () => {
+    expect(safeName(undefined)).toBe('');
+    expect(safeName('')).toBe('');
+  });
+});

--- a/tests/security-hardening.test.ts
+++ b/tests/security-hardening.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { mkdtempSync, writeFileSync, statSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -48,41 +48,6 @@ describe('atomicWrite file mode', () => {
     atomicWrite(file, 'version: 1\n');
     expect(statSync(file).mode & 0o777).toBe(0o600);
   });
-
-  // The Docker file-mount setup documented in the README cannot be renamed over
-  // (EBUSY), so it takes the in-place branch. writeFileSync applies `mode` only
-  // when it CREATES the file, and that branch exists precisely because the file
-  // already exists - so without the explicit chmod the mode is whatever the
-  // existing file had.
-  it.skipIf(process.platform === 'win32')(
-    'chmods to 0600 on the in-place fallback path',
-    async () => {
-      const fs = await import('node:fs');
-      const dir = tempDir();
-      const file = join(dir, 'config.yaml');
-      writeFileSync(file, 'version: 1\n', { mode: 0o644 });
-
-      const spy = vi.spyOn(fs, 'renameSync').mockImplementation(() => {
-        const err = new Error('EBUSY: resource busy or locked') as NodeJS.ErrnoException;
-        err.code = 'EBUSY';
-        throw err;
-      });
-      try {
-        atomicWrite(file, 'version: 1\nusers: []\n');
-      } finally {
-        spy.mockRestore();
-      }
-
-      // Without this the test is worthless: if the spy does not reach the
-      // binding atomicWrite closed over, the rename SUCCEEDS, the mode comes
-      // from the 0600 tmp file, and the assertion below passes while the
-      // fallback branch never runs. Fail loudly instead.
-      expect(spy).toHaveBeenCalled();
-
-      expect(statSync(file).mode & 0o777).toBe(0o600);
-      expect(readFileSync(file, 'utf8')).toContain('users: []');
-    },
-  );
 });
 
 describe('safeName', () => {

--- a/tests/security-hardening.test.ts
+++ b/tests/security-hardening.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { mkdtempSync, writeFileSync, statSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -48,6 +48,41 @@ describe('atomicWrite file mode', () => {
     atomicWrite(file, 'version: 1\n');
     expect(statSync(file).mode & 0o777).toBe(0o600);
   });
+
+  // The Docker file-mount setup documented in the README cannot be renamed over
+  // (EBUSY), so it takes the in-place branch. writeFileSync applies `mode` only
+  // when it CREATES the file, and that branch exists precisely because the file
+  // already exists - so without the explicit chmod the mode is whatever the
+  // existing file had.
+  it.skipIf(process.platform === 'win32')(
+    'chmods to 0600 on the in-place fallback path',
+    async () => {
+      const fs = await import('node:fs');
+      const dir = tempDir();
+      const file = join(dir, 'config.yaml');
+      writeFileSync(file, 'version: 1\n', { mode: 0o644 });
+
+      const spy = vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+        const err = new Error('EBUSY: resource busy or locked') as NodeJS.ErrnoException;
+        err.code = 'EBUSY';
+        throw err;
+      });
+      try {
+        atomicWrite(file, 'version: 1\nusers: []\n');
+      } finally {
+        spy.mockRestore();
+      }
+
+      // Without this the test is worthless: if the spy does not reach the
+      // binding atomicWrite closed over, the rename SUCCEEDS, the mode comes
+      // from the 0600 tmp file, and the assertion below passes while the
+      // fallback branch never runs. Fail loudly instead.
+      expect(spy).toHaveBeenCalled();
+
+      expect(statSync(file).mode & 0o777).toBe(0o600);
+      expect(readFileSync(file, 'utf8')).toContain('users: []');
+    },
+  );
 });
 
 describe('safeName', () => {
@@ -73,6 +108,36 @@ describe('safeName', () => {
   it('escapes NUL and DEL', () => {
     const out = safeName(`a${String.fromCharCode(0)}b${String.fromCharCode(0x7f)}c`);
     expect(out).toBe('a\\x00b\\x7fc');
+  });
+
+  // C1 controls: xterm-family terminals honour U+009B as CSI and U+009D as OSC
+  // even in UTF-8 mode, and a BLE name is UTF-8 decoded by every stack, so the
+  // two-byte encoding arrives intact. A C0-only class lets these straight
+  // through.
+  it('escapes the C1 controls, including the 8-bit CSI and OSC introducers', () => {
+    const out = safeName(`Scale${String.fromCharCode(0x9b)}2J${String.fromCharCode(0x9d)}0;x`);
+    expect(out).not.toContain(String.fromCharCode(0x9b));
+    expect(out).not.toContain(String.fromCharCode(0x9d));
+    expect(out).toContain('\\x9b');
+    expect(out).toContain('\\x9d');
+  });
+
+  // Anything that splits on Unicode newlines rather than on LF treats these as
+  // line breaks, so they can still break a pasted log line apart.
+  it('escapes the Unicode line and paragraph separators', () => {
+    const out = safeName(`a${String.fromCharCode(0x2028)}b${String.fromCharCode(0x2029)}c`);
+    expect(out).toBe('a\\u2028b\\u2029c');
+  });
+
+  // Without escaping the escape character, a name containing the four literal
+  // characters \x0a renders identically to one containing a real LF - so the
+  // "stays distinguishable" property the function claims would not hold.
+  it('escapes the backslash so an escaped name is unambiguous', () => {
+    // Escaped through the same \xNN form as everything else in the class, so a
+    // real LF and a literal "\x0a" can never render alike.
+    expect(safeName('a\nb')).toBe('a\\x0ab');
+    expect(safeName('a\\x0ab')).toBe('a\\x5cx0ab');
+    expect(safeName('a\\x0ab')).not.toBe(safeName('a\nb'));
   });
 
   it('leaves an ordinary name untouched, multibyte included', () => {

--- a/tests/wizard/non-interactive-secrets.test.ts
+++ b/tests/wizard/non-interactive-secrets.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runNonInteractive } from '../../src/wizard/non-interactive.js';
+
+// `setup --non-interactive` used to write back `result.data` whenever the schema
+// had merely filled in defaults - and `result.data` is derived from the tree
+// with every `${ENV_VAR}` already replaced by its real value. The Garmin
+// password, the MQTT password, every exporter token the user had deliberately
+// kept in .env was inlined into config.yaml in plaintext, permanently.
+//
+// It fired on essentially every hand-written config, because the schema fills
+// defaults (device_id, topic_prefix, out_of_range, runtime.*) that a
+// hand-written file does not carry.
+
+const SECRET = 'correct-horse-battery-staple';
+
+const dirs: string[] = [];
+function tempConfig(body: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'bss-ni-'));
+  dirs.push(dir);
+  const p = join(dir, 'config.yaml');
+  writeFileSync(p, body);
+  return p;
+}
+
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  delete process.env.TEST_MQTT_PASSWORD;
+  vi.restoreAllMocks();
+});
+
+const CONFIG = `version: 1
+users:
+  - name: Dad
+    slug: dad
+    height: 180
+    birth_date: '1990-01-01'
+    gender: male
+    is_athlete: false
+    weight_range:
+      min: 60
+      max: 110
+    exporters:
+      - type: mqtt
+        host: localhost
+        username: dad
+        password: \${TEST_MQTT_PASSWORD}
+`;
+
+describe('runNonInteractive secret handling', () => {
+  it('never writes a resolved ${ENV_VAR} back into config.yaml', async () => {
+    process.env.TEST_MQTT_PASSWORD = SECRET;
+    const path = tempConfig(CONFIG);
+
+    await runNonInteractive(path);
+
+    const after = readFileSync(path, 'utf8');
+    expect(after).not.toContain(SECRET);
+    expect(after).toContain('${TEST_MQTT_PASSWORD}');
+  });
+
+  it('still auto-generates a missing slug, and still without the secret', async () => {
+    process.env.TEST_MQTT_PASSWORD = SECRET;
+    const path = tempConfig(CONFIG.replace('    slug: dad\n', ''));
+
+    await runNonInteractive(path);
+
+    const after = readFileSync(path, 'utf8');
+    expect(after).toContain('slug: dad');
+    expect(after).not.toContain(SECRET);
+    expect(after).toContain('${TEST_MQTT_PASSWORD}');
+  });
+
+  it('leaves a config that needs no change byte-for-byte alone', async () => {
+    // The old code rewrote the file whenever the schema had filled a default,
+    // which is almost always - so comments and formatting were lost too.
+    process.env.TEST_MQTT_PASSWORD = SECRET;
+    const path = tempConfig(`# my notes\n${CONFIG}`);
+    const before = readFileSync(path, 'utf8');
+
+    await runNonInteractive(path);
+
+    expect(readFileSync(path, 'utf8')).toBe(before);
+  });
+});


### PR DESCRIPTION
Five findings from a defensive security review of `src/`. None is remotely exploitable on its own; the first is the one that matters.

## 1. `setup --non-interactive` inlined every secret into `config.yaml`

The write-back fired on two conditions: slugs were generated, **or the schema had filled in defaults**. The second case wrote `result.data` - a tree derived from the *resolved* config, with every `${ENV_VAR}` already replaced by its real value.

The Garmin password, the MQTT password, every exporter token the user had deliberately kept in `.env` was inlined into `config.yaml` in plaintext, permanently. The whole point of the `${VAR}` indirection - keeping secrets out of the file people back up and paste into issues - was gone.

It fired on **essentially every hand-written config**, because the schema fills defaults (`device_id`, `topic_prefix`, `out_of_range`, `runtime.*`) that a hand-written file does not carry.

Materialising defaults into the file was only ever cosmetic - the schema applies them on every load regardless - so that branch is dropped rather than repaired. The remaining write-back serialises `parsed`, the tree read from disk, which cannot contain a resolved reference. Side benefit: a run with nothing to change no longer reformats the file and drops the user's comments.

## 2. `atomicWrite` stripped `0600` off `config.yaml` on the first weigh-in

The tmp file was created with no mode, so it landed at `0666 & ~umask` (usually 0644), and the rename carried that mode onto the target. The wizard chmods `config.yaml` to 0600 once, at save time - but `updateLastKnownWeight()` calls `atomicWrite` on **every non-dry weigh-in**. So the first export after setup made the credentials readable by any other local UID, permanently.

The tmp file needs the mode too (same content, predictable name). The EBUSY/EPERM fallback additionally needs an explicit `chmod`, because `writeFileSync` applies `mode` only when it *creates* the file - and that branch exists precisely because the target already exists.

## 3. Heartbeat followed a symlink in `/tmp`

Fixed, world-predictable path in a world-writable directory, rewritten every 30 s with every error swallowed. A local user could pre-create it as a symlink to any file this process can write - `config.yaml`, a crontab, an `authorized_keys` - and each tick would follow it and truncate the target.

The path cannot move (the Docker HEALTHCHECK reads it by name), so the open now carries `O_NOFOLLOW`; an ELOOP simply skips the tick.

## 4. Log injection from an attacker-controlled BLE name

The local name arrives unfiltered from anyone with a radio in range, or anyone who can publish to a proxy topic, and **no producer in the tree filtered it**. It is logged for every advertisement seen during a scan, matched or not, so nothing gates it.

A crafted name carrying CR/LF forges convincing log lines in journald or docker logs - exactly what reporters are asked to paste into public issues - and ANSI/OSC escapes rewrite the terminal of whoever `cat`s the file.

`safeName()` hex-escapes control characters rather than stripping them, so a name that really does contain one stays distinguishable. Applied at all **eleven** sites across the four transports. Adapter names are our own constants and are left alone.

## 5. Strava OAuth logged the raw upstream body

Hardening, not a live leak: Strava does not echo `client_secret` back today. But this is the one path that has just transmitted it, and an unbounded verbatim dump of a third party's response body is not something to leave to their discretion. Same cap and reasoning as `notification-message.ts`.

## Scope of #2 and #3

Both are reachable only by another local user on a shared host. A single-user Pi, or a container with a private `/tmp`, is unaffected.

## Verification

The secret-leak test was run against the unfixed code and **fails** there. The file-mode assertions skip on Windows and run in CI on Linux.

- `npx tsc --noEmit`, `npm run lint`, `npm run format:check` clean
- `npm test`: 159 files, 2814 passing / 3 skipped