### PR TITLE
feat: add Google Health exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Requires Node.js v22+ and a BLE adapter. See the **[full install guide](https://
 ## Features
 
 - **[25+ scale brands](https://blescalesync.dev/guide/supported-scales).** Xiaomi (Mi Scale 2 passive broadcast), Renpho (Elis 1, ES-CS20M, QN-Scale), Eufy, Yunmai, Beurer (incl. BF720), Sanitas (incl. SBF70 body composition), Medisana, and more.
-- **[11 export targets](https://blescalesync.dev/exporters).** Garmin Connect, Strava, Intervals.icu, Runalyze, Wger, MQTT (Home Assistant), InfluxDB, Webhook, Ntfy, Telegram, File (CSV/JSONL).
+- **[12 export targets](https://blescalesync.dev/exporters).** Garmin Connect, Strava, Intervals.icu, Runalyze, Wger, MQTT (Home Assistant), InfluxDB, Webhook, Ntfy, Telegram, File (CSV/JSONL).
 - **[10 body metrics](https://blescalesync.dev/body-composition).** BIA-based body composition from weight + impedance.
 - **[Multi-user](https://blescalesync.dev/multi-user).** Automatic weight-based identification with per-user exporters.
 - **Historical sync.** Replays a scale's onboard cache of offline measurements with their original timestamps to exporters that support back-dating (Garmin Connect, InfluxDB, File).

--- a/docs/exporters.md
+++ b/docs/exporters.md
@@ -1,6 +1,6 @@
 ---
 title: Exporters
-description: Configure Garmin Connect, Strava, Intervals.icu, Runalyze, Wger, MQTT, Webhook, InfluxDB, Ntfy, Telegram, and File export targets.
+description: Configure Garmin Connect, Google Health, Strava, Intervals.icu, Runalyze, Wger, MQTT, Webhook, InfluxDB, Ntfy, Telegram, and File export targets.
 head:
   - - meta
     - name: keywords
@@ -9,7 +9,7 @@ head:
 
 # Exporters
 
-BLE Scale Sync exports body composition data to 11 targets. The [setup wizard](/guide/configuration#setup-wizard-recommended) walks you through exporter selection, configuration, and connectivity testing.
+BLE Scale Sync exports body composition data to 12 targets. The [setup wizard](/guide/configuration#setup-wizard-recommended) walks you through exporter selection, configuration, and connectivity testing.
 
 Exporters are configured in `global_exporters` (shared by all users). For multi-user setups with separate accounts, see [Per-User Exporters](/multi-user#per-user-exporters). All enabled exporters run in parallel; the process reports an error only if **every** exporter fails.
 
@@ -22,6 +22,7 @@ Exporters are configured in `global_exporters` (shared by all users). For multi-
 | [**Ntfy**](#ntfy)               | Push notifications to phone/desktop                    |
 | [**Telegram**](#telegram)       | Send measurement notifications to a Telegram chat      |
 | [**File (CSV/JSONL)**](#file)   | Append readings to a local file                        |
+| [**Google Health**](#google-health) | Push weight and derived body fat to Google Health  |
 | [**Strava**](#strava)           | Update weight in your Strava athlete profile           |
 | [**Intervals.icu**](#intervals) | Push weight + body fat to Intervals.icu wellness       |
 | [**Runalyze**](#runalyze)       | Push weight + body composition to Runalyze metrics     |
@@ -292,6 +293,92 @@ volumes:
 ```
 
 :::
+## Google Health {#google-health}
+
+Push weight measurements to the Google Health API and optionally upload derived body-fat percentage.
+
+Google Health uses OAuth 2.0. BLE Scale Sync does not currently include an interactive setup helper for obtaining the initial refresh token, so a one-time manual OAuth setup is required.
+
+Google Health is a per-user exporter because its OAuth credentials authorize access to one person's health account.
+
+::: warning Per-user configuration only
+Configure `google-health` under a user's `exporters:` list, not under `global_exporters`. A Google Health OAuth refresh token authorizes one person's health account.
+:::
+
+| Field                 | Required | Default | Description                           |
+| --------------------- | -------- | ------- | ------------------------------------- |
+| `client_id`           | Yes      | (none)  | Google OAuth 2.0 client ID            |
+| `client_secret`       | Yes      | (none)  | Google OAuth 2.0 client secret        |
+| `refresh_token`       | Yes      | (none)  | Long-lived Google OAuth refresh token |
+| `write_body_fat`      | No       | `true`  | Upload derived body-fat percentage    |
+| `device_manufacturer` | No       | (none)  | Optional scale manufacturer metadata  |
+| `device_display_name` | No       | (none)  | Optional human-readable scale name    |
+
+```yaml
+users:
+  - name: Alice
+    exporters:
+      - type: google-health
+        client_id: '${GOOGLE_HEALTH_CLIENT_ID}'
+        client_secret: '${GOOGLE_HEALTH_CLIENT_SECRET}'
+        refresh_token: '${GOOGLE_HEALTH_REFRESH_TOKEN}'
+        write_body_fat: true
+```
+
+Optional device metadata can also be supplied:
+
+```yaml
+        device_manufacturer: 'Your scale manufacturer'
+        device_display_name: 'Bathroom Scale'
+```
+
+### Google Cloud setup
+
+1. Open the Google Cloud Console and create or select a project.
+
+2. Enable the **Google Health API** for the project.
+
+3. Configure the project's OAuth consent screen.
+
+4. Create an OAuth 2.0 client.
+
+   A Web application client can be used for the manual authorization flow.
+
+5. Authorize the client with offline access and the following scope:
+
+   ```text
+   https://www.googleapis.com/auth/googlehealth.health_metrics_and_measurements.writeonly
+   ```
+
+6. Obtain a refresh token.
+
+   One convenient method is the Google OAuth 2.0 Playground:
+
+   - Open the OAuth 2.0 Playground.
+   - Open its configuration/settings.
+   - Enable **Use your own OAuth credentials**.
+   - Enter the OAuth client ID and client secret created above.
+   - Authorize the Google Health write scope.
+   - Exchange the authorization code for tokens.
+   - Copy the resulting refresh token into your BLE Scale Sync configuration.
+
+7. Restart BLE Scale Sync and check the logs for a successful Google Health export.
+
+BLE Scale Sync exchanges the refresh token for short-lived access tokens automatically and caches those access tokens in memory. OAuth credentials and access tokens are not logged.
+
+### Weight and body-fat records
+
+Weight measurements are uploaded as actively measured scale data.
+
+If `write_body_fat` is enabled and BLE Scale Sync has a valid `bodyFatPercent` value, body fat is uploaded as a derived Google Health data point.
+
+If body-fat data is unavailable or invalid, the weight measurement is still uploaded.
+
+### Credential security
+
+Treat the OAuth client secret and refresh token as credentials. Prefer `${ENV_VAR}` references rather than storing credentials directly in tracked configuration.
+
+Never commit a real `config.yaml` containing Google OAuth credentials. Use placeholder credentials only in documentation, examples, and tests.
 
 ## Strava {#strava}
 
@@ -441,6 +528,7 @@ A reading with a timestamp is sent **only to exporters that can record it at tha
 | --- | --- |
 | `file` | Yes |
 | `garmin` | Yes |
+| `google-health` | Yes |
 | `influxdb` | Yes |
 | `intervals` | Yes |
 | `runalyze` | Yes |
@@ -472,6 +560,7 @@ At startup, exporters are tested for connectivity. Failures are logged as warnin
 | InfluxDB      | `/health` endpoint, with token |
 | Ntfy          | `/v1/health` endpoint          |
 | Telegram      | `getChat` endpoint             |
+| Google Health | OAuth access-token refresh     |
 | Intervals.icu | `GET` wellness record          |
 | Runalyze      | `GET` bodyComposition metric   |
 | Wger          | `GET` userprofile record       |

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ features:
     link: /guide/supported-scales
     linkText: See all scales
   - icon: "\uD83D\uDCE4"
-    title: 11 Export Targets
+    title: 12 Export Targets
     details: Garmin Connect &bull; Strava &bull; Intervals.icu &bull; Runalyze &bull; Wger &bull; MQTT (Home Assistant) &bull; InfluxDB &bull; Webhook &bull; Ntfy &bull; Telegram &bull; File (CSV/JSONL)
     link: /exporters
     linkText: Configure exporters

--- a/docs/public/logo.svg
+++ b/docs/public/logo.svg
@@ -3,7 +3,7 @@
   <rect x="14" y="14" width="100" height="100" rx="18" fill="#1e293b"/>
   <!-- Display -->
   <rect x="30" y="34" width="68" height="28" rx="4" fill="#0c4a6e"/>
-  <text x="64" y="54" text-anchor="middle" font-family="monospace" font-size="18" font-weight="700" fill="#38bdf8">35.11</text>
+  <text x="64" y="54" text-anchor="middle" font-family="monospace" font-size="18" font-weight="700" fill="#38bdf8">35.12</text>
   <!-- Bluetooth rune (bold, simplified) -->
   <g transform="translate(64, 84)" stroke="#38bdf8" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" fill="none">
     <line x1="0" y1="-9" x2="0" y2="9"/>

--- a/src/exporters/config.ts
+++ b/src/exporters/config.ts
@@ -13,7 +13,8 @@ export type ExporterName =
   | 'telegram'
   | 'intervals'
   | 'runalyze'
-  | 'wger';
+  | 'wger'
+  | 'google-health';
 
 /**
  * Runtime twin of `ExporterName`, for validating `EXPORTERS=...`.
@@ -35,6 +36,7 @@ const KNOWN_EXPORTERS = new Set<ExporterName>([
   'intervals',
   'runalyze',
   'wger',
+  'google-health',
 ]);
 
 /** @internal Exported for the registry-agreement test only. */
@@ -122,6 +124,21 @@ export interface WgerConfig {
   syncMeasurements: boolean;
 }
 
+export interface GoogleHealthConfig {
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+
+  /** Upload bodyFatPercent as a DERIVED Google Health data point. */
+  writeBodyFat: boolean;
+
+  /** Optional metadata identifying the physical scale. */
+  deviceManufacturer?: string;
+
+  /** Optional human-readable scale name. */
+  deviceDisplayName?: string;
+}
+
 export interface ExporterConfig {
   exporters: ExporterName[];
   garmin?: GarminConfig;
@@ -135,6 +152,7 @@ export interface ExporterConfig {
   intervals?: IntervalsConfig;
   runalyze?: RunalyzeConfig;
   wger?: WgerConfig;
+  googleHealth?: GoogleHealthConfig;
 }
 
 function fail(msg: string): never {
@@ -381,10 +399,12 @@ export function loadExporterConfig(): ExporterConfig {
     if (!baseUrl) {
       fail('WGER_BASE_URL is required when wger exporter is enabled.');
     }
+
     const token = process.env.WGER_TOKEN?.trim();
     if (!token) {
       fail('WGER_TOKEN is required when wger exporter is enabled.');
     }
+
     wger = {
       baseUrl,
       token,
@@ -393,6 +413,37 @@ export function loadExporterConfig(): ExporterConfig {
         process.env.WGER_SYNC_MEASUREMENTS?.trim(),
         true,
       ),
+    };
+  }
+
+  let googleHealth: GoogleHealthConfig | undefined;
+  if (exporters.includes('google-health')) {
+    const clientId = process.env.GOOGLE_HEALTH_CLIENT_ID?.trim();
+    if (!clientId) {
+      fail('GOOGLE_HEALTH_CLIENT_ID is required when google-health exporter is enabled.');
+    }
+
+    const clientSecret = process.env.GOOGLE_HEALTH_CLIENT_SECRET?.trim();
+    if (!clientSecret) {
+      fail('GOOGLE_HEALTH_CLIENT_SECRET is required when google-health exporter is enabled.');
+    }
+
+    const refreshToken = process.env.GOOGLE_HEALTH_REFRESH_TOKEN?.trim();
+    if (!refreshToken) {
+      fail('GOOGLE_HEALTH_REFRESH_TOKEN is required when google-health exporter is enabled.');
+    }
+
+    googleHealth = {
+      clientId,
+      clientSecret,
+      refreshToken,
+      writeBodyFat: parseBoolean(
+        'GOOGLE_HEALTH_WRITE_BODY_FAT',
+        process.env.GOOGLE_HEALTH_WRITE_BODY_FAT?.trim(),
+        true,
+      ),
+      deviceManufacturer: process.env.GOOGLE_HEALTH_DEVICE_MANUFACTURER?.trim() || undefined,
+      deviceDisplayName: process.env.GOOGLE_HEALTH_DEVICE_DISPLAY_NAME?.trim() || undefined,
     };
   }
 
@@ -409,5 +460,6 @@ export function loadExporterConfig(): ExporterConfig {
     intervals,
     runalyze,
     wger,
+    googleHealth,
   };
 }

--- a/src/exporters/google-health.ts
+++ b/src/exporters/google-health.ts
@@ -1,0 +1,517 @@
+import { createLogger } from '../logger.js';
+import type { BodyComposition } from '../interfaces/scale-adapter.js';
+import type { Exporter, ExportContext, ExportResult } from '../interfaces/exporter.js';
+import type { ExporterSchema } from '../interfaces/exporter-schema.js';
+import { withRetry, httpError, NonRetryableError } from '../utils/retry.js';
+import { errMsg } from '../utils/error.js';
+import type { GoogleHealthConfig } from './config.js';
+
+const log = createLogger('GoogleHealth');
+
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const API_BASE = 'https://health.googleapis.com/v4/users/me/dataTypes';
+const WEIGHT_URL = `${API_BASE}/weight/dataPoints`;
+const BODY_FAT_URL = `${API_BASE}/body-fat/dataPoints`;
+
+const REQUIRED_SCOPE =
+  'https://www.googleapis.com/auth/googlehealth.health_metrics_and_measurements.writeonly';
+
+const REQUEST_TIMEOUT_MS = 10_000;
+const TOKEN_EXPIRY_SKEW_MS = 60_000;
+
+/**
+ * Runtime configuration for the Google Health exporter.
+ *
+ * The refresh token must have been granted with offline access and the
+ * health_metrics_and_measurements.writeonly scope. Access tokens are obtained
+ * and cached in memory; they are never persisted or logged.
+ */
+export const googleHealthSchema: ExporterSchema = {
+  name: 'google-health',
+  displayName: 'Google Health',
+  description: 'Push weight and derived body fat to the Google Health API',
+  fields: [
+    {
+      key: 'client_id',
+      label: 'OAuth Client ID',
+      type: 'string',
+      required: true,
+      description: 'Google OAuth 2.0 Web application client ID',
+    },
+    {
+      key: 'client_secret',
+      label: 'OAuth Client Secret',
+      type: 'password',
+      required: true,
+      description: 'Google OAuth 2.0 Web application client secret',
+    },
+    {
+      key: 'refresh_token',
+      label: 'OAuth Refresh Token',
+      type: 'password',
+      required: true,
+      description:
+        'Refresh token granted with offline access and the Google Health health-metrics write scope',
+    },
+    {
+      key: 'write_body_fat',
+      label: 'Upload body fat',
+      type: 'boolean',
+      required: false,
+      default: true,
+      description: 'Upload bodyFatPercent as a DERIVED Google Health body-fat data point',
+    },
+    {
+      key: 'device_manufacturer',
+      label: 'Scale manufacturer',
+      type: 'string',
+      required: false,
+      description: 'Optional device metadata, for example Juniper',
+    },
+    {
+      key: 'device_display_name',
+      label: 'Scale display name',
+      type: 'string',
+      required: false,
+      description: 'Optional device metadata, for example Juniper Body Fat Scale',
+    },
+  ],
+
+  // Google OAuth credentials belong to one person's health account. Requiring
+  // per-user configuration prevents one shared token receiving every household
+  // member's measurements by mistake.
+  supportsGlobal: false,
+  supportsPerUser: true,
+};
+
+interface GoogleTokenResponse {
+  access_token?: string;
+  expires_in?: number;
+  scope?: string;
+  token_type?: string;
+  error?: string;
+  error_description?: string;
+}
+
+interface GoogleApiError {
+  error?: {
+    code?: number;
+    message?: string;
+    status?: string;
+  };
+}
+
+interface GoogleOperation {
+  name?: string;
+  done?: boolean;
+  response?: unknown;
+  error?: {
+    code?: number;
+    message?: string;
+  };
+}
+
+type RecordingMethod = 'ACTIVELY_MEASURED' | 'DERIVED';
+
+interface SampleTime {
+  physicalTime: string;
+  utcOffset?: string;
+}
+
+interface DataSource {
+  recordingMethod: RecordingMethod;
+  device?: {
+    formFactor: 'SCALE';
+    manufacturer?: string;
+    displayName?: string;
+  };
+}
+
+interface WeightDataPoint {
+  dataSource: DataSource;
+  weight: {
+    sampleTime: SampleTime;
+    weightGrams: number;
+  };
+}
+
+interface BodyFatDataPoint {
+  bodyFat: {
+    sampleTime: SampleTime;
+    percentage: number;
+  };
+}
+
+function safeJson<T>(text: string): T | undefined {
+  if (!text) return undefined;
+
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+function tokenErrorDetail(payload: GoogleTokenResponse | undefined): string | undefined {
+  if (!payload) return undefined;
+
+  if (payload.error_description) {
+    return payload.error_description;
+  }
+
+  return payload.error;
+}
+
+function apiErrorDetail(payload: GoogleApiError | undefined): string | undefined {
+  const error = payload?.error;
+
+  if (!error) {
+    return undefined;
+  }
+
+  return error.message ?? error.status;
+}
+
+/**
+ * Build the Google Health sample timestamp.
+ *
+ * The physical time is sent as RFC3339 and the UTC offset follows the process
+ * timezone and the date's DST rules. Containers that should use local civil
+ * time should set TZ explicitly.
+ */
+function buildSampleTime(timestamp: Date): SampleTime {
+  if (Number.isNaN(timestamp.getTime())) {
+    throw new NonRetryableError('Google Health measurement timestamp is invalid');
+  }
+
+  return {
+    physicalTime: timestamp.toISOString(),
+    utcOffset: `${-timestamp.getTimezoneOffset() * 60}s`,
+  };
+}
+
+function validWeight(weightKg: number): boolean {
+  return Number.isFinite(weightKg) && weightKg > 0;
+}
+
+function validBodyFat(percentage: number): boolean {
+  // BLE Scale Sync uses non-positive values as effectively absent in several
+  // exporters. Google permits 0, but suppressing it here avoids turning a
+  // missing or placeholder value into a genuine health record.
+  return Number.isFinite(percentage) && percentage > 0 && percentage <= 100;
+}
+
+export class GoogleHealthExporter implements Exporter {
+  readonly name = 'google-health';
+  readonly supportsBackdate = true;
+
+  private readonly config: GoogleHealthConfig;
+
+  private accessToken: string | null = null;
+  private accessTokenExpiresAt = 0;
+  private tokenRefreshInFlight: Promise<string> | null = null;
+
+  constructor(config: GoogleHealthConfig) {
+    this.config = config;
+  }
+
+  private buildDataSource(recordingMethod: RecordingMethod): DataSource {
+    const manufacturer = this.config.deviceManufacturer?.trim();
+    const displayName = this.config.deviceDisplayName?.trim();
+
+    const dataSource: DataSource = {
+      recordingMethod,
+    };
+
+    if (manufacturer || displayName) {
+      dataSource.device = {
+        formFactor: 'SCALE',
+        ...(manufacturer ? { manufacturer } : {}),
+        ...(displayName ? { displayName } : {}),
+      };
+    }
+
+    return dataSource;
+  }
+
+  private buildWeightPayload(data: BodyComposition, timestamp: Date): WeightDataPoint {
+    return {
+      dataSource: this.buildDataSource('ACTIVELY_MEASURED'),
+      weight: {
+        sampleTime: buildSampleTime(timestamp),
+
+        // Scale readings are currently at 0.1 kg resolution. Whole grams
+        // avoid carrying floating-point noise into the Google Health record.
+        weightGrams: Math.round(data.weight * 1000),
+      },
+    };
+  }
+
+  private buildBodyFatPayload(data: BodyComposition, timestamp: Date): BodyFatDataPoint {
+    return {
+      bodyFat: {
+        sampleTime: buildSampleTime(timestamp),
+        percentage: Number(data.bodyFatPercent.toFixed(2)),
+      },
+    };
+  }
+
+  private clearCachedAccessToken(): void {
+    this.accessToken = null;
+    this.accessTokenExpiresAt = 0;
+  }
+
+  /**
+   * Perform one refresh-token exchange.
+   *
+   * Credentials and returned tokens are never logged.
+   */
+  private async refreshAccessTokenOnce(): Promise<string> {
+    const body = new URLSearchParams({
+      client_id: this.config.clientId,
+      client_secret: this.config.clientSecret,
+      refresh_token: this.config.refreshToken,
+      grant_type: 'refresh_token',
+    });
+
+    const response = await fetch(TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+
+    const text = await response.text();
+    const payload = safeJson<GoogleTokenResponse>(text);
+
+    if (!response.ok) {
+      const detail = tokenErrorDetail(payload);
+
+      throw httpError(
+        response.status,
+        detail ? `Google OAuth token refresh (${detail})` : 'Google OAuth token refresh',
+      );
+    }
+
+    if (!payload?.access_token) {
+      throw new NonRetryableError('Google OAuth token refresh returned no access_token');
+    }
+
+    if (payload.scope) {
+      const scopes = new Set(payload.scope.split(/\s+/).filter(Boolean));
+
+      if (!scopes.has(REQUIRED_SCOPE)) {
+        throw new NonRetryableError(
+          'Google OAuth refresh token does not include the Google Health health-metrics write scope',
+        );
+      }
+    }
+
+    const expiresInSeconds =
+      typeof payload.expires_in === 'number' && payload.expires_in > 0 ? payload.expires_in : 3600;
+
+    this.accessToken = payload.access_token;
+    this.accessTokenExpiresAt = Date.now() + expiresInSeconds * 1000;
+
+    return payload.access_token;
+  }
+
+  /**
+   * Refreshing an OAuth access token is safe to retry; unlike creating a health
+   * data point, it cannot duplicate a measurement.
+   */
+  private async refreshAccessToken(): Promise<string> {
+    let token = '';
+
+    const result = await withRetry(
+      async () => {
+        token = await this.refreshAccessTokenOnce();
+
+        return {
+          success: true,
+        };
+      },
+      {
+        log,
+        label: 'Google OAuth token refresh',
+      },
+    );
+
+    if (!result.success || !token) {
+      throw new Error(result.error ?? 'Google OAuth token refresh failed');
+    }
+
+    return token;
+  }
+
+  private async getAccessToken(forceRefresh = false): Promise<string> {
+    if (
+      !forceRefresh &&
+      this.accessToken &&
+      Date.now() + TOKEN_EXPIRY_SKEW_MS < this.accessTokenExpiresAt
+    ) {
+      return this.accessToken;
+    }
+
+    if (forceRefresh) {
+      this.clearCachedAccessToken();
+    }
+
+    // Coalesce concurrent exports or health checks so they do not race
+    // multiple refresh-token exchanges against the same Google account.
+    if (!this.tokenRefreshInFlight) {
+      this.tokenRefreshInFlight = this.refreshAccessToken().finally(() => {
+        this.tokenRefreshInFlight = null;
+      });
+    }
+
+    return this.tokenRefreshInFlight;
+  }
+
+  /**
+   * POST one Google Health data point.
+   *
+   * Data creation is deliberately not wrapped in withRetry(): POST /dataPoints
+   * is not treated as idempotent here. If Google accepted the record but the
+   * connection failed before the response reached us, retrying could create a
+   * duplicate health entry.
+   *
+   * HTTP 401 is the exception. The request was not authorized, so refreshing
+   * the bearer token and retrying once does not risk duplicating the record.
+   */
+  private async createDataPoint(
+    label: 'weight' | 'body fat',
+    url: string,
+    payload: WeightDataPoint | BodyFatDataPoint,
+    allowAuthRetry = true,
+  ): Promise<void> {
+    const accessToken = await this.getAccessToken();
+    const requestBody = JSON.stringify(payload);
+
+    log.debug(`Google Health ${label} endpoint: ${url}`);
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: requestBody,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+
+    const text = await response.text();
+
+    if (response.status === 401 && allowAuthRetry) {
+      log.warn(
+        `Google Health ${label} received HTTP 401; refreshing access token and retrying once.`,
+      );
+
+      await this.getAccessToken(true);
+
+      return this.createDataPoint(label, url, payload, false);
+    }
+
+    if (!response.ok) {
+      const parsedError = safeJson<GoogleApiError>(text);
+      const detail = apiErrorDetail(parsedError);
+
+      throw new Error(
+        detail
+          ? `Google Health ${label} upload failed: HTTP ${response.status} (${detail})`
+          : `Google Health ${label} upload failed: HTTP ${response.status}`,
+      );
+    }
+
+    const operation = safeJson<GoogleOperation>(text);
+
+    if (operation?.error) {
+      throw new Error(
+        `Google Health ${label} operation failed` +
+          (operation.error.message ? `: ${operation.error.message}` : ''),
+      );
+    }
+
+    if (operation?.done === false) {
+      log.info(`Google Health ${label} upload accepted and is still processing.`);
+    }
+  }
+
+  async export(data: BodyComposition, context?: ExportContext): Promise<ExportResult> {
+    if (!validWeight(data.weight)) {
+      return {
+        success: false,
+        error: `invalid weight: ${data.weight}`,
+      };
+    }
+
+    const timestamp = context?.timestamp ?? new Date();
+
+    try {
+      await this.createDataPoint('weight', WEIGHT_URL, this.buildWeightPayload(data, timestamp));
+
+      log.info(`Google Health weight uploaded: ${data.weight.toFixed(2)} kg.`);
+    } catch (err) {
+      const error = errMsg(err);
+
+      log.error(`Google Health weight upload failed: ${error}`);
+
+      return {
+        success: false,
+        error,
+      };
+    }
+
+    if (this.config.writeBodyFat) {
+      if (!validBodyFat(data.bodyFatPercent)) {
+        log.warn(`Skipping Google Health body fat: invalid value ${String(data.bodyFatPercent)}%.`);
+      } else {
+        try {
+          const bodyFatPayload = this.buildBodyFatPayload(data, timestamp);
+
+          await this.createDataPoint('body fat', BODY_FAT_URL, bodyFatPayload);
+
+          log.info(`Google Health derived body fat uploaded: ${data.bodyFatPercent.toFixed(2)}%.`);
+        } catch (err) {
+          const error = errMsg(err);
+
+          log.error(`Google Health body fat upload failed after weight succeeded: ${error}`);
+
+          return {
+            success: false,
+            error: `weight uploaded; body fat upload failed: ${error}`,
+          };
+        }
+      }
+    }
+
+    return {
+      success: true,
+    };
+  }
+
+  /**
+   * Validate the long-lived credentials without writing a fake health record.
+   *
+   * This confirms that the refresh token can still produce an access token.
+   * Google Health API authorization itself is exercised by the next real upload.
+   */
+  async healthcheck(): Promise<ExportResult> {
+    try {
+      await this.getAccessToken(true);
+
+      return {
+        success: true,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        error: errMsg(err),
+      };
+    }
+  }
+}

--- a/src/exporters/index.ts
+++ b/src/exporters/index.ts
@@ -11,6 +11,7 @@ import { TelegramExporter } from './telegram.js';
 import { IntervalsExporter } from './intervals.js';
 import { RunalyzeExporter } from './runalyze.js';
 import { WgerExporter } from './wger.js';
+import { GoogleHealthExporter } from './google-health.js';
 
 export { loadExporterConfig } from './config.js';
 export { createExporterFromEntry, EXPORTER_SCHEMAS, KNOWN_EXPORTER_NAMES } from './registry.js';
@@ -57,6 +58,9 @@ export function createExporters(config: ExporterConfig): Exporter[] {
         break;
       case 'wger':
         exporters.push(new WgerExporter(config.wger!));
+        break;
+      case 'google-health':
+        exporters.push(new GoogleHealthExporter(config.googleHealth!));
         break;
       default: {
         const _exhaustive: never = name;

--- a/src/exporters/registry.ts
+++ b/src/exporters/registry.ts
@@ -12,6 +12,7 @@ import type {
   IntervalsConfig,
   RunalyzeConfig,
   WgerConfig,
+  GoogleHealthConfig,
 } from './config.js';
 import {
   garminSchema,
@@ -29,6 +30,7 @@ import { telegramSchema, TelegramExporter } from './telegram.js';
 import { intervalsSchema, IntervalsExporter } from './intervals.js';
 import { runalyzeSchema, RunalyzeExporter } from './runalyze.js';
 import { wgerSchema, WgerExporter } from './wger.js';
+import { googleHealthSchema, GoogleHealthExporter } from './google-health.js';
 
 // --- Registry entry type ---
 
@@ -269,6 +271,21 @@ export const EXPORTER_REGISTRY: ExporterRegistryEntry[] = [
         syncMeasurements: optionalBool(config, 'wger', 'sync_measurements') ?? true,
       };
       return new WgerExporter(wgerConfig);
+    },
+  },
+  {
+    schema: googleHealthSchema,
+    factory: (config) => {
+      const googleHealthConfig: GoogleHealthConfig = {
+        clientId: requireField(config, 'google-health', 'client_id'),
+        clientSecret: requireField(config, 'google-health', 'client_secret'),
+        refreshToken: requireField(config, 'google-health', 'refresh_token'),
+        writeBodyFat: optionalBool(config, 'google-health', 'write_body_fat') ?? true,
+        deviceManufacturer: config.device_manufacturer as string | undefined,
+        deviceDisplayName: config.device_display_name as string | undefined,
+      };
+
+      return new GoogleHealthExporter(googleHealthConfig);
     },
   },
 ];

--- a/tests/exporters/google-health.test.ts
+++ b/tests/exporters/google-health.test.ts
@@ -1,0 +1,425 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GoogleHealthExporter } from '../../src/exporters/google-health.js';
+import type { GoogleHealthConfig } from '../../src/exporters/config.js';
+import type { BodyComposition } from '../../src/interfaces/scale-adapter.js';
+
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const WEIGHT_URL = 'https://health.googleapis.com/v4/users/me/dataTypes/weight/dataPoints';
+const BODY_FAT_URL = 'https://health.googleapis.com/v4/users/me/dataTypes/body-fat/dataPoints';
+
+const REQUIRED_SCOPE =
+  'https://www.googleapis.com/auth/googlehealth.health_metrics_and_measurements.writeonly';
+
+const samplePayload: BodyComposition = {
+  weight: 72.5,
+  impedance: 485,
+  bmi: 23.1,
+  bodyFatPercent: 18.456,
+  waterPercent: 55.2,
+  boneMass: 3.1,
+  muscleMass: 58.4,
+  visceralFat: 6,
+  physiqueRating: 5,
+  bmr: 1650,
+  metabolicAge: 25,
+};
+
+const defaultConfig: GoogleHealthConfig = {
+  clientId: 'test-client-id',
+  clientSecret: 'test-client-secret',
+  refreshToken: 'test-refresh-token',
+  writeBodyFat: true,
+};
+
+const mockFetch = vi.fn();
+
+vi.stubGlobal('fetch', mockFetch);
+
+function mockResponse(
+  status: number,
+  body: unknown = {},
+): {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  text: () => Promise<string>;
+} {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status >= 200 && status < 300 ? 'OK' : 'Error',
+    text: () => Promise.resolve(typeof body === 'string' ? body : JSON.stringify(body)),
+  };
+}
+
+function tokenResponse(
+  accessToken = 'test-access-token',
+  expiresIn = 3600,
+): ReturnType<typeof mockResponse> {
+  return mockResponse(200, {
+    access_token: accessToken,
+    expires_in: expiresIn,
+    scope: REQUIRED_SCOPE,
+    token_type: 'Bearer',
+  });
+}
+
+function parseRequestBody(callIndex: number): unknown {
+  const options = mockFetch.mock.calls[callIndex][1] as RequestInit;
+  return JSON.parse(String(options.body));
+}
+
+describe('GoogleHealthExporter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('has name "google-health" and supports backdated readings', () => {
+    const exporter = new GoogleHealthExporter(defaultConfig);
+
+    expect(exporter.name).toBe('google-health');
+    expect(exporter.supportsBackdate).toBe(true);
+  });
+
+  it('refreshes an OAuth access token and uploads weight', async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenResponse())
+      .mockResolvedValueOnce(mockResponse(200, { done: true }));
+
+    const exporter = new GoogleHealthExporter({
+      ...defaultConfig,
+      writeBodyFat: false,
+    });
+
+    const result = await exporter.export(samplePayload);
+
+    expect(result.success).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    expect(mockFetch.mock.calls[0][0]).toBe(TOKEN_URL);
+
+    const tokenOptions = mockFetch.mock.calls[0][1] as RequestInit;
+    expect(tokenOptions.method).toBe('POST');
+    expect(tokenOptions.headers).toEqual(
+      expect.objectContaining({
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      }),
+    );
+
+    const tokenBody = tokenOptions.body as URLSearchParams;
+
+    expect(tokenBody.get('client_id')).toBe('test-client-id');
+    expect(tokenBody.get('client_secret')).toBe('test-client-secret');
+    expect(tokenBody.get('refresh_token')).toBe('test-refresh-token');
+    expect(tokenBody.get('grant_type')).toBe('refresh_token');
+
+    expect(mockFetch.mock.calls[1][0]).toBe(WEIGHT_URL);
+
+    const uploadOptions = mockFetch.mock.calls[1][1] as RequestInit;
+
+    expect(uploadOptions.method).toBe('POST');
+    expect(uploadOptions.headers).toEqual(
+      expect.objectContaining({
+        Authorization: 'Bearer test-access-token',
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      }),
+    );
+
+    const payload = parseRequestBody(1) as {
+      dataSource: {
+        recordingMethod: string;
+      };
+      weight: {
+        weightGrams: number;
+      };
+    };
+
+    expect(payload.dataSource.recordingMethod).toBe('ACTIVELY_MEASURED');
+    expect(payload.weight.weightGrams).toBe(72_500);
+  });
+
+  it('uses the measurement timestamp supplied in ExportContext', async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenResponse())
+      .mockResolvedValueOnce(mockResponse(200, { done: true }));
+
+    const exporter = new GoogleHealthExporter({
+      ...defaultConfig,
+      writeBodyFat: false,
+    });
+
+    const timestamp = new Date('2026-08-24T10:15:30.000Z');
+
+    const result = await exporter.export(samplePayload, {
+      timestamp,
+    });
+
+    expect(result.success).toBe(true);
+
+    const payload = parseRequestBody(1) as {
+      weight: {
+        sampleTime: {
+          physicalTime: string;
+        };
+      };
+    };
+
+    expect(payload.weight.sampleTime.physicalTime).toBe('2026-08-24T10:15:30.000Z');
+  });
+
+  it('uploads body fat when enabled and a valid value is available', async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenResponse())
+      .mockResolvedValueOnce(mockResponse(200, { done: true }))
+      .mockResolvedValueOnce(mockResponse(200, { done: true }));
+
+    const exporter = new GoogleHealthExporter(defaultConfig);
+
+    const result = await exporter.export(samplePayload);
+
+    expect(result.success).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+
+    expect(mockFetch.mock.calls[1][0]).toBe(WEIGHT_URL);
+    expect(mockFetch.mock.calls[2][0]).toBe(BODY_FAT_URL);
+
+    const bodyFatPayload = parseRequestBody(2) as {
+      bodyFat: {
+        percentage: number;
+      };
+    };
+
+    expect(bodyFatPayload.bodyFat.percentage).toBe(18.46);
+  });
+
+  it('does not upload body fat when writeBodyFat is disabled', async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenResponse())
+      .mockResolvedValueOnce(mockResponse(200, { done: true }));
+
+    const exporter = new GoogleHealthExporter({
+      ...defaultConfig,
+      writeBodyFat: false,
+    });
+
+    const result = await exporter.export(samplePayload);
+
+    expect(result.success).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[1][0]).toBe(WEIGHT_URL);
+  });
+
+  it('skips an invalid body-fat value but still uploads weight', async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenResponse())
+      .mockResolvedValueOnce(mockResponse(200, { done: true }));
+
+    const exporter = new GoogleHealthExporter(defaultConfig);
+
+    const result = await exporter.export({
+      ...samplePayload,
+      bodyFatPercent: 0,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[1][0]).toBe(WEIGHT_URL);
+  });
+
+  it('includes optional scale metadata in the weight data source', async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenResponse())
+      .mockResolvedValueOnce(mockResponse(200, { done: true }));
+
+    const exporter = new GoogleHealthExporter({
+      ...defaultConfig,
+      writeBodyFat: false,
+      deviceManufacturer: 'Test Manufacturer',
+      deviceDisplayName: 'Test Scale',
+    });
+
+    const result = await exporter.export(samplePayload);
+
+    expect(result.success).toBe(true);
+
+    const payload = parseRequestBody(1) as {
+      dataSource: {
+        device?: {
+          formFactor: string;
+          manufacturer?: string;
+          displayName?: string;
+        };
+      };
+    };
+
+    expect(payload.dataSource.device).toEqual({
+      formFactor: 'SCALE',
+      manufacturer: 'Test Manufacturer',
+      displayName: 'Test Scale',
+    });
+  });
+
+  it('reuses a cached access token for subsequent uploads', async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenResponse('cached-token'))
+      .mockResolvedValueOnce(mockResponse(200, { done: true }))
+      .mockResolvedValueOnce(mockResponse(200, { done: true }));
+
+    const exporter = new GoogleHealthExporter({
+      ...defaultConfig,
+      writeBodyFat: false,
+    });
+
+    const first = await exporter.export(samplePayload);
+    const second = await exporter.export(samplePayload);
+
+    expect(first.success).toBe(true);
+    expect(second.success).toBe(true);
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(mockFetch.mock.calls[0][0]).toBe(TOKEN_URL);
+    expect(mockFetch.mock.calls[1][0]).toBe(WEIGHT_URL);
+    expect(mockFetch.mock.calls[2][0]).toBe(WEIGHT_URL);
+
+    const secondUploadOptions = mockFetch.mock.calls[2][1] as RequestInit;
+
+    expect(secondUploadOptions.headers).toEqual(
+      expect.objectContaining({
+        Authorization: 'Bearer cached-token',
+      }),
+    );
+  });
+
+  it('refreshes the token and retries once after an HTTP 401', async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenResponse('expired-token'))
+      .mockResolvedValueOnce(
+        mockResponse(401, {
+          error: {
+            message: 'Invalid Credentials',
+          },
+        }),
+      )
+      .mockResolvedValueOnce(tokenResponse('replacement-token'))
+      .mockResolvedValueOnce(mockResponse(200, { done: true }));
+
+    const exporter = new GoogleHealthExporter({
+      ...defaultConfig,
+      writeBodyFat: false,
+    });
+
+    const result = await exporter.export(samplePayload);
+
+    expect(result.success).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+
+    expect(mockFetch.mock.calls[0][0]).toBe(TOKEN_URL);
+    expect(mockFetch.mock.calls[1][0]).toBe(WEIGHT_URL);
+    expect(mockFetch.mock.calls[2][0]).toBe(TOKEN_URL);
+    expect(mockFetch.mock.calls[3][0]).toBe(WEIGHT_URL);
+
+    const firstUpload = mockFetch.mock.calls[1][1] as RequestInit;
+    const retryUpload = mockFetch.mock.calls[3][1] as RequestInit;
+
+    expect(firstUpload.headers).toEqual(
+      expect.objectContaining({
+        Authorization: 'Bearer expired-token',
+      }),
+    );
+
+    expect(retryUpload.headers).toEqual(
+      expect.objectContaining({
+        Authorization: 'Bearer replacement-token',
+      }),
+    );
+  });
+
+  it('returns a structured Google API error when weight upload fails', async () => {
+    mockFetch.mockResolvedValueOnce(tokenResponse()).mockResolvedValueOnce(
+      mockResponse(400, {
+        error: {
+          code: 400,
+          message: 'Invalid data point',
+          status: 'INVALID_ARGUMENT',
+        },
+      }),
+    );
+
+    const exporter = new GoogleHealthExporter({
+      ...defaultConfig,
+      writeBodyFat: false,
+    });
+
+    const result = await exporter.export(samplePayload);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('HTTP 400');
+    expect(result.error).toContain('Invalid data point');
+  });
+
+  it('reports partial failure when weight succeeds but body fat fails', async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenResponse())
+      .mockResolvedValueOnce(mockResponse(200, { done: true }))
+      .mockResolvedValueOnce(
+        mockResponse(500, {
+          error: {
+            message: 'Body fat service unavailable',
+          },
+        }),
+      );
+
+    const exporter = new GoogleHealthExporter(defaultConfig);
+
+    const result = await exporter.export(samplePayload);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('weight uploaded; body fat upload failed');
+    expect(result.error).toContain('HTTP 500');
+  });
+
+  it('fails without making a request when the weight is invalid', async () => {
+    const exporter = new GoogleHealthExporter(defaultConfig);
+
+    const result = await exporter.export({
+      ...samplePayload,
+      weight: 0,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('invalid weight');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('healthcheck refreshes the access token without writing health data', async () => {
+    mockFetch.mockResolvedValueOnce(tokenResponse());
+
+    const exporter = new GoogleHealthExporter(defaultConfig);
+
+    const result = await exporter.healthcheck();
+
+    expect(result.success).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0][0]).toBe(TOKEN_URL);
+  });
+
+  it('healthcheck fails when the refresh token lacks the required scope', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse(200, {
+        access_token: 'test-access-token',
+        expires_in: 3600,
+        scope: 'https://www.googleapis.com/auth/some.other.scope',
+        token_type: 'Bearer',
+      }),
+    );
+
+    const exporter = new GoogleHealthExporter(defaultConfig);
+
+    const result = await exporter.healthcheck();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('does not include the Google Health health-metrics write scope');
+  });
+});

--- a/tests/exporters/registry.test.ts
+++ b/tests/exporters/registry.test.ts
@@ -31,6 +31,7 @@ describe('boolean exporter fields resolved from strings', () => {
     ['telegram', 'silent', 'silent'],
     ['telegram', 'report_exports', 'reportExports'],
     ['wger', 'sync_measurements', 'syncMeasurements'],
+    ['google-health', 'write_body_fat', 'writeBodyFat'],
   ];
 
   const base: Record<string, Record<string, unknown>> = {
@@ -38,6 +39,11 @@ describe('boolean exporter fields resolved from strings', () => {
     ntfy: { topic: 'scale' },
     telegram: { bot_token: 't', chat_id: '1' },
     wger: { base_url: 'https://wger.example', token: 'tok' },
+    'google-health': {
+      client_id: 'test-client-id',
+      client_secret: 'test-client-secret',
+      refresh_token: 'test-refresh-token',
+    },
   };
 
   it.each(CASES)('reads %s.%s = "false" as false, not as true', (type, key, field) => {
@@ -73,8 +79,8 @@ describe('boolean exporter fields resolved from strings', () => {
 // ─── EXPORTER_REGISTRY ─────────────────────────────────────────────────────
 
 describe('EXPORTER_REGISTRY', () => {
-  it('contains 11 exporter entries', () => {
-    expect(EXPORTER_REGISTRY).toHaveLength(11);
+  it('contains 12 exporter entries', () => {
+    expect(EXPORTER_REGISTRY).toHaveLength(12);
   });
 
   it('has entries for all known exporters', () => {
@@ -90,6 +96,7 @@ describe('EXPORTER_REGISTRY', () => {
     expect(names).toContain('intervals');
     expect(names).toContain('runalyze');
     expect(names).toContain('wger');
+    expect(names).toContain('google-health');
   });
 
   it('each entry has a schema and factory', () => {
@@ -107,8 +114,8 @@ describe('EXPORTER_REGISTRY', () => {
 // ─── EXPORTER_SCHEMAS ──────────────────────────────────────────────────────
 
 describe('EXPORTER_SCHEMAS', () => {
-  it('derives 11 schemas from registry', () => {
-    expect(EXPORTER_SCHEMAS).toHaveLength(11);
+  it('derives 12 schemas from registry', () => {
+    expect(EXPORTER_SCHEMAS).toHaveLength(12);
   });
 
   it('each schema has required fields', () => {
@@ -270,9 +277,9 @@ describe('EXPORTER_SCHEMAS', () => {
 // ─── KNOWN_EXPORTER_NAMES ──────────────────────────────────────────────────
 
 describe('KNOWN_EXPORTER_NAMES', () => {
-  it('is a Set with 11 entries', () => {
+  it('is a Set with 12 entries', () => {
     expect(KNOWN_EXPORTER_NAMES).toBeInstanceOf(Set);
-    expect(KNOWN_EXPORTER_NAMES.size).toBe(11);
+    expect(KNOWN_EXPORTER_NAMES.size).toBe(12);
   });
 
   it('contains all exporter names', () => {
@@ -287,6 +294,7 @@ describe('KNOWN_EXPORTER_NAMES', () => {
     expect(KNOWN_EXPORTER_NAMES.has('intervals')).toBe(true);
     expect(KNOWN_EXPORTER_NAMES.has('runalyze')).toBe(true);
     expect(KNOWN_EXPORTER_NAMES.has('wger')).toBe(true);
+    expect(KNOWN_EXPORTER_NAMES.has('google-health')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a standalone Google Health exporter, allowing BLE Scale Sync to upload weight measurements and, optionally, derived body-fat percentage to the Google Health API.

The exporter is intentionally independent of the scale/protocol work and is configured per user, as the OAuth refresh token authorizes access to an individual Google Health account.

## Changes

- Add new `google-health` per-user exporter
- Upload weight measurements to the Google Health API as actively measured scale data
- Optionally upload valid derived body-fat percentage
- Add OAuth 2.0 refresh-token authentication with:
  - in-memory access-token caching
  - expiry handling
  - coalesced concurrent token refreshes
  - one forced token refresh/retry following an HTTP 401
- Avoid generic retries for health-data POST requests to reduce the risk of duplicate data points
- Support historical/backdated readings using the reading timestamp
- Add optional scale manufacturer and display-name metadata
- Add Google Health configuration to the exporter registry and legacy environment-variable configuration
- Handle `write_body_fat` through the existing boolean parsing safeguards, including `${ENV_VAR}` values such as `"false"`
- Add exporter and registry tests, including OAuth, token caching, error handling, body-fat behaviour, healthcheck and configuration handling
- Add Google Health setup and `config.yaml` documentation, including the required OAuth scope and refresh-token setup
- Document that Google Health must be configured under a user's `exporters:` list rather than `global_exporters`
- Update published exporter counts from 11 to 12

## Test Plan

- [ ] Tests pass (`npm test`) — the Google Health changes pass, but 8 existing `tests/ble/handler-node-ble/scan-order.test.ts` tests time out on this machine. The identical 8 failures were reproduced against a clean detached current `origin/dev`, independently of this branch.
- [x] Lint clean (`npm run lint`)
- [x] TypeScript compiles (`npm run build`)
- [x] Tested manually

Manual testing included completing the OAuth flow with Google Health and successfully uploading real weight and body-fat measurements. Refresh-token exchange and subsequent access-token use were also verified end-to-end.

Dedicated Google Health and exporter-registry tests pass, as do the documentation build and published exporter-count checks.

## Notes

This PR contains no BLE scale/protocol changes.

Google Health OAuth credentials are per-user and should normally be supplied through `${ENV_VAR}` references rather than committed directly to `config.yaml`.

The healthcheck validates OAuth access-token refresh without writing a synthetic health measurement.

The 8 local `scan-order.test.ts` timeouts are unrelated to this PR and reproduce unchanged on current `origin/dev`.