### PR TITLE
docs: fix the config reference so a hand-written config actually loads

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -75,12 +75,16 @@ version: 1
 | --------- | -------- | ------- | ------------------------------------------------------------------ |
 | `version` | Yes      | (none)  | Config schema version. Must be `1`; loading fails without this key |
 
-The wizard writes it for you. A hand-written file that omits it fails validation before anything else is checked:
+The wizard writes it for you. A hand-written file that omits it fails validation, and the error opens with this key:
 
 ```
-version
-  Invalid input: expected 1
+Configuration error in config.yaml:
+
+  version
+    Invalid input: expected 1
 ```
+
+Every problem is reported in one pass, so a file missing several required fields lists them all at once.
 
 ### BLE
 
@@ -471,21 +475,21 @@ users:
     weight_range: { min: 50, max: 75 }
 ```
 
-| Field                      | Required | Default | Description                                                                                                                                  |
-| -------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                     | Yes      | (none)  | Display name                                                                                                                                 |
-| `slug`                     | Yes      | (none)  | Unique ID (lowercase, hyphens) for MQTT topics, InfluxDB tags. The setup wizard fills it in from the name; a hand-written config must set it |
-| `height`                   | Yes      | (none)  | Height in configured unit                                                                                                                    |
-| `birth_date`               | Yes      | (none)  | ISO date (`YYYY-MM-DD`)                                                                                                                      |
-| `gender`                   | Yes      | (none)  | `male` or `female`                                                                                                                           |
-| `is_athlete`               | Yes      | (none)  | `true` or `false`. Adjusts [body composition](/body-composition#athlete-mode) formulas                                                       |
-| `weight_range`             | Yes      | (none)  | `{ min, max }` in kg. Also the matching input for [multi-user](/multi-user) setups                                                           |
-| `last_known_weight`        | No       | `null`  | Auto-updated after each measurement. Also used as the weight anchor some scales expect                                                       |
-| `exporters`                | No       | (none)  | [Per-user exporter](/multi-user#per-user-exporters) overrides                                                                                |
-| `beurer_pin`               | Beurer   | (none)  | Consent code the Beurer BF7xx / BF9xx scale was paired with                                                                                  |
-| `beurer_user_index`        | No       | `1`     | Scale user slot the consent code belongs to                                                                                                  |
-| `beurer_provision`         | No       | `false` | Write this profile into a Beurer scale that has no stored user                                                                               |
-| `beurer_register_new_user` | No       | `false` | Create a new user record on the scale instead of consenting to one. One-shot; see below                                                      |
+| Field                      | Required | Default | Description                                                                                                                                                                                                 |
+| -------------------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                     | Yes      | (none)  | Display name                                                                                                                                                                                                |
+| `slug`                     | Yes      | (none)  | Unique ID (lowercase, hyphens) for MQTT topics, InfluxDB tags. The wizard fills it in from the name, and `setup --non-interactive` does the same for a file that has one missing; otherwise set it yourself |
+| `height`                   | Yes      | (none)  | Height in configured unit                                                                                                                                                                                   |
+| `birth_date`               | Yes      | (none)  | ISO date (`YYYY-MM-DD`)                                                                                                                                                                                     |
+| `gender`                   | Yes      | (none)  | `male` or `female`                                                                                                                                                                                          |
+| `is_athlete`               | Yes      | (none)  | `true` or `false`. Adjusts [body composition](/body-composition#athlete-mode) formulas                                                                                                                      |
+| `weight_range`             | Yes      | (none)  | `{ min, max }` in kg. Also the matching input for [multi-user](/multi-user) setups                                                                                                                          |
+| `last_known_weight`        | No       | `null`  | Auto-updated after each measurement. Also used as the weight anchor some scales expect                                                                                                                      |
+| `exporters`                | No       | (none)  | [Per-user exporter](/multi-user#per-user-exporters) overrides                                                                                                                                               |
+| `beurer_pin`               | Beurer   | (none)  | Consent code the Beurer BF7xx / BF9xx scale was paired with                                                                                                                                                 |
+| `beurer_user_index`        | No       | `1`     | Scale user slot the consent code belongs to                                                                                                                                                                 |
+| `beurer_provision`         | No       | `false` | Write this profile into a Beurer scale that has no stored user                                                                                                                                              |
+| `beurer_register_new_user` | No       | `false` | Create a new user record on the scale instead of consenting to one. One-shot; see below                                                                                                                     |
 
 ### Exporters
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -65,6 +65,23 @@ Two consequences worth knowing:
 
 If you prefer manual configuration, here's the full reference. See [`config.yaml.example`](https://github.com/KristianP26/ble-scale-sync/blob/main/config.yaml.example) for an annotated template.
 
+### File version
+
+```yaml
+version: 1
+```
+
+| Field     | Required | Default | Description                                                        |
+| --------- | -------- | ------- | ------------------------------------------------------------------ |
+| `version` | Yes      | (none)  | Config schema version. Must be `1`; loading fails without this key |
+
+The wizard writes it for you. A hand-written file that omits it fails validation before anything else is checked:
+
+```
+version
+  Invalid input: expected 1
+```
+
 ### BLE
 
 ```yaml
