### PR TITLE
docs(readme): add gvarph and chrisauer to the contributors grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ BlueZ and noble, plus the ESP32 and ESPHome proxies).
 <td align="center"><a href="https://github.com/Bretos"><img src="https://avatars.githubusercontent.com/u/4947212?v=4" width="60" height="60" alt="Bretos"><br><sub>Bretos</sub></a></td>
 <td align="center"><a href="https://github.com/albert-canfield"><img src="https://avatars.githubusercontent.com/u/153834574?v=4" width="60" height="60" alt="albert-canfield"><br><sub>albert-canfield</sub></a></td>
 <td align="center"><a href="https://github.com/JamieSBenson"><img src="https://avatars.githubusercontent.com/u/21150960?v=4" width="60" height="60" alt="JamieSBenson"><br><sub>JamieSBenson</sub></a></td>
+<td align="center"><a href="https://github.com/gvarph"><img src="https://avatars.githubusercontent.com/u/17300137?v=4" width="60" height="60" alt="gvarph"><br><sub>gvarph</sub></a></td>
+<td align="center"><a href="https://github.com/chrisauer"><img src="https://avatars.githubusercontent.com/u/884764?v=4" width="60" height="60" alt="chrisauer"><br><sub>chrisauer</sub></a></td>
 </tr></table>
 
 ## Contributing


### PR DESCRIPTION
Two people who landed code were missing from the grid.

| Who | What |
|---|---|
| [gvarph](https://github.com/gvarph) | Home Assistant Bluetooth transport (#375), Xiaomi Body Composition Scale S400 adapter (#374) |
| [chrisauer](https://github.com/chrisauer) | Speediance Smart Scale FG2211WBF adapter (#383) |

Checked by diffing the grid against `git log origin/main` authors and the GitHub contributors API. Everyone else with commits is already there; `dependabot[bot]` is deliberately excluded, and `dev` carries no author who is not already on `main`.

Both rows now hold eight cells.

**Correction to an earlier version of this description**, which said JamieSBenson looked anomalous: they belong in the grid. Their code landed as `b3239f8` (`fix(beurer): decode impedance instead of skipping it as unused`), which carries `Co-authored-by: Jamie Benson` and "Found by @JamieSBenson in #354". The contributors API counts commit authors only, not co-authors, which is why they do not appear in it. Nothing to change.
