### PR TITLE
docs: switch the star history chart back to star-history.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,4 +167,10 @@ GPL-3.0. See [LICENSE](LICENSE) for details.
 
 ## Star History
 
-[![Star History Chart](https://star-history.dera.page/svg?repos=KristianP26/ble-scale-sync&legend=bottom-right)](https://star-history.dera.page/#KristianP26/ble-scale-sync&legend=bottom-right)
+<a href="https://www.star-history.com/?repos=kristianp26%2Fble-scale-sync&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=kristianp26/ble-scale-sync&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=kristianp26/ble-scale-sync&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=kristianp26/ble-scale-sync&type=date&legend=top-left" />
+ </picture>
+</a>


### PR DESCRIPTION
Replaces the single-image `star-history.dera.page` chart at the bottom of the README with the `star-history.com` `<picture>` form.

Two differences that matter:

- **Theme-aware.** `prefers-color-scheme` picks the dark or light chart instead of shipping one theme to every reader.
- **Legend moved to `top-left`**, where it does not sit on top of the curve.

The `<img>` fallback keeps it working anywhere `<picture>` is not honoured.

Note: this reverses e0dfe2b, which had deliberately moved the chart to `star-history.dera.page`. Requested change.