@@ -454,21 +471,21 @@ users:
     weight_range: { min: 50, max: 75 }
 ```
 
-| Field                      | Required | Default        | Description                                                                             |
-| -------------------------- | -------- | -------------- | --------------------------------------------------------------------------------------- |
-| `name`                     | Yes      | (none)         | Display name                                                                            |
-| `slug`                     | No       | Auto-generated | Unique ID (lowercase, hyphens) for MQTT topics, InfluxDB tags                           |
-| `height`                   | Yes      | (none)         | Height in configured unit                                                               |
-| `birth_date`               | Yes      | (none)         | ISO date (`YYYY-MM-DD`)                                                                 |
-| `gender`                   | Yes      | (none)         | `male` or `female`                                                                      |
-| `is_athlete`               | No       | `false`        | Adjusts [body composition](/body-composition#athlete-mode) formulas                     |
-| `weight_range`             | No       | (none)         | `{ min, max }` in kg. Required for [multi-user](/multi-user) deployments                |
-| `last_known_weight`        | No       | `null`         | Auto-updated after each measurement. Also used as the weight anchor some scales expect  |
-| `exporters`                | No       | (none)         | [Per-user exporter](/multi-user#per-user-exporters) overrides                           |
-| `beurer_pin`               | Beurer   | (none)         | Consent code the Beurer BF7xx / BF9xx scale was paired with                             |
-| `beurer_user_index`        | No       | `1`            | Scale user slot the consent code belongs to                                             |
-| `beurer_provision`         | No       | `false`        | Write this profile into a Beurer scale that has no stored user                          |
-| `beurer_register_new_user` | No       | `false`        | Create a new user record on the scale instead of consenting to one. One-shot; see below |
+| Field                      | Required | Default | Description                                                                                                                                  |
+| -------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                     | Yes      | (none)  | Display name                                                                                                                                 |
+| `slug`                     | Yes      | (none)  | Unique ID (lowercase, hyphens) for MQTT topics, InfluxDB tags. The setup wizard fills it in from the name; a hand-written config must set it |
+| `height`                   | Yes      | (none)  | Height in configured unit                                                                                                                    |
+| `birth_date`               | Yes      | (none)  | ISO date (`YYYY-MM-DD`)                                                                                                                      |
+| `gender`                   | Yes      | (none)  | `male` or `female`                                                                                                                           |
+| `is_athlete`               | Yes      | (none)  | `true` or `false`. Adjusts [body composition](/body-composition#athlete-mode) formulas                                                       |
+| `weight_range`             | Yes      | (none)  | `{ min, max }` in kg. Also the matching input for [multi-user](/multi-user) setups                                                           |
+| `last_known_weight`        | No       | `null`  | Auto-updated after each measurement. Also used as the weight anchor some scales expect                                                       |
+| `exporters`                | No       | (none)  | [Per-user exporter](/multi-user#per-user-exporters) overrides                                                                                |
+| `beurer_pin`               | Beurer   | (none)  | Consent code the Beurer BF7xx / BF9xx scale was paired with                                                                                  |
+| `beurer_user_index`        | No       | `1`     | Scale user slot the consent code belongs to                                                                                                  |
+| `beurer_provision`         | No       | `false` | Write this profile into a Beurer scale that has no stored user                                                                               |
+| `beurer_register_new_user` | No       | `false` | Create a new user record on the scale instead of consenting to one. One-shot; see below                                                      |
 
 ### Exporters
 

--- a/docs/multi-user.md
+++ b/docs/multi-user.md
@@ -31,6 +31,8 @@ users:
     last_known_weight: 85.5
 ```
 
+Only the matching-relevant fields are shown. Every user also needs `slug`, `height`, `birth_date`, `gender` and `is_athlete`, and the file needs `version: 1` -> see the [full reference](/guide/configuration#config-yaml-reference).
+
 ## Weight Matching
 
 The app uses a 4-tier priority system to identify users:


### PR DESCRIPTION
Anyone following the page's own *"If you prefer manual configuration, here's the full reference"* path wrote a `config.yaml` that **does not load**. Four required fields were misdocumented.

## What was wrong

| Field | Docs said | Schema says |
|---|---|---|
| `version` | *not mentioned on any page* | required, must be `1` |
| `slug` | optional, "Auto-generated" | required |
| `is_athlete` | optional, default `false` | required |
| `weight_range` | optional | required |

`version` is the first key checked, so every hand-written config failed on an error no page explained. Slug auto-generation exists only in the wizard (`wizard/steps/users.ts`), never at load time - `yaml-load.ts` parses straight into `AppConfigSchema`.

## Verified by running it, not by reading the schema

A config written exactly as the old page documented:

```
version
  Invalid input: expected 1
users.0.slug
  Invalid input: expected string, received undefined
users.0.is_athlete
  Invalid input: expected boolean, received undefined
users.0.weight_range
  Invalid input: expected object, received undefined
```

A config written exactly as the corrected page documents:

```
Config valid ✓ (source: yaml, 1 user(s), 0 exporter(s), continuous: on)
```

## Also

The `multi-user.md` example is a deliberate fragment about weight matching, and it omits six required fields. Rather than bloating it and burying its point, it gains one line pointing at the full reference - so nobody copies it as a whole config.

`docs:build` passes, and every internal link in the changed hunks resolves (VitePress fails the build on a dead link).

---

This is the user-blocking half of a larger docs audit. The remaining gaps - `unknown_user` missing from the reference, exporter retry policy, back-date support varying by exporter, `BLE_RAW_CAPTURE`, the session cap, and a stale `qn_report_byte` default on the add-on page - are filed separately.

